### PR TITLE
feat(aina): BitmaskGattPttReader base + ZelloBleReader scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,78 @@
 
 An ATAK voice plugin focused on operational use cases that existing
 options don't cover well: correct Bluetooth audio routing, predictable
-auto-reconnect, a flexible model for external PTT hardware, and a
+auto-reconnect, a curated model for external PTT hardware, and a
 foundation for bridging server-mediated voice to mesh radios.
+
+## Status and intended use
+
+**TAK-XVoice is provided for non-mission-critical use only.** It is
+distributed under Apache 2.0 (see [LICENSE](LICENSE) and
+[NOTICE](NOTICE)) and comes with **no warranty of any kind, express or
+implied**, including no warranty of merchantability, fitness for a
+particular purpose, or non-infringement. Do not rely on this plugin as
+the sole means of communication for any life-safety, public-safety,
+military, or other mission-critical application. Operators assume all
+risk associated with its use.
+
+The plugin is under active development. Interfaces, defaults, and
+on-wire behavior can change between builds while the codebase
+stabilizes.
+
+## Why this exists
+
+TAK-XVoice began as a response to gaps in the existing VX voice plugin
+that made it difficult to run ATAK the way volunteer comms operators
+actually use their phones in the field:
+
+- **No broad external-PTT support.** VX did not integrate cleanly with
+  the range of Bluetooth speakermics and BLE PTT pucks that operators
+  had already invested in. XV registers external buttons per-MAC
+  address and ships with vetted defaults for a small, curated set of
+  hardware (see below).
+- **Audio routing that fought the rest of the phone.** With VX in the
+  loop, keeping music, navigation prompts, and ATAK alerts flowing to
+  their normal outputs while driving between event checkpoints was
+  awkward at best. XV treats the BT speakermic as XV-exclusive comms
+  gear and only engages HFP/SCO while the mic is actually open, so
+  A2DP media and ATAK's own audio keep working the way the operator
+  expects.
+- **A place to add functionality without forking the world.** XV is a
+  clean surface to iterate on features like configurable talk-permit
+  tones, an LMR-style emergency button, direct calling, and the mesh /
+  multicast work described below.
+
+The near-term focus is **mobile-connectivity reliability** — Wi-Fi ↔
+cell handoff, fast reconnect, Bluetooth stability across audio-plant
+edge cases, and correct behavior on locked/sleeping phones. Once that
+baseline is solid, the roadmap moves toward **multicast and
+decentralized voice**: server-optional operation, mesh-radio
+interoperability via standard RTP framing, and per-frame AEAD with
+distributed key election so a channel can keep running when the server
+is gone.
+
+## Hardware philosophy — curated, not exhaustive
+
+The goal is **not** to claim support for every Bluetooth PTT device on
+the market. Each device that ships as "supported" is deliberately
+curated — sourced, integrated, and validated against real event
+traffic — so operators can trust that what's listed actually works
+under load. New hardware is added on that basis, not on a spec-sheet
+claim. If a device isn't listed as supported, it isn't yet.
+
+## Primary mission
+
+The initial deployment target is **volunteer communications teams
+supporting public-service events** — parades, bike rallies, triathlons,
+marathons, 5Ks, and similar community events where a small comms crew
+covers a large geographic footprint over a few hours and needs
+lightweight, phone-first voice that plays nicely with the operator's
+music, GPS, and ATAK situational picture.
+
+One volunteer organization put TAK-XVoice into production just a
+couple of weeks after the first working build, and it has been running
+in event traffic since. Work continues on maintenance, stabilization,
+and feature polish.
 
 ## What's different
 
@@ -19,16 +89,16 @@ foundation for bridging server-mediated voice to mesh radios.
    ATAK restart.
 
 3. **External button registration.** XV registers BT speakermic buttons
-   per-MAC, including SPP-based hardware (AINA APTT V1, similar Pryme /
-   Sheepdog speakermics) and BLE GATT devices (AINA APTT V2, Pryme
-   BT-PTT-Z, and other generic BLE PTT pucks via a learn-mode wizard).
+   per-MAC for the curated device list — SPP-based hardware (AINA APTT
+   V1 and similar Pryme speakermics) and BLE GATT devices (AINA APTT V2,
+   Pryme BT-PTT-Z).
 
 XV also adds:
 
