### PR TITLE
feat(ui): reorder settings to Devices | TX/RX | Server + BT-off banner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,44 @@ will read.
   bodies. Summarize ("verified against an AINA V2 puck") instead of
   quoting raw evidence.
 
+## README maintenance
+
+The top-level `README.md` is the project's public-facing description
+of what TAK-XVoice does, who it's for, and what hardware and features
+are supported. Because this repo is public, the README is often the
+first thing an operator, contributor, or downstream packager reads —
+keep it current alongside the code.
+
+- When a change lands that affects user-visible behavior — new
+  supported hardware, a new UX affordance, a new transport, a new
+  build task, a changed default, a retired feature — update the
+  relevant README section in the same PR that ships the code.
+  Do not treat README updates as a follow-up task; a merged feature
+  that isn't in the README is functionally invisible to new
+  operators.
+- The **curated-hardware policy** is load-bearing: nothing is listed
+  under "Hardware tested" as supported until it has been integrated
+  and validated end-to-end against real event traffic. Do not add
+  speculative, aspirational, or "should work" entries. When a device
+  graduates to supported (or is retired), update both "What's
+  different" and "Hardware tested" together.
+- When shipped work materially reshapes the roadmap
+  ("Now / Next / Later"), promote or retire bullets to reflect
+  reality rather than intent. A roadmap that reads like a wish list
+  loses signal.
+- The **status-and-intended-use disclaimer**, the
+  **hardware-philosophy** section, and the **reporting-issues**
+  guidance are load-bearing legal / policy language. Do not reword
+  them unilaterally — flag proposed changes to the operator first.
+- Vendor names for downstream / interop targets that the operator has
+  chosen to keep out of the README stay out. If unsure whether a
+  vendor or product name belongs, treat it like sensitive content:
+  redact and ask.
+- README updates are subject to the same sensitive-content rules as
+  commits and code (no real MACs, TAK URLs, callsigns, unit or
+  organization names, or operator GPS coordinates), and they go
+  through the same PR workflow described below.
+
 ## Branching + PR workflow
 
 - `main` is protected by convention — **never push directly**.

--- a/app/src/main/java/com/atakmap/android/xv/ui/XvDropDownReceiver.kt
+++ b/app/src/main/java/com/atakmap/android/xv/ui/XvDropDownReceiver.kt
@@ -1,7 +1,10 @@
 package com.atakmap.android.xv.ui
 
+import android.bluetooth.BluetoothAdapter
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
 import android.os.Handler
