### PR TITLE
fix(tpt): stop TPT tone truncation from AudioTrack buffer under-size

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/audio/TptPlayer.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/TptPlayer.kt
@@ -208,13 +208,34 @@ class TptPlayer(
                 .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
                 .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
                 .build()
+        // Buffer must fit BOTH the silence preRoll AND the tone PCM AND
+        // a matching postRoll of trailing silence. Under-sizing it
+        // silently drops the tail in MODE_STATIC — the second write past
+        // capacity is a no-op, playback stops early, and (worse) the
+        // notificationMarkerPosition set at end-of-buffer never fires
+        // because the head position never gets there.
+        //
+        // The postRoll matters even more than the preRoll: the
+        // AudioTrack head-position counter (which the marker fires on)
+        // advances as samples are consumed by the DAC internal buffer,
+        // NOT when they leave the physical speaker. On Pixel there is
+        // typically 10-30 ms of samples in the hardware output pipeline
+        // that hasn't reached the driver's audible-output stage yet.
+        // Firing the marker at "end of tone PCM" and calling t.stop()
+        // there flushes that pipeline — the operator perceives the tone
+        // getting truncated. Padding the buffer with SILENCE_POSTROLL_MS
+        // of silence means the marker fires on silent samples and the
+        // hardware flush eats silence, not tone. Field-observed
+        // 2026-07-07 on the built-in speaker.
+        val preRollSamples = sampleRateHz * SILENCE_PREROLL_MS / 1000
+        val postRollSamples = sampleRateHz * SILENCE_POSTROLL_MS / 1000
         val t =
             try {
                 AudioTrack
                     .Builder()
                     .setAudioAttributes(attrs)
                     .setAudioFormat(format)
-                    .setBufferSizeInBytes(pcm.size * 2)
+                    .setBufferSizeInBytes((preRollSamples + pcm.size + postRollSamples) * 2)
                     .setTransferMode(AudioTrack.MODE_STATIC)
                     .build()
             } catch (th: Throwable) {
@@ -246,10 +267,24 @@ class TptPlayer(
         // perceived TPT start (no operator can react that fast) but
         // long enough to cover the worst-case BT chipset settling
         // window measured on the AINA V1.
-        val preRoll = ShortArray(sampleRateHz * SILENCE_PREROLL_MS / 1000)
+        val preRoll = ShortArray(preRollSamples)
+        val postRoll = ShortArray(postRollSamples)
+        // Concatenate preRoll + pcm + postRoll into a single buffer so
+        // MODE_STATIC gets exactly one write() call. Some AudioTrack
+        // implementations refuse subsequent write() calls after the
+        // first for MODE_STATIC — the effective sample count then
+        // matched only preRoll+pcm, and the postRoll silence never
+        // reached the hardware, so marker firing on a truncated buffer
+        // still cut the tone tail.
+        val buffered = ShortArray(preRoll.size + pcm.size + postRoll.size)
+        System.arraycopy(preRoll, 0, buffered, 0, preRoll.size)
+        System.arraycopy(pcm, 0, buffered, preRoll.size, pcm.size)
+        System.arraycopy(postRoll, 0, buffered, preRoll.size + pcm.size, postRoll.size)
         try {
-            t.write(preRoll, 0, preRoll.size)
-            t.write(pcm, 0, pcm.size)
+            val written = t.write(buffered, 0, buffered.size)
+            if (written < buffered.size) {
+                Log.w(TAG, "$label short write: wrote $written / ${buffered.size} samples")
+            }
             t.play()
         } catch (th: Throwable) {
             Log.e(TAG, "$label write/play failed", th)
@@ -261,7 +296,12 @@ class TptPlayer(
             return
         }
         track = t
-        Log.i(TAG, "playing $label (${pcm.size} samples + ${preRoll.size} preRoll, useSco=$useScoRoute)")
+        Log.i(
+            TAG,
+            "playing $label (${pcm.size} tone + ${preRoll.size} preRoll + ${postRoll.size} postRoll " +
+                "= ${buffered.size} total samples, marker@${preRoll.size + pcm.size + postRoll.size}, " +
+                "useSco=$useScoRoute)",
+        )
         logAudioContext("playing $label")
         val finalize: () -> Unit = {
             try {
@@ -291,6 +331,7 @@ class TptPlayer(
             t.setPlaybackPositionUpdateListener(
                 object : AudioTrack.OnPlaybackPositionUpdateListener {
                     override fun onMarkerReached(track: AudioTrack?) {
+                        Log.i(TAG, "$label marker reached — finalizing (playback complete)")
                         mainHandler.post {
                             mainHandler.removeCallbacks(watchdog)
                             finalize()
@@ -300,7 +341,13 @@ class TptPlayer(
                     override fun onPeriodicNotification(track: AudioTrack?) {}
                 },
             )
-            t.notificationMarkerPosition = pcm.size
+            // Marker fires at end-of-buffer = preRoll + tone PCM +
+            // postRoll. Setting it here (rather than at end-of-tone-PCM)
+            // means finalize()'s t.stop() flushes the postRoll silence
+            // out of the hardware pipeline, not the tone tail. Paired
+            // with the buffer-size expansion above — the two invariants
+            // move together.
+            t.notificationMarkerPosition = preRoll.size + pcm.size + postRoll.size
         } catch (th: Throwable) {
             Log.w(TAG, "$label marker setup failed; relying on watchdog", th)
         }
@@ -856,5 +903,13 @@ class TptPlayer(
          * TPT start by anything an operator can detect.
          */
         private const val SILENCE_PREROLL_MS: Int = 50
+
+        // Trailing silence appended after the tone PCM so the
+        // notification marker fires on silent samples — that way the
+        // t.stop() call in finalize() flushes silence out of the
+        // hardware output pipeline rather than the tone's last few ms.
+        // Matched to the preRoll size so total added latency (before +
+        // after) is symmetric.
+        private const val SILENCE_POSTROLL_MS: Int = 50
     }
 }


### PR DESCRIPTION
## Summary

Three coupled defects in `TptPlayer.playPcmSession` were combining to truncate the talk permit tone on the Pixel 9 Pro built-in speaker (and, per user report, any speaker output — BT SCO wasn't tested this round). Fix ships one commit that addresses all three, plus a diagnostic log line so the wire behavior is observable in logcat next time.

## Symptoms

- Operator perceives every TPT tone as cut short. On rapid consecutive presses the truncation was more noticeable.
- Log at TX time showed `XvTpt: … marker watchdog fired — finishing via wall clock` on every playback — the notification marker never actually reached the finalize path; the fallback wall-clock did.

## Root cause chain

1. **Under-sized `AudioTrack` buffer.** `setBufferSizeInBytes(pcm.size * 2)` reserved space only for the tone PCM, ignoring the ~50 ms silence preRoll that was being written first. In `MODE_STATIC`, `write()` past capacity is a **silent no-op** — the tone's tail never reached the hardware. Worse, the notification marker set at end-of-buffer never fired because the head position never got there; the wall-clock watchdog (`durationMs * 2 + slack`) took its place.

2. **Marker at end-of-tone-PCM, not end-of-audio-pipeline.** Even with a correctly sized buffer, the `AudioTrack` head-position counter advances as samples are consumed by the DAC's internal buffer, NOT when they reach the physical speaker. On Pixel there is typically 10–30 ms of samples still in the hardware output pipeline. Firing the marker at end-of-tone and calling `t.stop()` immediately flushed those pending samples — the operator heard the tone's last few ms clipped even after the buffer-size fix.

3. **Multi-write for `MODE_STATIC`.** Some `AudioTrack` implementations accept only one `write()` call before `play()` in `MODE_STATIC`. Splitting `preRoll` / `pcm` / `postRoll` into three writes meant the `postRoll` (silence) was silently discarded on those devices, collapsing the fix from (2) back to the raw truncation.

## Fix

- Extend the `AudioTrack` buffer to `(preRoll + pcm + postRoll) * sizeof(int16)`. `postRoll` is a new `SILENCE_POSTROLL_MS` constant matched to `SILENCE_PREROLL_MS` (50 ms) so the total added latency (before + after the tone) is symmetric.
- Point `notificationMarkerPosition` at `preRoll + pcm + postRoll` (the true end of the buffer). Marker now fires on silence, so `t.stop()` in `finalize()` flushes silence out of the hardware pipeline — not the tone tail.
- Concatenate `preRoll + pcm + postRoll` into a single `ShortArray` and write it with **one** `t.write()` call. Also log a warning if the write returns fewer samples than requested, so future drift is visible.
- Update the `playing` log line to enumerate all three sample segments and the marker position so the wire behavior is observable in logcat.
- Add a `Log.i` in `onMarkerReached` so playback completion is attributable (previous behavior was silence-then-watchdog, which made it look like the marker had never been set at all).

## Test plan

- [x] `./gradlew ktlintCheck` — clean.
- [x] `./gradlew assembleCivDebug` — clean.
- [x] `./gradlew testCivDebugUnitTest` — passes.
- [x] On-device (Pixel 9 Pro, ATAK CIV 5.7 dev, phone speaker): playback→marker delta measures 241-259 ms across successive presses (matches the 250 ms buffer duration), no watchdog wall-clock fires, no perceptible truncation on either isolated or rapid consecutive PTTs. Operator confirmed "working correctly now."
- [ ] On-device (BT SCO route): not exercised in this session. Behavior should be strictly better (more buffer, marker at end-of-pipeline), but the `SCO_TAIL_GUARD_MS` path is untouched so no regression is expected. Flag for smoke on BT before merge.

## Related but not in scope

- Volume drift between successive tones (`STREAM_VOICE_CALL` moving between 10/15 and 12/15). Discussed but not addressed here; would live on a separate `fix/tpt-stream-volume-pin` branch that extends `ensureVoiceCallAudible()` to clamp toward a target index.