-- **Per-device defaults with overrides** — each speakermic ships pre-
-  mapped (PTT → Channel 1, secondary → Channel 2, emergency button,
-  prev/next channel) so a fresh pairing "just works." Operators edit
-  the defaults; overrides persist by BT address.
+- **Per-device defaults with overrides** — each supported speakermic
+  ships pre-mapped (PTT → Channel 1, secondary → Channel 2, emergency
+  button, prev/next channel) so a fresh pairing "just works." Operators
+  edit the defaults; overrides persist by BT address.
 - **LMR-style emergency button** — short press fires the emergency
   configured in ATAK's Alert Tool; long press (1 s) cancels.
 - **Configurable Talk Permit Tones** (ASTRO 25 / Nextel / DMR / MOTOTRBO
@@ -40,8 +110,36 @@ XV also adds:
 - **Direct calling** — Notification.CallStyle ring + full-screen call
   surface, VX-compatible private-call signaling.
 - **Mesh-voice-bridge foundation** — per-frame AEAD (ChaCha20-Poly1305),
-  TAK-cert-wrapped channel keys, distributed key election. RTP framing
-  (RFC 3550 + 7587) for OpenMANET / Doodle Labs Mesh Rider interop.
+  TAK-cert-wrapped channel keys, distributed key election. Standard
+  RTP framing (RFC 3550 + 7587) for mesh-radio interop.
+
+## Roadmap
+
+- **Now:** mobile-connectivity reliability — Wi-Fi/cell handoff, fast
+  reconnect, BT stability across audio-plant edge cases, background
+  behavior on locked phones.
+- **Next:** multicast channel operation, offline / server-optional
+  calling, mesh-radio RTP bridge.
+- **Later:** decentralized channel key management (already scaffolded
+  via distributed key election and AEAD), and additional curated
+  hardware as devices are validated in the field.
+
+## Reporting issues
+
+If you find a defect or see an opportunity for improvement, please
+open a GitHub issue on this repository so it can be discussed and
+tracked. Please **do not** paste operator-identifying information into
+issues — no real Bluetooth MAC addresses, TAK server URLs, callsigns
+of live operators, unit or organization names, or GPS coordinates
+tied to a real deployment. Redacted / example values (`AA:BB:CC:DD:EE:FF`,
+`tak.example`, `Alpha` / `Bravo`) are fine and preferred.
+
+## Acknowledgments
+
+Special thanks to **Bernie, K5BP**, for jumping in head-first —
+helping build this out, hammering on it in the field, and pushing it
+to where it is today. This project would not be in the shape it is
+without his time and testing.
 
 ## Build
 
@@ -69,13 +167,24 @@ portal.
 
 ## Hardware tested
 
+Test devices:
+
 - Pixel 9 Pro (primary test device)
 - Motorola legacy Android (AINA APTT V1 SPP rig)
 - Samsung Galaxy Tab (XV + existing voice-plugin coexistence)
 
-Speakermics: AINA APTT V1 (BR/EDR SPP), AINA APTT V2 (BLE GATT), Pryme
-BT-PTT-Z (HM-10 UART), generic BLE HID pucks.
+Curated / validated speakermics:
+
+- AINA APTT V1 (BR/EDR SPP)
+- AINA APTT V2 (BLE GATT)
+- Pryme BT-PTT-Z (HM-10 UART)
+
+This list only includes devices that have been integrated end-to-end
+and validated against event traffic. Additional hardware is added the
+same way — one device at a time, once it's been tested.
 
 ## License
 
 Apache License 2.0 — see [LICENSE](LICENSE) and [NOTICE](NOTICE).
+Distributed **as-is, without warranty**. See the "Status and intended
+use" section above.

--- a/app/src/main/java/com/atakmap/android/xv/aina/BitmaskGattPttReader.kt
+++ b/app/src/main/java/com/atakmap/android/xv/aina/BitmaskGattPttReader.kt
@@ -1,0 +1,351 @@
+package com.atakmap.android.xv.aina
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import android.bluetooth.BluetoothProfile
+import android.content.Context
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import java.util.UUID
+
+/**
+ * Reusable BLE GATT plumbing for PTT buttons that expose their state
+ * as a bitmask on one or more notify characteristics inside a vendor
+ * service. Handles:
+ *
+ *   - `connectGatt` with a bounded direct-retry burst then a long-lived
+ *     `autoConnect` for out-of-range recovery.
+ *   - Service discovery, matching against a list of candidate service
+ *     UUIDs (so a single reader class covers hardware revisions that
+ *     differ only in advertised UUID).
+ *   - CCCD subscription on every notify-capable characteristic in the
+ *     matched service (broad subscription — the vendor decides which
+ *     characteristic actually carries button state; extras are harmless).
+ *   - Edge-triggered PER-BUTTON down/up events derived from bitmask
+ *     transitions between successive notifications, so a device that
+ *     only reports "current mask" (no separate down/up packets) works
+ *     transparently.
+ *
+ * Instances are configured by [Config] — each supported button family
+ * (Pryme BT-PTT-Z, AINA V2, Zello-convention BLE, …) supplies its own
+ * candidate service UUIDs, log tag, and mask-decode function. The
+ * plumbing itself carries no vendor knowledge.
+ *
+ * Threading: all GATT callbacks arrive on the Bluetooth binder threads
+ * and are handed off to a main-looper Handler for retry scheduling.
+ * `onEvent` and `onConnectionState` are invoked from whichever thread
+ * delivered the underlying GATT event — call sites that touch UI must
+ * marshal to the UI thread themselves. This mirrors [AinaBleReader]'s
+ * behavior so the existing `VoicePlant` wiring can bind either reader
+ * interchangeably.
+ */
+@SuppressLint("MissingPermission")
+open class BitmaskGattPttReader(
+    private val context: Context,
+    private val config: Config,
+    private val onEvent: (AinaButton, isDown: Boolean) -> Unit,
+    private val onConnectionState: (Boolean) -> Unit = {},
+) {
+    /**
+     * Static per-vendor configuration passed to the reader at
+     * construction. Everything vendor-specific lives here so the base
+     * class stays generic.
+     *
+     * @param tag Log tag (grep-friendly per-vendor prefix, e.g.
+     *   `XvPrymeBle` or `XvZelloBle`).
+     * @param candidateServiceUuids Service UUIDs to try in priority
+     *   order during service discovery. First match wins. Multiple
+     *   entries let a single reader cover hardware revisions that
+     *   changed UUIDs without changing wire format.
+     * @param decodeMask Called on every incoming notification with the
+     *   raw notification payload's first byte (masked to unsigned 8
+     *   bits). Returns the set of buttons the vendor considers
+     *   currently held. The base class diffs against the previous
+     *   result to fire per-button down/up events.
+     *
+     *   A vendor that reports only "any button held / none held" (like
+     *   the current Pryme heuristic) can return `setOf(PTT)` for any
+     *   non-zero mask and `emptySet()` for zero.
+     *
+     *   A vendor that packs multiple buttons into one byte (like
+     *   Zello's 0x01/0x02/0x04/0x08/0x10 bitmap) can decode each bit
+     *   independently and return a multi-element set.
+     */
+    data class Config(
+        val tag: String,
+        val candidateServiceUuids: List<UUID>,
+        val decodeMask: (mask: Int) -> Set<AinaButton>,
+    )
+
+    private val handler = Handler(Looper.getMainLooper())
+    private var gatt: BluetoothGatt? = null
+    private var targetDevice: BluetoothDevice? = null
+
+    @Volatile
+    private var intentionalDisconnect: Boolean = false
+
+    private var directRetryCount: Int = 0
+    private var autoConnectArmed: Boolean = false
+
+    // Previous "buttons currently held" set, used to derive
+    // edge-triggered down/up events. Starts empty (nothing held);
+    // first notification with a non-empty decode = down events for
+    // each button in the new set. Reset on disconnect so a
+    // reconnect doesn't spuriously fire an "up" for whatever was
+    // held at the moment the link dropped.
+    @Volatile
+    private var lastHeld: Set<AinaButton> = emptySet()
+
+    private val retryRunnable =
+        Runnable {
+            val device = targetDevice ?: return@Runnable
+            if (intentionalDisconnect) return@Runnable
+            connectInternal(device, useAutoConnect = autoConnectArmed)
+        }
+
+    fun connect(device: BluetoothDevice) {
+        disconnect()
+        intentionalDisconnect = false
+        targetDevice = device
+        directRetryCount = 0
+        autoConnectArmed = false
+        connectInternal(device, useAutoConnect = false)
+    }
+
+    private fun connectInternal(
+        device: BluetoothDevice,
+        useAutoConnect: Boolean,
+    ) {
+        lastHeld = emptySet()
+        Log.i(
+            config.tag,
+            "Connecting to ${device.address} " +
+                "(autoConnect=$useAutoConnect, attempt=${directRetryCount + 1})",
+        )
+        gatt = device.connectGatt(context, useAutoConnect, callback, BluetoothDevice.TRANSPORT_LE)
+    }
+
+    fun disconnect() {
+        intentionalDisconnect = true
+        targetDevice = null
+        handler.removeCallbacks(retryRunnable)
+        closeGatt()
+        onConnectionState(false)
+    }
+
+    private fun closeGatt() {
+        gatt?.let {
+            try {
+                it.disconnect()
+            } catch (_: Throwable) {
+            }
+            try {
+                it.close()
+            } catch (_: Throwable) {
+            }
+        }
+        gatt = null
+    }
+
+    private fun scheduleReconnect(reason: String) {
+        if (intentionalDisconnect) return
+        val device = targetDevice ?: return
+        closeGatt()
+        if (directRetryCount >= MAX_DIRECT_RETRIES) {
+            autoConnectArmed = true
+        }
+        val delayMs =
+            if (autoConnectArmed) {
+                AUTO_CONNECT_DELAY_MS
+            } else {
+                val base = INITIAL_RETRY_DELAY_MS shl directRetryCount.coerceAtMost(4)
+                base.coerceAtMost(MAX_DIRECT_RETRY_DELAY_MS)
+            }
+        directRetryCount++
+        Log.i(
+            config.tag,
+            "Scheduling reconnect to ${device.address} in ${delayMs}ms " +
+                "($reason, autoConnect=$autoConnectArmed)",
+        )
+        handler.removeCallbacks(retryRunnable)
+        handler.postDelayed(retryRunnable, delayMs)
+    }
+
+    private val callback =
+        object : BluetoothGattCallback() {
+            override fun onConnectionStateChange(
+                g: BluetoothGatt,
+                status: Int,
+                newState: Int,
+            ) {
+                when (newState) {
+                    BluetoothProfile.STATE_CONNECTED -> {
+                        Log.i(config.tag, "Connected (status=$status), discovering services")
+                        directRetryCount = 0
+                        autoConnectArmed = false
+                        onConnectionState(true)
+                        g.discoverServices()
+                    }
+                    BluetoothProfile.STATE_DISCONNECTED -> {
+                        Log.i(config.tag, "Disconnected (status=$status)")
+                        lastHeld = emptySet()
+                        onConnectionState(false)
+                        if (!intentionalDisconnect) {
+                            scheduleReconnect("status=$status")
+                        }
+                    }
+                }
+            }
+
+            override fun onServicesDiscovered(
+                g: BluetoothGatt,
+                status: Int,
+            ) {
+                if (status != BluetoothGatt.GATT_SUCCESS) {
+                    Log.w(config.tag, "Service discovery failed: $status")
+                    return
+                }
+                // One-time enumeration of every service + characteristic
+                // so bring-up on new hardware has a paper trail. Cheap
+                // and only fires once per (re)connect.
+                for (svc in g.services) {
+                    Log.i(config.tag, "service: ${svc.uuid}")
+                    for (ch in svc.characteristics) {
+                        val props = describeProps(ch.properties)
+                        Log.i(config.tag, "  char: ${ch.uuid} [$props]")
+                    }
+                }
+                val service =
+                    config.candidateServiceUuids
+                        .asSequence()
+                        .mapNotNull { uuid ->
+                            g.getService(uuid)?.also {
+                                Log.i(config.tag, "matched service $uuid")
+                            }
+                        }.firstOrNull()
+                if (service == null) {
+                    Log.w(
+                        config.tag,
+                        "no known service on device " +
+                            "(tried ${config.candidateServiceUuids}) — bond may be wrong protocol",
+                    )
+                    return
+                }
+                var subscribed = 0
+                for (ch in service.characteristics) {
+                    if ((ch.properties and BluetoothGattCharacteristic.PROPERTY_NOTIFY) == 0) continue
+                    if (!g.setCharacteristicNotification(ch, true)) {
+                        Log.w(config.tag, "setCharacteristicNotification(true) failed for ${ch.uuid}")
+                        continue
+                    }
+                    val cccd = ch.getDescriptor(CCCD_UUID)
+                    if (cccd == null) {
+                        Log.w(config.tag, "CCCD missing on ${ch.uuid} — cannot enable notifications")
+                        continue
+                    }
+                    val enableValue = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+                    val ok =
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            g.writeDescriptor(cccd, enableValue) == BluetoothGatt.GATT_SUCCESS
+                        } else {
+                            @Suppress("DEPRECATION")
+                            cccd.value = enableValue
+                            @Suppress("DEPRECATION")
+                            g.writeDescriptor(cccd)
+                        }
+                    if (ok) {
+                        subscribed++
+                        Log.i(config.tag, "subscribed to notifications on ${ch.uuid}")
+                    } else {
+                        Log.w(config.tag, "writeDescriptor(enable) failed for ${ch.uuid}")
+                    }
+                }
+                if (subscribed == 0) {
+                    Log.w(config.tag, "no notify-capable characteristics in matched service — protocol mismatch")
+                }
+            }
+
+            @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+            override fun onCharacteristicChanged(
+                g: BluetoothGatt,
+                ch: BluetoothGattCharacteristic,
+            ) {
+                handleNotification(ch, ch.value)
+            }
+
+            override fun onCharacteristicChanged(
+                g: BluetoothGatt,
+                ch: BluetoothGattCharacteristic,
+                value: ByteArray,
+            ) {
+                handleNotification(ch, value)
+            }
+
+            private fun handleNotification(
+                ch: BluetoothGattCharacteristic,
+                bytes: ByteArray?,
+            ) {
+                if (bytes == null) return
+                Log.i(config.tag, "notify ${ch.uuid}: ${bytes.toHexString()}")
+                if (bytes.isEmpty()) return
+                val mask = bytes[0].toInt() and 0xFF
+                val nowHeld = config.decodeMask(mask)
+                val prev = lastHeld
+                val edges = diffEdges(prev, nowHeld) ?: return
+                lastHeld = nowHeld
+                for (btn in edges.down) onEvent(btn, true)
+                for (btn in edges.up) onEvent(btn, false)
+            }
+        }
+
+    private fun describeProps(p: Int): String {
+        val parts = mutableListOf<String>()
+        if (p and BluetoothGattCharacteristic.PROPERTY_READ != 0) parts += "READ"
+        if (p and BluetoothGattCharacteristic.PROPERTY_WRITE != 0) parts += "WRITE"
+        if (p and BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE != 0) parts += "WRITE_NR"
+        if (p and BluetoothGattCharacteristic.PROPERTY_NOTIFY != 0) parts += "NOTIFY"
+        if (p and BluetoothGattCharacteristic.PROPERTY_INDICATE != 0) parts += "INDICATE"
+        return parts.joinToString(",")
+    }
+
+    private fun ByteArray.toHexString(): String = joinToString(" ") { "%02x".format(it.toInt() and 0xff) }
+
+    /**
+     * Pure computation of down/up edges between two "held" sets.
+     * Returns `null` when there is nothing to fire (identical sets),
+     * so callers can early-return without allocating an [Edges].
+     *
+     * Extracted as a top-level companion function so unit tests can
+     * pin the diff behavior without instantiating the reader (which
+     * requires an Android [Context] and a live GATT stack).
+     */
+    data class Edges(
+        val down: List<AinaButton>,
+        val up: List<AinaButton>,
+    )
+
+    companion object {
+        private const val MAX_DIRECT_RETRIES = 4
+        private const val INITIAL_RETRY_DELAY_MS = 2_000L
+        private const val MAX_DIRECT_RETRY_DELAY_MS = 16_000L
+        private const val AUTO_CONNECT_DELAY_MS = 5_000L
+
+        val CCCD_UUID: UUID = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
+
+        fun diffEdges(
+            prev: Set<AinaButton>,
+            now: Set<AinaButton>,
+        ): Edges? {
+            if (prev == now) return null
+            val down = now.filter { it !in prev }
+            val up = prev.filter { it !in now }
+            return Edges(down = down, up = up)
+        }
+    }
+}

