### PR TITLE
fix(transport): stop Mumble self-kick reconnect loop; add project-context README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,68 @@ options don't cover well: correct Bluetooth audio routing, predictable
 auto-reconnect, a flexible model for external PTT hardware, and a
 foundation for bridging server-mediated voice to mesh radios.
 
+## Status and intended use
+
+**TAK-XVoice is provided for non-mission-critical use only.** It is
+distributed under Apache 2.0 (see [LICENSE](LICENSE) and
+[NOTICE](NOTICE)) and comes with **no warranty of any kind, express or
+implied**, including no warranty of merchantability, fitness for a
+particular purpose, or non-infringement. Do not rely on this plugin as
+the sole means of communication for any life-safety, public-safety,
+military, or other mission-critical application. Operators assume all
+risk associated with its use.
+
+The plugin is under active development. Interfaces, defaults, and
+on-wire behavior can change between builds while the codebase
+stabilizes.
+
+## Why this exists
+
+TAK-XVoice began as a response to gaps in the existing VX voice plugin
+that made it difficult to run ATAK the way volunteer comms operators
+actually use their phones in the field:
+
+- **No broad external-PTT support.** VX did not integrate cleanly with
+  the range of Bluetooth speakermics and BLE PTT pucks that operators
+  had already invested in. XV registers external buttons per-MAC
+  address and ships with defaults for common hardware (AINA APTT V1
+  SPP, AINA APTT V2 BLE, Pryme BT-PTT-Z, and generic BLE HID pucks
+  via a learn-mode wizard).
+- **Audio routing that fought the rest of the phone.** With VX in the
+  loop, keeping music, navigation prompts, and ATAK alerts flowing to
+  their normal outputs while driving between event checkpoints was
+  awkward at best. XV treats the BT speakermic as XV-exclusive comms
+  gear and only engages HFP/SCO while the mic is actually open, so
+  A2DP media and ATAK's own audio keep working the way the operator
+  expects.
+- **A place to add functionality without forking the world.** XV is a
+  clean surface to iterate on features like configurable talk-permit
+  tones, an LMR-style emergency button, direct calling, and the mesh /
+  multicast work described below.
+
+The near-term focus is **mobile-connectivity reliability** — Wi-Fi ↔
+cell handoff, fast reconnect, Bluetooth stability across audio-plant
+edge cases, and correct behavior on locked/sleeping phones. Once that
+baseline is solid, the roadmap moves toward **multicast and
+decentralized voice**: server-optional operation, mesh-radio
+interoperability (OpenMANET / Doodle Labs Mesh Rider RTP framing), and
+per-frame AEAD with distributed key election so a channel can keep
+running when the server is gone.
+
+## Primary mission
+
+The initial deployment target is **volunteer communications teams
+supporting public-service events** — parades, bike rallies, triathlons,
+marathons, 5Ks, and similar community events where a small comms crew
+covers a large geographic footprint over a few hours and needs
+lightweight, phone-first voice that plays nicely with the operator's
+music, GPS, and ATAK situational picture.
+
+One volunteer organization put TAK-XVoice into production just a
+couple of weeks after the first working build, and it has been running
+in event traffic since. Work continues on maintenance, stabilization,
+and feature polish.
+
 ## What's different
 
 1. **Audio routing.** The plugin treats your Bluetooth speakermic as
@@ -43,6 +105,34 @@ XV also adds:
   TAK-cert-wrapped channel keys, distributed key election. RTP framing
   (RFC 3550 + 7587) for OpenMANET / Doodle Labs Mesh Rider interop.
 
