### PR TITLE
chore: add commit-safety guardrails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,10 @@ Thumbs.db
 
 # ---------- Logs ----------
 *.log
+# Ignore the entire top-level logs/ directory even when its contents
+# don't end in .log (e.g. dumpsys snapshots, raw audio captures, JSON
+# diagnostics). Field-capture material; never committed.
+/logs/
 hs_err_pid*
 # Scratch dir for logcat dumps + ad-hoc diagnostics (created by
 # agent sessions to keep large/noisy artifacts out of the project

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,48 @@
+# gitleaks configuration for TAK-XVoice.
+#
+# We extend the gitleaks-shipped default ruleset (all built-in secret
+# detection rules stay active) and only add an allowlist for strings
+# that are known to be safe in this repository but which look secret-
+# adjacent enough to trip a generic scanner.
+#
+# DO NOT add allowlist entries to silence real findings — every entry
+# below must correspond to a value that is intentionally public and
+# whose presence in the repo has been reviewed.
+
+# Pull in the gitleaks-bundled default rules. Without this line our
+# config would replace the defaults instead of extending them.
+[extend]
+useDefault = true
+
+# Repository-wide allowlist. `gitleaks` evaluates this in addition to
+# rule-level allowlists; matches here suppress any rule.
+[[allowlists]]
+description = "TAK-XVoice known-safe public constants and example strings"
+# `commits` and `paths` left unset so the allowlist applies repo-wide.
+# `regexTarget = "match"` would only inspect the matched secret span;
+# we leave it unset so the default ("line") applies, which is what we
+# want for the multicast-formula and magic-number cases below.
+regexes = [
+    # Multicast group derivation formula. Appears in source comments
+    # and design docs as a literal template; the `{sha256[0]}` /
+    # `{sha256[1]}` placeholders are not secrets, just byte indices
+    # into a SHA-256 digest of (server cert fingerprint, channel id).
+    '''239\.42\.\{sha256\[0\]\}\.\{sha256\[1\]\}''',
+
+    # ControlPacket magic — first four bytes of the XV mesh-bridge
+    # control wire format. Public protocol constant, not a token.
+    '''"XVMC"''',
+
+    # FNV-1a 32-bit offset basis. Standardized public constant used
+    # for SSRC derivation in the RTP framing layer.
+    '''0x811c9dc5''',
+
+    # FNV-1a 32-bit prime. Same context as above.
+    '''0x01000193''',
+
+    # AinaA2dpController connection-policy sentinels. These mirror
+    # Android `BluetoothProfile.CONNECTION_POLICY_*` integer values
+    # and are reproduced as named constants in the controller.
+    '''CONNECTION_POLICY_ALLOWED\s*=\s*100''',
+    '''CONNECTION_POLICY_FORBIDDEN\s*=\s*-1''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+# Pre-commit framework configuration for TAK-XVoice.
+#
+# Install once per clone:
+#   pipx install pre-commit
+#   pre-commit install
+#
+# After install, `git commit` runs the hooks below and refuses commits
+# that trip them. See CLAUDE.md for the project-wide sensitive-content
+# rules these hooks back up.
+#
+# Tag pins are deliberate: floating refs (HEAD / main) make builds
+# non-reproducible and let upstream silently change behavior between
+# clones.
+---
+repos:
+  # Secret scanner. Backed by .gitleaks.toml at the repo root, which
+  # extends the gitleaks default ruleset with project-specific
+  # allowlist entries for known-safe public constants.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+
+  # Whitespace / EOL hygiene. Catches files committed without a
+  # trailing newline, which trips diff tools and editor configs.
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: end-of-file-fixer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,141 @@
+# CLAUDE.md — Operator handoff for Claude Code sessions
+
+This file is the standing brief for any Claude Code (or other agentic
+assistant) session working on this repository. Read it before making
+edits, opening shells, or composing commit messages.
+
+## Project identity
+
+TAK-XVoice (XV) is a **public, Apache-2.0-licensed ATAK plugin**. The
+repository at `https://github.com/TX-RX/TAK-XVoice` is public and the
+default branch is `main`. Anything that lands on `main` is, for
+practical purposes, world-readable forever — assume git history is a
+publication surface, not a private workspace.
+
+## Sensitive-content rules
+
+The following content categories MUST NEVER appear in committed files,
+commit messages, PR descriptions, code comments, log output captured
+into the repo, or any message text that gets pushed to a remote (this
+includes chat replies the assistant emits while pairing with the
+operator):
+
+- **Credentials of any kind**
+  - Personal access tokens (GitHub PATs, GitLab PATs, anything similar)
+  - API keys, service account keys, OAuth client secrets, OAuth tokens
+    (access or refresh)
+  - Android/JKS signing keys, keystore passwords, key aliases tied to
+    a production keystore
+  - SSH private keys, GPG private keys
+- **Bluetooth MAC addresses tied to a specific operator's hardware.**
+  Use the redacted placeholder `XX:XX:XX:XX:XX:XX` in examples,
+  docstrings, log lines, and tests. Realistic-looking fake MACs are
+  also fine (e.g. `AA:BB:CC:DD:EE:FF`) — the point is never to ship a
+  real operator's device address.
+- **TAK server hostnames, FQDNs, URLs, or IP addresses.** This
+  includes staging/dev servers as well as production. Use
+  `tak.example` / `tak.example.com` / RFC 5737 (`192.0.2.x`,
+  `198.51.100.x`, `203.0.113.x`) for examples. Multicast group
+  literals derived from server cert fingerprints are also off-limits
+  even when they "look" generic.
+- **Customer, agency, or unit names.** No identifying organization
+  strings, no real operator callsigns, no team identifiers from live
+  deployments. Use `Alpha`/`Bravo`/`Charlie` or numbered placeholders
+  in examples.
+- **Operator GPS coordinates** of any precision. If a bug repro
+  involves a real location, replace with a coordinate inside a known
+  uninhabited region (e.g. `0.0, 0.0`) or a published city centroid
+  before pasting.
+- **Internal IP ranges.** No RFC 1918 prefixes that identify a real
+  internal network. Generic illustrations of `10.0.0.0/8` etc. are
+  fine; specific subnets observed in the field are not.
+
+If the assistant is unsure whether a string falls into one of the
+above categories, the default is **redact and ask** — never commit
+and apologize later. Operator deployments depend on this; the public
+history of an ATAK plugin is one of the first things an adversary
+will read.
+
+## Commit-message style
+
+- Subject line: terse, conventional-commit-style prefix
+  (`feat:` / `fix:` / `chore:` / `docs:` / `refactor:` / `test:`),
+  imperative mood, under ~72 characters.
+- Body: technical and descriptive. Explain *why* the change was made,
+  what subsystem it touches, and any constraints a future reader
+  needs to know. The single squashed `Initial public commit —
+  TAK-XVoice` commit is the canonical tone reference: dense,
+  factual, organized by subsystem, zero operator-identifying detail.
+- Never name customers, agencies, units, real operators, or specific
+  field deployments in commit messages, even at a high level.
+- Do not paste log excerpts, device serials, or BT MACs into commit
+  bodies. Summarize ("verified against an AINA V2 puck") instead of
+  quoting raw evidence.
+
+## Branching + PR workflow
+
+- `main` is protected by convention — **never push directly**.
+- Feature work: `feat/<short-slug>`
+- Bug fixes: `fix/<short-slug>`
+- Chores / tooling / docs: `chore/<short-slug>`
+- Open a pull request against `main` for every change. Even one-line
+  fixes go through a PR so the public history has a reviewable
+  audit trail.
+- Squash-merge is the expected merge style; keep the PR description
+  in the same technical-and-descriptive tone as commits.
+
+## Build commands the user expects to be green before merge
+
+Run all three from the repository root before considering a branch
+ready for review:
+
+```sh
+./gradlew ktlintCheck
+./gradlew assembleCivDebug
+./gradlew testCivDebugUnitTest
+```
+
+`ktlintCheck` enforces the formatting baseline. `assembleCivDebug`
+exercises the takdev SDK wiring + manifest, which is the most common
+way a refactor breaks plugin loading. `testCivDebugUnitTest` is the
+JUnit/MockK/Robolectric unit suite for the state machines listed in
+the initial commit.
+
+## ATAK SDK jar
+
+`app/libs/main.jar` is gitignored and is **not** vendored in this
+repository. The build resolves it from the local SDK distribution
+per `build.gradle.kts` — the default search path is
+`../ATAK-CIV-5.6.0.17-SDK/atak-gradle-takdev.jar` relative to the
+repo root. If a Claude session reports a missing-jar error, the
+correct response is to point the operator at the SDK installation
+step, **not** to try to commit a copy of the jar into `app/libs/`.
+
+## logs/ and capture directories
+
+Anything under `logs/`, `.logs/`, `.tmp/`, or `diagnostics/` is
+local-only field-capture material — logcat dumps, `dumpsys`
+snapshots, batterystats pulls, post-mortem traces. **Never commit
+anything from these directories**, even if it looks innocuous.
+Field captures routinely contain Bluetooth MACs, device serials,
+TAK server URLs, and call metadata that fall under the sensitive-
+content rules above. The `.gitignore` already excludes them; do not
+add `git add -f` overrides.
+
+## Pre-commit hooks
+
+This repo uses the `pre-commit` framework (configured in
+`.pre-commit-config.yaml`) plus `gitleaks` (configured in
+`.gitleaks.toml`) as belt-and-suspenders against accidental secret
+commits. Install once per clone:
+
+```sh
+pipx install pre-commit
+pre-commit install
+```
+
+After that, `git commit` will run `gitleaks` + `end-of-file-fixer`
+locally and refuse commits that trip either hook. If a hook trips,
+**investigate the underlying content** — do not bypass with
+`--no-verify` unless the operator explicitly approves it for a
+specific commit, and even then prefer fixing the content.


### PR DESCRIPTION
Establish a three-layer safety net against accidentally committing sensitive operator material (credentials, BT MACs, TAK server URLs, agency / callsign / GPS identifiers) before the next field deployment. Configuration and documentation only — no Kotlin source is touched and no behavior changes on the build / test paths.

CLAUDE.md
  Standing operator handoff for any Claude Code session working on
  this repo. Codifies project identity (public Apache-2.0 ATAK
  plugin, public GitHub remote), the sensitive-content categories
  that must never reach a commit / log / PR description, commit-
  message tone (technical and descriptive, tracking the existing
  initial-commit baseline), branching convention (feat/* fix/*
  chore/*, never push to main, always PR), the green-before-merge
  build commands (ktlintCheck, assembleCivDebug,
  testCivDebugUnitTest), the ATAK SDK jar resolution note pointing
  at the ../ATAK-CIV-5.6.0.17-SDK/ search path consumed by
  build.gradle.kts, and the logs/ never-commit rule.

.gitleaks.toml
  Repository-scoped gitleaks configuration. Extends the bundled
  default ruleset (useDefault = true) so every shipped secret-
  detection rule stays active; adds an allowlist for known-safe
  strings that would otherwise trip generic scanners — the
  multicast group derivation template
  239.42.{sha256[0]}.{sha256[1]}, the ControlPacket "XVMC" magic,
  the FNV-1a 32-bit offset basis 0x811c9dc5 and prime 0x01000193
  used in RTP SSRC derivation, and the AinaA2dpController
  CONNECTION_POLICY_ALLOWED=100 / CONNECTION_POLICY_FORBIDDEN=-1
  constants. No default rule is disabled.

.pre-commit-config.yaml
  pre-commit framework wiring with two hooks pinned to explicit
  release tags: gitleaks v8.21.2 (drives the .gitleaks.toml ruleset
  above) and pre-commit-hooks v5.0.0 end-of-file-fixer. Install
  steps are documented in CLAUDE.md ("pipx install pre-commit &&
  pre-commit install"); this commit only configures the hooks, it
  does not bundle any binary.

.gitignore
  Adds an explicit /logs/ entry beside the existing *.log line so
  the entire top-level logs/ directory is excluded from git, even
  when capture material lands there under non-.log extensions
  (dumpsys snapshots, raw audio, JSON diagnostics).