--- a/app/src/main/java/com/atakmap/android/xv/aina/PrymeBleReader.kt
+++ b/app/src/main/java/com/atakmap/android/xv/aina/PrymeBleReader.kt
@@ -1,22 +1,11 @@
 package com.atakmap.android.xv.aina
 
-import android.annotation.SuppressLint
-import android.bluetooth.BluetoothDevice
-import android.bluetooth.BluetoothGatt
-import android.bluetooth.BluetoothGattCallback
-import android.bluetooth.BluetoothGattCharacteristic
-import android.bluetooth.BluetoothGattDescriptor
-import android.bluetooth.BluetoothProfile
 import android.content.Context
-import android.os.Build
-import android.os.Handler
-import android.os.Looper
-import android.util.Log
 import java.util.UUID
 
 /**
- * Custom BLE GATT button reader for Pryme BT-PTT-Z (and similar
- * devices that use the same vendor service).
+ * BLE GATT button reader for Pryme BT-PTT-Z (and firmware revisions
+ * that use the same wire format).
  *
  * The Pryme PTT button does NOT pair as a generic HID-over-GATT
  * input device — Android's HidHostService never claims it (verified
@@ -27,288 +16,59 @@ import java.util.UUID
  * subscribe to the vendor button-state characteristic itself, the
  * same way [AinaBleReader] does for AINA V2.
  *
- * Service UUID `00420000-8f59-4420-870d-84f3b617e493` was identified
- * by inspecting the production VX plugin (com.atakmap.android.gbr.vx.plugin)
- * — the only custom UUID family in its dex. The two child characteristics
- * `00420001` and `00420002` are subscribed for notifications; raw
- * bytes are logged at INFO so we can iterate the parser once we
- * see real wire-format data.
+ * All connect / retry / notify / edge-triggered-mask plumbing lives
+ * in [BitmaskGattPttReader]; this class only supplies the vendor
+ * config (candidate service UUIDs + mask-decode heuristic).
  *
- * Shared retry strategy with AinaBleReader: a few quick direct retries
- * for transient status=133, then auto-connect for long-term recovery
- * after the device sleeps / leaves range.
+ * Service UUIDs, in priority order:
+ *   - `0000ffe0-…-00805f9b34fb` (HM-10 / TI CC2540 transparent UART)
+ *     is what production Pryme BT-PTT-Z units advertise — verified
+ *     on-device: their GATT tree exposes only Generic Access (1800),
+ *     Generic Attribute (1801), and `ffe0` with characteristic
+ *     `ffe1` [WRITE,NOTIFY].
+ *   - `00420000-8f59-4420-870d-84f3b617e493` was extracted from VX
+ *     2.1.0's dex during protocol study. It doesn't match the units
+ *     we have on hand but is kept as a fallback in case a Pryme
+ *     firmware revision exposes it instead.
+ *
+ * Add new UUIDs to [PRYME_SERVICE_UUIDS] as new hardware is tested.
+ *
+ * Mask decode heuristic: any non-zero first byte on the notify
+ * characteristic = PTT held; zero = released. Pryme reports a raw
+ * button-state byte and we treat every combination as "PTT is down"
+ * until wire-format documentation lets us distinguish per-button
+ * bits. Refine [decodePrymeMask] when that documentation arrives.
  */