+## Roadmap
+
+- **Now:** mobile-connectivity reliability — Wi-Fi/cell handoff, fast
+  reconnect, BT stability across audio-plant edge cases, background
+  behavior on locked phones.
+- **Next:** multicast channel operation, offline / server-optional
+  calling, mesh-radio RTP bridge.
+- **Later:** decentralized channel key management (already scaffolded
+  via distributed key election and AEAD), expanded hardware coverage,
+  additional interoperability targets as operator needs surface.
+
+## Reporting issues
+
+If you find a defect or see an opportunity for improvement, please
+open a GitHub issue on this repository so it can be discussed and
+tracked. Please **do not** paste operator-identifying information into
+issues — no real Bluetooth MAC addresses, TAK server URLs, callsigns
+of live operators, unit or organization names, or GPS coordinates
+tied to a real deployment. Redacted / example values (`AA:BB:CC:DD:EE:FF`,
+`tak.example`, `Alpha` / `Bravo`) are fine and preferred.
+
+## Acknowledgments
+
+Special thanks to **Bernie, K5BP**, for jumping in head-first —
+helping build this out, hammering on it in the field, and pushing it
+to where it is today. This project would not be in the shape it is
+without his time and testing.
+
 ## Build
 
 Drop the ATAK CIV SDK jar in place (gitignored, not bundled):
@@ -79,3 +169,5 @@ BT-PTT-Z (HM-10 UART), generic BLE HID pucks.
 ## License
 
 Apache License 2.0 — see [LICENSE](LICENSE) and [NOTICE](NOTICE).
+Distributed **as-is, without warranty**. See the "Status and intended
+use" section above.