@@ -1038,6 +1041,7 @@ class XvDropDownReceiver(
         wireTxRxSection(v)
         wireChannelSelectors(v)
         wirePreferencesSection(v)
+        wireBtOffBanner(v)
 
         val takLabel = v.findViewById<TextView>(R.id.xv_tak_server_label)
         renderTakServerLabel(takLabel)
@@ -1118,6 +1122,92 @@ class XvDropDownReceiver(
     // plain Buttons swapping the visibility of three sibling LinearLayouts —
     // simpler than a TabLayout/ViewPager for a panel this small. The
     // selected tab is highlighted via alpha.
+    /**
+     * Banner at the top of the Devices tab that shows only when the
+     * Bluetooth adapter is disabled. Tapping opens the system BT
+     * settings so the operator can turn it back on without leaving
+     * XV.
+     *
+     * Wiring lifecycle: registers a broadcast receiver for
+     * `BluetoothAdapter.ACTION_STATE_CHANGED` when the settings view
+     * is attached to the window and unregisters on detach. That's
+     * scoped to the dropdown's lifetime — no receiver leaks past the
+     * moment the operator closes the panel.
+     *
+     * Rationale: previously, opening the AINA picker with BT off left
+     * the operator staring at an empty spinner with no explanation
+     * (`availableAinaDevices()` returns nothing when the adapter is
+     * off). This banner is the "why is the dropdown empty" answer,
+     * one tap away from the fix.
+     */
+    private fun wireBtOffBanner(v: View) {
+        val banner = v.findViewById<TextView>(R.id.xv_prefs_bt_off_banner) ?: return
+        banner.setOnClickListener {
+            try {
+                val i =
+                    Intent(android.provider.Settings.ACTION_BLUETOOTH_SETTINGS).apply {
+                        flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                    }
+                pluginContext.startActivity(i)
+            } catch (_: Throwable) {
+                // ACTION_BLUETOOTH_SETTINGS is present on every
+                // consumer Android build we ship against; swallow
+                // silently on the vanishing chance a stripped
+                // ROM refuses.
+            }
+        }
+
+        fun refresh() {
+            val adapter =
+                try {
+                    val bm = pluginContext.getSystemService(Context.BLUETOOTH_SERVICE)
+                        as? android.bluetooth.BluetoothManager
+                    bm?.adapter ?: BluetoothAdapter.getDefaultAdapter()
+                } catch (_: Throwable) {
+                    null
+                }
+            banner.visibility = if (adapter?.isEnabled == true) View.GONE else View.VISIBLE
+        }
+
+        val stateReceiver =
+            object : BroadcastReceiver() {
+                override fun onReceive(
+                    context: Context?,
+                    intent: Intent?,
+                ) {
+                    if (intent?.action == BluetoothAdapter.ACTION_STATE_CHANGED) refresh()
+                }
+            }
+
+        v.addOnAttachStateChangeListener(
+            object : View.OnAttachStateChangeListener {
+                override fun onViewAttachedToWindow(view: View) {
+                    try {
+                        pluginContext.registerReceiver(
+                            stateReceiver,
+                            IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED),
+                        )
+                    } catch (_: Throwable) {
+                    }
+                    refresh()
+                }
+
+                override fun onViewDetachedFromWindow(view: View) {
+                    try {
+                        pluginContext.unregisterReceiver(stateReceiver)
+                    } catch (_: IllegalArgumentException) {
+                        // Not registered — attach-fail path or double-detach; ignore.
+                    } catch (_: Throwable) {
+                    }
+                }
+            },
+        )
+        // Set initial visibility BEFORE attach fires so the first
+        // frame of the panel is already correct — avoids a brief
+        // "banner missing then appears" flash if the adapter is off.
+        refresh()
+    }
+
     private fun wireSettingsTabs(v: View) {
         val tabTxRx = v.findViewById<Button>(R.id.xv_tab_txrx)
         val tabCalls = v.findViewById<Button>(R.id.xv_tab_calls)
@@ -1125,16 +1215,23 @@ class XvDropDownReceiver(
         val sectionTxRx = v.findViewById<View>(R.id.xv_section_txrx)
         val sectionCalls = v.findViewById<View>(R.id.xv_section_calls)
         val sectionPrefs = v.findViewById<View>(R.id.xv_section_prefs)
-        val tabs = listOf(tabTxRx, tabCalls, tabPrefs)
-        val sections = listOf(sectionTxRx, sectionCalls, sectionPrefs)
+        // List order MUST match the tab strip's visual order so
+        // select(0) puts the first tab up. Operator-visible ordering
+        // is Devices (prefs) | TX/RX | Server (calls) — Devices leads
+        // because it carries the AINA / secondary PTT / audio-device
+        // pickers operators touch every session. The XML id names
+        // still say "prefs" for backward compatibility with the
+        // findViewById calls above.
+        val tabs = listOf(tabPrefs, tabTxRx, tabCalls)
+        val sections = listOf(sectionPrefs, sectionTxRx, sectionCalls)
 
         fun select(idx: Int) {
             sections.forEachIndexed { i, s -> s.visibility = if (i == idx) View.VISIBLE else View.GONE }
             tabs.forEachIndexed { i, b -> b.alpha = if (i == idx) 1.0f else 0.55f }
         }
-        tabTxRx.setOnClickListener { select(0) }
-        tabCalls.setOnClickListener { select(1) }
-        tabPrefs.setOnClickListener { select(2) }
+        tabPrefs.setOnClickListener { select(0) }
+        tabTxRx.setOnClickListener { select(1) }
+        tabCalls.setOnClickListener { select(2) }
         select(0)
     }
 

--- a/app/src/main/java/com/atakmap/android/xv/ui/XvDropDownReceiver.kt
+++ b/app/src/main/java/com/atakmap/android/xv/ui/XvDropDownReceiver.kt
@@ -1143,17 +1143,35 @@ class XvDropDownReceiver(
     private fun wireBtOffBanner(v: View) {
         val banner = v.findViewById<TextView>(R.id.xv_prefs_bt_off_banner) ?: return
         banner.setOnClickListener {
-            try {
-                val i =
-                    Intent(android.provider.Settings.ACTION_BLUETOOTH_SETTINGS).apply {
-                        flags = Intent.FLAG_ACTIVITY_NEW_TASK
-                    }
-                pluginContext.startActivity(i)
-            } catch (_: Throwable) {
-                // ACTION_BLUETOOTH_SETTINGS is present on every
-                // consumer Android build we ship against; swallow
-                // silently on the vanishing chance a stripped
-                // ROM refuses.
+            // Prefer the in-place system prompt over dropping the
+            // operator into full Bluetooth settings — the prompt is a
+            // one-tap "Allow XV to turn on Bluetooth?" dialog that
+            // leaves the operator on XV's screen. Falls back to the
+            // system Bluetooth settings screen only if the prompt
+            // intent isn't resolvable (stripped ROM, unusual OEM
+            // policy). Field-observed 2026-07-07: operator flagged
+            // the ACTION_BLUETOOTH_SETTINGS detour as more UX
+            // friction than necessary.
+            val requested =
+                try {
+                    val enableIntent =
+                        Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE).apply {
+                            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                        }
+                    pluginContext.startActivity(enableIntent)
+                    true
+                } catch (_: Throwable) {
+                    false
+                }
+            if (!requested) {
+                try {
+                    val fallback =
+                        Intent(android.provider.Settings.ACTION_BLUETOOTH_SETTINGS).apply {
+                            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                        }
+                    pluginContext.startActivity(fallback)
+                } catch (_: Throwable) {
+                }
             }
         }
 
@@ -1175,7 +1193,40 @@ class XvDropDownReceiver(
                     context: Context?,
                     intent: Intent?,
                 ) {
-                    if (intent?.action == BluetoothAdapter.ACTION_STATE_CHANGED) refresh()
+                    if (intent?.action != BluetoothAdapter.ACTION_STATE_CHANGED) return
+                    refresh()
+                    // Repopulate the AINA + secondary AINA pickers so
+                    // newly-visible (or newly-hidden) bonded devices
+                    // show up without the operator having to close
+                    // and reopen the Settings panel. wireAinaPicker /
+                    // wireSecondaryAinaPicker are idempotent — each
+                    // just resets adapter + selection + listener on
+                    // the same spinner view. Field-observed 2026-07-07:
+                    // after re-enabling Bluetooth from the banner tap,
+                    // the AINA picker was stuck on "Screen-only PTT"
+                    // even though the operator's bonded AINA was
+                    // back in system BT state — the picker had been
+                    // populated once at Settings-open time when the
+                    // adapter reported no devices.
+                    val state =
+                        intent.getIntExtra(
+                            BluetoothAdapter.EXTRA_STATE,
+                            BluetoothAdapter.ERROR,
+                        )
+                    if (state == BluetoothAdapter.STATE_ON ||
+                        state == BluetoothAdapter.STATE_OFF
+                    ) {
+                        try {
+                            wireAinaPicker(v)
+                        } catch (t: Throwable) {
+                            android.util.Log.w("XvSettings", "wireAinaPicker refresh after BT state change threw", t)
+                        }
+                        try {
+                            wireSecondaryAinaPicker(v)
+                        } catch (t: Throwable) {
+                            android.util.Log.w("XvSettings", "wireSecondaryAinaPicker refresh after BT state change threw", t)
+                        }
+                    }
                 }
             }
 

--- a/app/src/main/res/layout/xv_settings.xml
+++ b/app/src/main/res/layout/xv_settings.xml
@@ -34,7 +34,16 @@
             android:layout_marginStart="4dp"/>
     </LinearLayout>
 
-    <!-- Tab strip: TX/RX | Channels | Preferences -->
+    <!-- Tab strip: Devices | TX/RX | Server.
+         Devices sits leftmost + is the default because the AINA
+         speakermic / secondary PTT / audio-device pickers are the
+         controls operators touch every session; TX/RX (hot-mic,
+         timeouts, tone) is tuning; Server (TAK server picker, Mumble
+         connect/disconnect) is one-time enrollment. Tab IDs were
+         historically xv_tab_prefs / xv_tab_txrx / xv_tab_calls —
+         those IDs are preserved so the wireSettingsTabs findViewById
+         calls in XvDropDownReceiver don't break; only display order,
+         labels, and the default-selection index changed. -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -43,10 +52,22 @@
         android:paddingEnd="12dp">
 
         <Button
+            android:id="@+id/xv_tab_prefs"
+            android:layout_width="0dp"
+            android:layout_height="40dp"
+            android:layout_weight="1"
+            android:text="Devices"
+            android:textColor="@color/xv_text"
+            android:textSize="13sp"
+            android:textAllCaps="false"
+            android:background="@drawable/xv_button_bg"/>
+
+        <Button
             android:id="@+id/xv_tab_txrx"
             android:layout_width="0dp"
             android:layout_height="40dp"
             android:layout_weight="1"
+            android:layout_marginStart="6dp"
             android:text="TX/RX"
             android:textColor="@color/xv_text"
             android:textSize="13sp"
@@ -60,18 +81,6 @@
             android:layout_weight="1"
             android:layout_marginStart="6dp"
             android:text="Server"
-            android:textColor="@color/xv_text"
-            android:textSize="13sp"
-            android:textAllCaps="false"
-            android:background="@drawable/xv_button_bg"/>
-
-        <Button
-            android:id="@+id/xv_tab_prefs"
-            android:layout_width="0dp"
-            android:layout_height="40dp"
-            android:layout_weight="1"
-            android:layout_marginStart="6dp"
-            android:text="Preferences"
             android:textColor="@color/xv_text"
             android:textSize="13sp"
             android:textAllCaps="false"
@@ -95,7 +104,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:visibility="visible">
+                android:visibility="gone">
 
                 <!-- Latched-mode toggle hidden from Settings UI per user
                      direction (2026-05-10). Latched mode remains
@@ -207,6 +216,39 @@
                     android:text="180 s"
                     android:visibility="gone"/>
 
+                <!-- Talk permit tone lives on the TX/RX tab because
+                     it's a transmit behavior, not a device choice —
+                     the tone plays when the operator keys, regardless
+                     of which speakermic / route is active. Moved here
+                     from the Devices tab so the Devices tab is closer
+                     to what operators reach for every session. -->
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Talk permit tone"
+                    android:textColor="@color/xv_text_dim"
+                    android:textSize="11sp"
+                    android:textAllCaps="true"
+                    android:letterSpacing="0.1"
+                    android:layout_marginTop="20dp"/>
+
+                <Spinner
+                    android:id="@+id/xv_spinner_tpt"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:background="@drawable/xv_card_bg"
+                    android:popupBackground="@color/xv_surface_alt"/>
+
+                <Button
+                    android:id="@+id/xv_btn_test_tpt"
+                    android:layout_width="match_parent"
+                    android:layout_height="44dp"
+                    android:layout_marginTop="8dp"
+                    android:text="Test tone"
+                    android:textColor="@color/xv_text"
+                    android:background="@drawable/xv_button_bg"/>
+
                 <View
                     android:layout_width="match_parent"
                     android:layout_height="40dp"/>
@@ -310,7 +352,30 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:visibility="gone">
+                android:visibility="visible">
+
+                <!-- Persistent banner shown ONLY when the Bluetooth
+                     adapter is off. Tapping opens the system BT
+                     settings so the operator can turn it back on
+                     without leaving XV. Visibility is driven by an
+                     ACTION_STATE_CHANGED receiver registered while
+                     the dropdown view is attached — see
+                     XvDropDownReceiver.wireBtOffBanner. Default is
+                     gone so it doesn't flash at inflate; the receiver
+                     sets the correct state on the initial poll. -->
+                <TextView
+                    android:id="@+id/xv_prefs_bt_off_banner"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="12dp"
+                    android:layout_marginBottom="16dp"
+                    android:background="@drawable/xv_card_bg"
+                    android:text="Bluetooth is off — tap to enable"
+                    android:textColor="@color/xv_text"
+                    android:textSize="13sp"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:visibility="gone"/>
 
                 <!-- Section header: PTT input -->
                 <TextView
@@ -471,34 +536,6 @@
                     android:textColor="@color/xv_text_dim"
                     android:textSize="11sp"
                     android:layout_marginTop="4dp"/>
-
-                <!-- TPT -->
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="Talk permit tone"
-                    android:textColor="@color/xv_text_dim"
-                    android:textSize="11sp"
-                    android:textAllCaps="true"
-                    android:letterSpacing="0.1"
-                    android:layout_marginTop="20dp"/>
-
-                <Spinner
-                    android:id="@+id/xv_spinner_tpt"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="4dp"
-                    android:background="@drawable/xv_card_bg"
-                    android:popupBackground="@color/xv_surface_alt"/>
-
-                <Button
-                    android:id="@+id/xv_btn_test_tpt"
-                    android:layout_width="match_parent"
-                    android:layout_height="44dp"
-                    android:layout_marginTop="8dp"
-                    android:text="Test tone"
-                    android:textColor="@color/xv_text"
-                    android:background="@drawable/xv_button_bg"/>
 
                 <View
                     android:layout_width="match_parent"


### PR DESCRIPTION
> **DRAFT** — no on-device verification yet. Stacked on `feat/auto-connect-compat-bt`; GitHub will auto-retarget to `main` when that branch lands. User specifically asked to eyeball this on the phone before merge because it changes what the operator sees first.

## Summary

Two related settings-panel improvements, both driven by observations during the 2026-07-06 session:

1. **Tab reorder + default change** — `Devices` first (default), then `TX/RX`, then `Server`. Moves the per-session controls (AINA / secondary PTT / audio device / auto-connect BT) into the first thing an operator sees, and demotes TX/RX (tuning) + Server (one-time enrollment) behind it. Talk permit tone + test button moved from Devices to TX/RX because TPT is a transmit behavior, not a device choice.
2. **BT-off banner** at the top of the Devices tab, visible only when the Bluetooth adapter is disabled, tap to open the system BT settings. Fixes the "why is my AINA picker empty" surprise the operator hit during the session.

## What changed

`app/src/main/res/layout/xv_settings.xml`:
- Tab strip reordered: `xv_tab_prefs` (labelled "Devices") first, then `xv_tab_txrx` ("TX/RX"), then `xv_tab_calls` ("Server"). IDs are unchanged so existing `findViewById` calls keep working.
- `xv_section_prefs` default `visibility` flipped to `visible`; `xv_section_txrx` flipped to `gone`.
- New `xv_prefs_bt_off_banner` TextView at the top of `xv_section_prefs`, default `gone`.
- TPT block (`xv_spinner_tpt` + `xv_btn_test_tpt` + the "Talk permit tone" header) moved from the end of `xv_section_prefs` into `xv_section_txrx` after the timeout sliders.

`app/src/main/java/com/atakmap/android/xv/ui/XvDropDownReceiver.kt`:
- `wireSettingsTabs`: tabs/sections list reordered to `[Prefs, TxRx, Calls]` so `select(0)` matches the new default. Click listeners re-bound accordingly.
- New `wireBtOffBanner(v)` function: registers a `BroadcastReceiver` for `ACTION_STATE_CHANGED` on view attach, unregisters on detach. Banner visibility gated on `BluetoothAdapter.isEnabled`. Tap fires `Intent(Settings.ACTION_BLUETOOTH_SETTINGS)`. Initial poll runs BEFORE attach so the first frame is already correct.

## Not touched

- Any TPT wiring in `wireTxRxSection` / `wirePreferencesSection` — the TextView IDs stayed put on the TPT block itself, and the wiring code doesn't care which parent `LinearLayout` those views live under. So moving the block in XML is a pure layout change; no Kotlin wiring updates required for TPT to keep working.
- Nothing in the AINA / audio-device / auto-connect BT wiring changes.

## README

Skipped intentionally — the README doesn't currently document the settings tab structure or the tab-strip content, so there's no section to update. Happy to add a "Settings" subsection under "What's different" if you'd like the tab structure to be documented; flagging as a call-out rather than doing it unilaterally per CLAUDE.md's "flag proposed changes to the operator first" guidance for load-bearing README sections.

## Test plan

- [x] `./gradlew ktlintCheck` — clean.
- [x] `./gradlew assembleCivDebug` — clean.
- [x] `./gradlew testCivDebugUnitTest` — passes (no new tests; this is a pure UI-layout change).
- [ ] On-device: open Settings, confirm Devices tab is default and the tab strip reads `Devices | TX/RX | Server`. Confirm TPT + test tone are on TX/RX not Devices. Confirm every existing control (spinners, sliders, connect/disconnect, TAK server picker) still works from its new tab.
- [ ] On-device: with Bluetooth OFF, open Settings → confirm banner visible and reads "Bluetooth is off — tap to enable". Tap → confirm system Bluetooth settings opens. Enable BT → confirm banner disappears without needing to re-open the panel.
- [ ] On-device: open the panel with BT already off → confirm banner is present on the first frame (no visible flash).