-@SuppressLint("MissingPermission")
 class PrymeBleReader(
-    private val context: Context,
-    private val onEvent: (AinaButton, isDown: Boolean) -> Unit,
-    private val onConnectionState: (Boolean) -> Unit = {},
+    context: Context,
+    onEvent: (AinaButton, isDown: Boolean) -> Unit,
+    onConnectionState: (Boolean) -> Unit = {},
+) : BitmaskGattPttReader(
+    context = context,
+    config = PRYME_CONFIG,
+    onEvent = onEvent,
+    onConnectionState = onConnectionState,
 ) {
-    private val handler = Handler(Looper.getMainLooper())
-    private var gatt: BluetoothGatt? = null
-    private var targetDevice: BluetoothDevice? = null
-
-    @Volatile
-    private var intentionalDisconnect: Boolean = false
-
-    private var directRetryCount: Int = 0
-    private var autoConnectArmed: Boolean = false
-
-    // Last raw mask seen on the button characteristic; used to derive
-    // edge-triggered AinaButton.PTT down/up events without the Pryme
-    // sending separate down/up packets. Initialized to 0 (no buttons
-    // pressed); first non-zero notification = PTT down, next 0 = up.
-    @Volatile
-    private var lastMask: Int = 0
-
-    private val retryRunnable =
-        Runnable {
-            val device = targetDevice ?: return@Runnable
-            if (intentionalDisconnect) return@Runnable
-            connectInternal(device, useAutoConnect = autoConnectArmed)
-        }
-
-    fun connect(device: BluetoothDevice) {
-        disconnect()
-        intentionalDisconnect = false
-        targetDevice = device
-        directRetryCount = 0
-        autoConnectArmed = false
-        connectInternal(device, useAutoConnect = false)
-    }
-
-    private fun connectInternal(
-        device: BluetoothDevice,
-        useAutoConnect: Boolean,
-    ) {
-        lastMask = 0
-        Log.i(
-            TAG,
-            "Connecting to Pryme at ${device.address} " +
-                "(autoConnect=$useAutoConnect, attempt=${directRetryCount + 1})",
-        )
-        gatt = device.connectGatt(context, useAutoConnect, callback, BluetoothDevice.TRANSPORT_LE)
-    }
-
-    fun disconnect() {
-        intentionalDisconnect = true
-        targetDevice = null
-        handler.removeCallbacks(retryRunnable)
-        closeGatt()
-        onConnectionState(false)
-    }
-
-    private fun closeGatt() {
-        gatt?.let {
-            try {
-                it.disconnect()
-            } catch (_: Throwable) {
-            }
-            try {
-                it.close()
-            } catch (_: Throwable) {
-            }
-        }
-        gatt = null
-    }
-
-    private fun scheduleReconnect(reason: String) {
-        if (intentionalDisconnect) return
-        val device = targetDevice ?: return
-        closeGatt()
-        if (directRetryCount >= MAX_DIRECT_RETRIES) {
-            autoConnectArmed = true
-        }
-        val delayMs =
-            if (autoConnectArmed) {
-                AUTO_CONNECT_DELAY_MS
-            } else {
-                val base = INITIAL_RETRY_DELAY_MS shl directRetryCount.coerceAtMost(4)
-                base.coerceAtMost(MAX_DIRECT_RETRY_DELAY_MS)
-            }
-        directRetryCount++
-        Log.i(
-            TAG,
-            "Scheduling reconnect to ${device.address} in ${delayMs}ms " +
-                "($reason, autoConnect=$autoConnectArmed)",
-        )
-        handler.removeCallbacks(retryRunnable)
-        handler.postDelayed(retryRunnable, delayMs)
-    }
-
-    private val callback =
-        object : BluetoothGattCallback() {
-            override fun onConnectionStateChange(
-                g: BluetoothGatt,
-                status: Int,
-                newState: Int,
-            ) {
-                when (newState) {
-                    BluetoothProfile.STATE_CONNECTED -> {
-                        Log.i(TAG, "Connected (status=$status), discovering services")
-                        directRetryCount = 0
-                        autoConnectArmed = false
-                        onConnectionState(true)
-                        g.discoverServices()
-                    }
-                    BluetoothProfile.STATE_DISCONNECTED -> {
-                        Log.i(TAG, "Disconnected (status=$status)")
-                        lastMask = 0
-                        onConnectionState(false)
-                        if (!intentionalDisconnect) {
-                            scheduleReconnect("status=$status")
-                        }
-                    }
-                }
-            }
-
-            override fun onServicesDiscovered(
-                g: BluetoothGatt,
-                status: Int,
-            ) {
-                if (status != BluetoothGatt.GATT_SUCCESS) {
-                    Log.w(TAG, "Service discovery failed: $status")
-                    return
-                }
-                // One-time enumeration of every service + characteristic
-                // so we can confirm the vendor service UUID matches what
-                // the device actually exposes. Cheap and only fires once
-                // per (re)connect.
-                for (svc in g.services) {
-                    Log.i(TAG, "service: ${svc.uuid}")
-                    for (ch in svc.characteristics) {
-                        val props = describeProps(ch.properties)
-                        Log.i(TAG, "  char: ${ch.uuid} [$props]")
-                    }
-                }
-                val service =
-                    KNOWN_SERVICE_UUIDS
-                        .asSequence()
-                        .mapNotNull { uuid ->
-                            g.getService(uuid)?.also {
-                                Log.i(TAG, "matched Pryme service $uuid")
-                            }
-                        }.firstOrNull()
-                if (service == null) {
-                    Log.w(
-                        TAG,
-                        "no known Pryme service on device " +
-                            "(tried $KNOWN_SERVICE_UUIDS) — bond may be wrong protocol",
-                    )
-                    return
-                }
-                // Subscribe to every notify-capable characteristic in
-                // the service. We don't yet know which one carries the
-                // button mask vs. which is config / battery / firmware,
-                // so subscribe broadly and let the logged raw-byte
-                // dumps tell us. Once the wire format is confirmed,
-                // narrow this to the one button characteristic.
-                var subscribed = 0
-                for (ch in service.characteristics) {
-                    if ((ch.properties and BluetoothGattCharacteristic.PROPERTY_NOTIFY) == 0) continue
-                    if (!g.setCharacteristicNotification(ch, true)) {
-                        Log.w(TAG, "setCharacteristicNotification(true) failed for ${ch.uuid}")
-                        continue
-                    }
-                    val cccd = ch.getDescriptor(CCCD_UUID)
-                    if (cccd == null) {
-                        Log.w(TAG, "CCCD missing on ${ch.uuid} — cannot enable notifications")
-                        continue
-                    }
-                    val enableValue = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
-                    val ok =
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                            g.writeDescriptor(cccd, enableValue) == BluetoothGatt.GATT_SUCCESS
-                        } else {
-                            @Suppress("DEPRECATION")
-                            cccd.value = enableValue
-                            @Suppress("DEPRECATION")
-                            g.writeDescriptor(cccd)
-                        }
-                    if (ok) {
-                        subscribed++
-                        Log.i(TAG, "subscribed to notifications on ${ch.uuid}")
-                    } else {
-                        Log.w(TAG, "writeDescriptor(enable) failed for ${ch.uuid}")
-                    }
-                }
-                if (subscribed == 0) {
-                    Log.w(TAG, "no notify-capable characteristics in Pryme service — protocol mismatch")
-                }
-            }
-
-            @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
-            override fun onCharacteristicChanged(
-                g: BluetoothGatt,
-                ch: BluetoothGattCharacteristic,
-            ) {
-                handleNotification(ch, ch.value)
-            }
-
-            override fun onCharacteristicChanged(
-                g: BluetoothGatt,
-                ch: BluetoothGattCharacteristic,
-                value: ByteArray,
-            ) {
-                handleNotification(ch, value)
-            }
-
-            private fun handleNotification(
-                ch: BluetoothGattCharacteristic,
-                bytes: ByteArray?,
-            ) {
-                if (bytes == null) return
-                Log.i(TAG, "notify ${ch.uuid}: ${bytes.toHexString()}")
-                if (bytes.isEmpty()) return
-                // Heuristic edge-trigger: any non-zero first byte = some
-                // button held; zero = all released. Single-button Pryme
-                // devices only need PTT semantics, so this maps any
-                // press to AinaButton.PTT down/up regardless of which
-                // bit is set. Refine once the protocol is documented.
-                val mask = bytes[0].toInt() and 0xFF
-                val prev = lastMask
-                lastMask = mask
-                if (prev == 0 && mask != 0) {
-                    onEvent(AinaButton.PTT, true)
-                } else if (prev != 0 && mask == 0) {
-                    onEvent(AinaButton.PTT, false)
-                }
-            }
-        }
-
-    private fun describeProps(p: Int): String {
-        val parts = mutableListOf<String>()
-        if (p and BluetoothGattCharacteristic.PROPERTY_READ != 0) parts += "READ"
-        if (p and BluetoothGattCharacteristic.PROPERTY_WRITE != 0) parts += "WRITE"
-        if (p and BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE != 0) parts += "WRITE_NR"
-        if (p and BluetoothGattCharacteristic.PROPERTY_NOTIFY != 0) parts += "NOTIFY"
-        if (p and BluetoothGattCharacteristic.PROPERTY_INDICATE != 0) parts += "INDICATE"
-        return parts.joinToString(",")
-    }
-
-    private fun ByteArray.toHexString(): String = joinToString(" ") { "%02x".format(it.toInt() and 0xff) }
-
     companion object {
-        private const val TAG = "XvPrymeBle"
-
-        private const val MAX_DIRECT_RETRIES = 4
-        private const val INITIAL_RETRY_DELAY_MS = 2_000L
-        private const val MAX_DIRECT_RETRY_DELAY_MS = 16_000L
-        private const val AUTO_CONNECT_DELAY_MS = 5_000L
-
-        // Service UUIDs we know carry Pryme button data, tried in
-        // order. The HM-10 / TI CC2540 transparent UART service
-        // (0000ffe0-…) is the actual one used by Pryme BT-PTT-Z
-        // hardware as verified by on-device service discovery: their
-        // unit advertises only Generic Access (1800), Generic Attribute
-        // (1801), and ffe0 with characteristic ffe1 [WRITE,NOTIFY].
-        // The 00420000-8f59-… UUID was extracted from VX 2.1.0's dex
-        // but doesn't match the units we have on hand — kept as a
-        // fallback in case a different Pryme firmware revision uses
-        // it. Add new UUIDs to this list as new hardware is tested.
         private val HM10_SERVICE_UUID: UUID = UUID.fromString("0000ffe0-0000-1000-8000-00805f9b34fb")
         private val PRYME_VENDOR_UUID: UUID = UUID.fromString("00420000-8f59-4420-870d-84f3b617e493")
-        private val KNOWN_SERVICE_UUIDS: List<UUID> = listOf(HM10_SERVICE_UUID, PRYME_VENDOR_UUID)
-        val CCCD_UUID: UUID = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
+
+        val PRYME_SERVICE_UUIDS: List<UUID> = listOf(HM10_SERVICE_UUID, PRYME_VENDOR_UUID)
+
+        /**
+         * "Any non-zero first byte = PTT held" — the field heuristic
+         * used since Pryme support was first added. Kept as a
+         * top-level function so unit tests can pin the exact
+         * behavior without touching the Android GATT stack.
+         */
+        fun decodePrymeMask(mask: Int): Set<AinaButton> =
+            if (mask != 0) setOf(AinaButton.PTT) else emptySet()
+
+        private val PRYME_CONFIG =
+            Config(
+                tag = "XvPrymeBle",
+                candidateServiceUuids = PRYME_SERVICE_UUIDS,
+                decodeMask = ::decodePrymeMask,
+            )
     }
 }