--- a/app/src/main/java/com/atakmap/android/xv/transport/ReconnectingMumbleTransport.kt
+++ b/app/src/main/java/com/atakmap/android/xv/transport/ReconnectingMumbleTransport.kt
@@ -104,6 +104,15 @@ class ReconnectingMumbleTransport(
     // swap path calls runAttempt() directly instead.
     private val swapInProgress = AtomicBoolean(false)
 
+    // Latched once a Fatal outcome has been observed (e.g. self-kicked
+    // because the server sees a duplicate username). Blocks any
+    // subsequent scheduleRetry — including the Transient one that
+    // onDisconnected fires when the read loop exits after the same
+    // failure — from tight-looping the reconnect. Cleared by an
+    // operator-initiated connect() or by a successful onConnected
+    // (network swap / manual retry re-arms the wrapper).
+    private val fatalRejected = AtomicBoolean(false)
+
     @Volatile
     private var lastScheduledDelayMs: Long = 0L
 
@@ -195,6 +204,7 @@ class ReconnectingMumbleTransport(
         teardownRequested = false
         policy.reset()
         secondaryUsernameInUseAttempts.set(0)
+        fatalRejected.set(false)
         executor.submit { runAttempt() }
     }
 
@@ -314,6 +324,18 @@ class ReconnectingMumbleTransport(
 
     private fun scheduleRetry(outcome: ReconnectPolicy.Outcome) {
         if (teardownRequested) return
+        // Fatal outcomes latch fatalRejected so the follow-up Transient
+        // outcome that onDisconnected fires (the read loop exits after
+        // the same server-side kick) can't slip past shouldRetry and
+        // reopen a session that will just get kicked again. Field bug
+        // 2026-07-06: a self-kick loop hammered Murmur once a second
+        // because Fatal was logged as "not retrying" but the paired
+        // Transient scheduled a retry anyway. See fatalRejected doc.
+        if (fatalRejected.get()) {
+            Log.i(TAG, "scheduleRetry($outcome): fatal already surfaced — ignoring")
+            reconnecting.set(false)
+            return
+        }
         // A single failed connect can produce multiple listener calls
         // (onError → onConnectionFailed AND read-loop finally →
         // onDisconnected). The single-threaded executor guarantees
@@ -326,6 +348,9 @@ class ReconnectingMumbleTransport(
         }
         if (!policy.shouldRetry(outcome)) {
             Log.w(TAG, "not retrying — outcome=$outcome")
+            if (outcome is ReconnectPolicy.Outcome.Fatal) {
+                fatalRejected.set(true)
+            }
             reconnecting.set(false)
             return
         }
@@ -430,6 +455,7 @@ class ReconnectingMumbleTransport(
                 policy.reset()
                 reconnecting.set(false)
                 secondaryUsernameInUseAttempts.set(0)
+                fatalRejected.set(false)
                 upstream?.onConnected()
             }
 

--- a/app/src/test/java/com/atakmap/android/xv/transport/ReconnectingMumbleTransportTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/transport/ReconnectingMumbleTransportTest.kt
@@ -219,6 +219,27 @@ class ReconnectingMumbleTransportTest {
         assertFalse(executor.hasPendingSchedule())
     }
 
+    // Regression test for the 2026-07-06 field bug: a self-kick surfaces
+    // BOTH as onConnectionFailed(Fatal) AND as onDisconnected(Transient)
+    // because the server-side kick closes the socket, which trips the
+    // read loop's finally-block. Without the fatalRejected latch, the
+    // Transient path scheduled a fresh reconnect ~1s later that got
+    // kicked again — infinite loop hammering the server.
+    @Test
+    fun `SelfKick followed by onDisconnected does NOT schedule a Transient retry`() {
+        val r = build()
+        r.connect(upstream)
+        capturedListeners[0].onConnectionFailed(
+            SelfKickedException(reason = "duplicate", banned = false, byActorSession = 0),
+        )
+        capturedListeners[0].onDisconnected("read loop exit")
+        assertFalse(
+            "Post-Fatal onDisconnected must not sneak a Transient retry past shouldRetry",
+            executor.hasPendingSchedule(),
+        )
+        assertEquals("no fresh factory invocation after fatal", 1, factoryInvocations.size)
+    }
+
     // ============================================================
     // UsernameInUse on primary — transient with same name
     // ============================================================


### PR DESCRIPTION
## Summary

- **Fix:** latch a `fatalRejected` flag in `ReconnectingMumbleTransport` so a server-side self-kick (duplicate-username collision, ban, WrongUserPW) only surfaces once and stops the wrapper's follow-up Transient retry from tight-looping the reconnect. Field-observed 2026-07-06 on a Pixel 9 Pro against a Murmur server that held a ghost session via keepalive — XV hammered the server at ~1 Hz with kick / reconnect / kick.
- **Docs:** fill in the README with the project-context sections (Status/intended-use, Why this exists, Primary mission, Roadmap, Reporting issues, Acknowledgments). Docs-only, no build or runtime impact.

## The fix in one paragraph

A single failed session produces TWO listener callbacks on the inner `MumbleTransport`: first `onConnectionFailed(SelfKickedException)` (routes to `Outcome.Fatal` → correctly logged as "not retrying"), then `onDisconnected("read loop exit")` (routes to `Outcome.Transient` → policy DOES retry). The Fatal handler previously just returned, leaving nothing to block the paired Transient path from scheduling a new attempt ~1 s later. That new attempt hit the same server-side condition, got kicked again, and the cycle repeated indefinitely — visible in logs as alternating `not retrying — outcome=Fatal` and `attempt #2` lines. The wrapper now latches `fatalRejected` when a Fatal outcome fails `policy.shouldRetry`; every subsequent `scheduleRetry` short-circuits while the latch is set. The latch clears on operator-initiated `connect()` (fresh wrapper lifecycle) and on a successful inner `onConnected` (network swap or manual retry re-arms the wrapper).

## Commits

1. `fix(transport): latch fatalRejected in ReconnectingMumbleTransport` — the fix + a targeted regression test.
2. `docs: add Status / Why / Mission / Roadmap / Acknowledgments to README` — narrative context for new readers of the public repo. Includes redaction guidance for issue reports and thanks Bernie, K5BP, for field testing.

## Test plan

- [x] `./gradlew ktlintCheck` — clean.
- [x] `./gradlew assembleCivDebug` — clean against ATAK CIV 5.7 SDK.
- [x] `./gradlew testCivDebugUnitTest` — passes, including the new regression test `SelfKick followed by onDisconnected does NOT schedule a Transient retry` in `ReconnectingMumbleTransportTest`.
- [x] Sideload verified on Pixel 9 Pro against a live Murmur — connect completes, no reconnect loop, operator can transmit; a fatal outcome surfaces once and stops.