--- a/app/src/main/java/com/atakmap/android/xv/aina/ZelloBleReader.kt
+++ b/app/src/main/java/com/atakmap/android/xv/aina/ZelloBleReader.kt
@@ -1,0 +1,118 @@
+package com.atakmap.android.xv.aina
+
+import android.content.Context
+import java.util.UUID
+
+/**
+ * BLE GATT button reader for Zello-convention PTT buttons.
+ *
+ * Zello's Hardware Partner Technical Integration document specifies
+ * that a compatible BLE PTT accessory:
+ *
+ *   1. Advertises with a vendor-specific Service UUID (Zello whitelists
+ *      per-{advertised-name, service UUID, characteristic UUID}).
+ *   2. Exposes a notify characteristic that carries a **bitmask byte**
+ *      describing which buttons are currently held:
+ *
+ *      | Bit  | Function            |
+ *      |------|---------------------|
+ *      | 0x01 | PTT (primary)       |
+ *      | 0x02 | SOS                 |
+ *      | 0x04 | Secondary PTT       |
+ *      | 0x08 | Channel Down        |
+ *      | 0x10 | Channel Up          |
+ *
+ * Because Zello whitelists each device individually, the actual
+ * Service and Characteristic UUIDs are hardware-specific — a
+ * `B0DHZDRH3B` on a motorcyclist's bike will not necessarily share
+ * UUIDs with a Zello-branded headset.
+ *
+ * ## Populating the UUIDs
+ *
+ * Until we have real UUIDs from an on-device probe (nRF Connect
+ * against the physical device — enumerate services + notify
+ * characteristics, press the button, capture the payload), the
+ * [ZELLO_CANDIDATE_SERVICE_UUIDS] list is intentionally empty. That
+ * makes `getService(uuid)` fail closed during service discovery and
+ * emits the standard "no known service" log line, so a caller who
+ * wires the reader up before UUIDs are known will see the mismatch
+ * loudly instead of silently swallowing button events.
+ *
+ * When real UUIDs land, add them here — same pattern as
+ * [PrymeBleReader.PRYME_SERVICE_UUIDS] — and drop the placeholder
+ * warning below.
+ *
+ * The [decodeZelloMask] function IS complete and unit-tested; the
+ * mask semantics are stable across Zello-conformant devices, so the
+ * decoder can be validated ahead of hardware bring-up.
+ *
+ * ## Button mapping onto AinaButton
+ *
+ * XV's existing button vocabulary ([AinaButton]) is AINA-derived and
+ * doesn't have first-class entries for "channel up" / "channel down".
+ * The Zello channel-switch bits (0x08, 0x10) are intentionally NOT
+ * mapped today — the goal for the first cut is primary + secondary
+ * PTT so a motorcyclist can key channel 1 from either their AINA
+ * speakermic or the Zello button. Channel switching from a physical
+ * button is future work; when we add it, extend [AinaButton] with
+ * CH_UP / CH_DOWN and light up those bits here.
+ *
+ * Mapping today:
+ *   0x01 → [AinaButton.PTT]  (primary — primary PTT input)
+ *   0x02 → [AinaButton.PTTE] (emergency PTT — closest existing analog to SOS)
+ *   0x04 → [AinaButton.PTTS] (secondary PTT — secondary PTT input)
+ *   0x08 → unmapped (Channel Down)
+ *   0x10 → unmapped (Channel Up)
+ */
+class ZelloBleReader(
+    context: Context,
+    onEvent: (AinaButton, isDown: Boolean) -> Unit,
+    onConnectionState: (Boolean) -> Unit = {},
+) : BitmaskGattPttReader(
+    context = context,
+    config = ZELLO_CONFIG,
+    onEvent = onEvent,
+    onConnectionState = onConnectionState,
+) {
+    companion object {
+        /**
+         * Populate from an on-device nRF Connect probe of the target
+         * hardware. Until then, service discovery will match nothing
+         * and the reader will log the mismatch.
+         *
+         * TODO(UUID): capture and add the actual Service UUID(s) of
+         *   the operator's Zello-convention BLE PTT button. Follow
+         *   the same "priority order, first match wins" contract
+         *   [PrymeBleReader.PRYME_SERVICE_UUIDS] uses so a single
+         *   reader can cover firmware revisions that only differ in
+         *   advertised UUID.
+         */
+        val ZELLO_CANDIDATE_SERVICE_UUIDS: List<UUID> = emptyList()
+
+        /**
+         * Zello Hardware Partner protocol bitmask. Stable across
+         * Zello-conformant devices, so this decoder can be pinned by
+         * unit tests before any hardware is available.
+         *
+         * Bit 0x08 (Channel Down) and 0x10 (Channel Up) are decoded
+         * as absent from the result set — see the class KDoc for why
+         * channel-switching is deferred.
+         */
+        fun decodeZelloMask(mask: Int): Set<AinaButton> {
+            val out = mutableSetOf<AinaButton>()
+            if (mask and 0x01 != 0) out += AinaButton.PTT
+            if (mask and 0x02 != 0) out += AinaButton.PTTE
+            if (mask and 0x04 != 0) out += AinaButton.PTTS
+            // 0x08 (Channel Down) — intentionally unmapped, see KDoc.
+            // 0x10 (Channel Up)   — intentionally unmapped, see KDoc.
+            return out
+        }
+
+        private val ZELLO_CONFIG =
+            Config(
+                tag = "XvZelloBle",
+                candidateServiceUuids = ZELLO_CANDIDATE_SERVICE_UUIDS,
+                decodeMask = ::decodeZelloMask,
+            )
+    }
+}

--- a/app/src/test/java/com/atakmap/android/xv/aina/BitmaskGattPttReaderTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/aina/BitmaskGattPttReaderTest.kt
@@ -1,0 +1,92 @@
+package com.atakmap.android.xv.aina
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Coverage for [BitmaskGattPttReader.diffEdges] (the base's edge-
+ * triggered press/release derivation) and [PrymeBleReader]'s mask
+ * decoder. Exercised as pure functions so no Android context / GATT
+ * stack is needed.
+ */
+class BitmaskGattPttReaderTest {
+    // ============================================================
+    // Edge diff — the base's press/release derivation
+    // ============================================================
+
+    @Test
+    fun `diffEdges returns null when nothing changes`() {
+        assertNull(BitmaskGattPttReader.diffEdges(emptySet(), emptySet()))
+        assertNull(
+            BitmaskGattPttReader.diffEdges(
+                setOf(AinaButton.PTT),
+                setOf(AinaButton.PTT),
+            ),
+        )
+    }
+
+    @Test
+    fun `diffEdges reports a down event for a newly pressed button`() {
+        val edges = BitmaskGattPttReader.diffEdges(emptySet(), setOf(AinaButton.PTT))
+        assertEquals(listOf(AinaButton.PTT), edges?.down)
+        assertTrue("no releases when going from nothing to something", edges?.up?.isEmpty() == true)
+    }
+
+    @Test
+    fun `diffEdges reports an up event for a released button`() {
+        val edges = BitmaskGattPttReader.diffEdges(setOf(AinaButton.PTT), emptySet())
+        assertTrue("no presses when going from something to nothing", edges?.down?.isEmpty() == true)
+        assertEquals(listOf(AinaButton.PTT), edges?.up)
+    }
+
+    @Test
+    fun `diffEdges reports both edges when the held set rotates`() {
+        // Ex: operator releases PTT and immediately presses secondary
+        val edges =
+            BitmaskGattPttReader.diffEdges(
+                setOf(AinaButton.PTT),
+                setOf(AinaButton.PTTS),
+            )
+        assertEquals(listOf(AinaButton.PTTS), edges?.down)
+        assertEquals(listOf(AinaButton.PTT), edges?.up)
+    }
+
+    @Test
+    fun `diffEdges handles multi-button transitions independently`() {
+        // Operator was holding PTT; now holds PTT + SOS. Only SOS
+        // reports as newly-pressed; PTT stays held so nothing about
+        // it is emitted.
+        val edges =
+            BitmaskGattPttReader.diffEdges(
+                setOf(AinaButton.PTT),
+                setOf(AinaButton.PTT, AinaButton.PTTE),
+            )
+        assertEquals(listOf(AinaButton.PTTE), edges?.down)
+        assertTrue(edges?.up?.isEmpty() == true)
+    }
+
+    // ============================================================
+    // Pryme decoder — "any non-zero = PTT" heuristic
+    // ============================================================
+
+    @Test
+    fun `Pryme decoder maps zero mask to nothing held`() {
+        assertTrue(PrymeBleReader.decodePrymeMask(0x00).isEmpty())
+    }
+
+    @Test
+    fun `Pryme decoder maps any non-zero mask to PTT held`() {
+        // Every observed value we've seen from field units is caught
+        // by the "non-zero = PTT" heuristic. This locks that behavior
+        // in so the refactor cannot silently narrow it.
+        for (m in 0x01..0xFF) {
+            assertEquals(
+                "mask=0x${m.toString(16)} should map to PTT held",
+                setOf(AinaButton.PTT),
+                PrymeBleReader.decodePrymeMask(m),
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/atakmap/android/xv/aina/ZelloBleReaderTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/aina/ZelloBleReaderTest.kt
@@ -1,0 +1,67 @@
+package com.atakmap.android.xv.aina
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Coverage for [ZelloBleReader.decodeZelloMask] — pins the bitmask
+ * decoder against Zello's Hardware Partner Technical Integration
+ * specification so the button-event mapping is validated ahead of
+ * hardware bring-up (the actual Service / Characteristic UUIDs are
+ * still `TODO(UUID)` in [ZelloBleReader], but the wire-level mask
+ * semantics are stable across Zello-conformant devices).
+ */
+class ZelloBleReaderTest {
+    @Test
+    fun `zero mask decodes to nothing held`() {
+        assertTrue(ZelloBleReader.decodeZelloMask(0x00).isEmpty())
+    }
+
+    @Test
+    fun `0x01 decodes to primary PTT`() {
+        assertEquals(setOf(AinaButton.PTT), ZelloBleReader.decodeZelloMask(0x01))
+    }
+
+    @Test
+    fun `0x02 decodes to emergency PTT (SOS analog)`() {
+        assertEquals(setOf(AinaButton.PTTE), ZelloBleReader.decodeZelloMask(0x02))
+    }
+
+    @Test
+    fun `0x04 decodes to secondary PTT`() {
+        assertEquals(setOf(AinaButton.PTTS), ZelloBleReader.decodeZelloMask(0x04))
+    }
+
+    @Test
+    fun `multiple simultaneously held bits combine into a set`() {
+        // Primary + secondary pressed at once — e.g. a dual-button
+        // Zello puck where the operator squeezes both.
+        assertEquals(
+            setOf(AinaButton.PTT, AinaButton.PTTS),
+            ZelloBleReader.decodeZelloMask(0x01 or 0x04),
+        )
+    }
+
+    @Test
+    fun `channel-switch bits are ignored today`() {
+        // 0x08 = Chan Down, 0x10 = Chan Up. Intentionally not mapped
+        // today (see ZelloBleReader KDoc); this pins that decision so
+        // a future extension is a deliberate choice, not accidental.
+        assertTrue(ZelloBleReader.decodeZelloMask(0x08).isEmpty())
+        assertTrue(ZelloBleReader.decodeZelloMask(0x10).isEmpty())
+        assertTrue(ZelloBleReader.decodeZelloMask(0x08 or 0x10).isEmpty())
+    }
+
+    @Test
+    fun `channel-switch bits ignored even when combined with PTT`() {
+        // Operator holds primary PTT AND presses channel-up. The PTT
+        // is honored; the channel-up bit is currently swallowed. When
+        // channel-switch is added to the button vocabulary this test
+        // will need updating.
+        assertEquals(
+            setOf(AinaButton.PTT),
+            ZelloBleReader.decodeZelloMask(0x01 or 0x10),
+        )
+    }
+}


### PR DESCRIPTION
> **DRAFT** — no on-device verification yet. Merge blocked on: (1) `feat/auto-connect-compat-bt` PR landing on `main` first (this PR is stacked on that branch — GitHub will auto-retarget on merge), and (2) an on-device probe of the physical Zello button so the `TODO(UUID)` slots can be populated before the Zello reader is actually wired into `VoicePlant`.

## Summary

Two commits, isolated by concern:

1. **`refactor(aina)`** — extract a reusable `BitmaskGattPttReader` base from `PrymeBleReader`. Behavior-preserving: same service UUID priority order, same "any non-zero byte = PTT held" heuristic for Pryme, same retry ladder, same CCCD-write compatibility across Tiramisu and pre-Tiramisu. `VoicePlant`'s call sites are unchanged.
2. **`feat(aina)`** — add `ZelloBleReader` as a thin config over the new base for Zello-convention BLE PTT buttons (Amazon B0DHZDRH3B being the initial target hardware). Mask decoder is complete + fully unit-tested against Zello's published Hardware Partner Technical Integration spec; Service / Characteristic UUIDs are `TODO(UUID)` markers pending an on-device nRF Connect probe.

## Why this design

Both Pryme and Zello-convention devices speak the same protocol shape: advertise a vendor Service UUID, expose one or more notify characteristics that carry a bitmask byte, and rely on the app to derive per-button down / up events from mask deltas. The old `PrymeBleReader` implemented all of that inline, so a Zello reader would have been a near-copy — the extraction avoids the copy and pins the shared behavior in one place. Vendor-specific knowledge is now a `Config { tag, candidateServiceUuids, decodeMask }` value; readers become 30-line thin configs.

## What's changed vs. Pryme's previous behavior

Nothing intentionally. The `decodePrymeMask` unit test iterates 0x01..0xFF and asserts every value maps to `{PTT}`, matching the pre-refactor "non-zero = PTT" heuristic exactly. The `diffEdges` pure function was pulled out of the reader for testability — its logic is `now - prev = down, prev - now = up`, which is what `PrymeBleReader.handleNotification` was already doing for a single-button case (0 → non-zero fires down; non-zero → 0 fires up).

## Zello mapping onto XV's button vocabulary

XV's `AinaButton` enum is AINA-derived and doesn't have first-class channel-switch entries. Initial cut:

| Zello bit | Mapped to | Notes |
|---|---|---|
| `0x01` PTT (primary)   | `AinaButton.PTT`  | Feeds the primary PTT input path |
| `0x02` SOS             | `AinaButton.PTTE` | Emergency PTT is the closest existing analog |
| `0x04` Secondary PTT   | `AinaButton.PTTS` | Feeds the secondary PTT input path (the motorcyclist case) |
| `0x08` Channel Down    | unmapped          | Add `CH_DOWN` to `AinaButton` when we want this |
| `0x10` Channel Up      | unmapped          | Same |

The unmapped-today decision is pinned by test: `channel-switch bits are ignored today` and `channel-switch bits ignored even when combined with PTT` will need updating when the vocabulary is extended.

## Test plan

- [x] `./gradlew ktlintCheck` — clean.
- [x] `./gradlew assembleCivDebug` — clean.
- [x] `./gradlew testCivDebugUnitTest` — passes; new tests cover the edge-diff (5 cases), the Pryme decoder (0x00 + every non-zero mask 0x01..0xFF), and the Zello decoder (per-bit, combined, and channel-switch-ignored cases).
- [ ] On-device: probe a physical Zello button with nRF Connect, populate `ZELLO_CANDIDATE_SERVICE_UUIDS`, wire `ZelloBleReader` into `VoicePlant` next to `AinaBleReader` and `PrymeBleReader`, and verify press / release on the actual hardware. Blocks the "ready for review" transition.
- [ ] On-device: regression pass on Pryme BT-PTT-Z — press / release still fires PTT down / up at the operator layer via the refactored base.

## Follow-ups (not in this PR)

- Populate `ZELLO_CANDIDATE_SERVICE_UUIDS` from an nRF Connect capture and wire `ZelloBleReader` into `VoicePlant`'s auto-detect path.
- Consider adding `CH_UP` / `CH_DOWN` entries to `AinaButton` if the operator wants channel switching from the physical button; light up the `0x08` / `0x10` decode at that point.
- Rev the auto-detect scanner in `XvMapComponent` so it recognizes Zello-convention advertisers as a distinct class (currently the AINA detection heuristic won't claim them).