### PR TITLE
fix(ui): PTT button pressed state — flip isPressed manually

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/ui/XvDropDownReceiver.kt
+++ b/app/src/main/java/com/atakmap/android/xv/ui/XvDropDownReceiver.kt
@@ -454,11 +454,23 @@ class XvDropDownReceiver(
             when (ev.action) {
                 MotionEvent.ACTION_DOWN -> {
                     android.util.Log.i("XV_PTT", ">>> ON-SCREEN $label (slot=$slot) DOWN <<<")
+                    // Manually flip the pressed state so xv_button_bg's
+                    // state_pressed selector fires immediately. Returning
+                    // true below consumes the event and prevents Android
+                    // from setting isPressed via the View's own touch
+                    // dispatch, so without this the operator sees no red
+                    // feedback until refreshMain() eventually swaps the
+                    // background to xv_button_bg_transmitting — a lag of
+                    // up to ~700 ms while mic priming, TPT playback, and
+                    // Telecom-call transition all serialize. That looks
+                    // like a broken button. Field-observed 2026-07-07.
+                    btn.isPressed = true
                     controller.startTx(slot)
                     true
                 }
                 MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                     android.util.Log.i("XV_PTT", ">>> ON-SCREEN $label (slot=$slot) UP <<<")
+                    btn.isPressed = false
                     controller.stopTx()
                     btn.performClick()
                     true


### PR DESCRIPTION
## Summary

The on-screen PTT button was staying blue (idle color) for ~600 ms after touch-down before turning red, which looked to the operator like the button wasn't responding. Fix flips `View.isPressed` explicitly on `ACTION_DOWN` / `ACTION_UP` so the drawable's `state_pressed="true"` selector fires immediately.

## Symptom

Operator holds the on-screen PTT button. Nothing happens visually for what feels like a broken-button lag. Eventually (after ~600 ms) the button turns red as `refreshMain()` swaps the background to `xv_button_bg_transmitting`. Release → returns to blue.

## Root cause

`pttListener` in `XvDropDownReceiver` returns `true` from `ACTION_DOWN`:

```kotlin
MotionEvent.ACTION_DOWN -> {
    controller.startTx(slot)
    true  // ← consumes the event
}
```

Returning `true` consumes the event so it never reaches the `View`'s own touch dispatch — meaning Android never sets `isPressed` on the View. The drawable's `<item android:state_pressed="true">` selector in `xv_button_bg.xml` was pinned to that state, so the red pressed appearance never fired.

Actual red feedback only appeared once `refreshMain()` observed the transmitting state and swapped the entire background to `xv_button_bg_transmitting`. That happened well after the state machine finished PRIMING (~200 ms), TPT playback (~250 ms), and the Telecom-call transition (~150 ms) — ~600 ms of visual dead time from touch-down.

## Fix

Manually toggle `btn.isPressed` on `ACTION_DOWN` and `ACTION_UP` / `ACTION_CANCEL`. The selector picks up the state change immediately, so the button snaps to red the moment the finger lands. The subsequent `xv_button_bg_transmitting` swap from `refreshMain()` still runs, persisting red across the 8 s post-activity Telecom debounce window as before — no change to the transmitting-state visual, just a fix for the touch-feedback gap that preceded it.

## Test plan

- [x] `./gradlew ktlintCheck` — clean.
- [x] `./gradlew assembleCivDebug` — clean.
- [x] `./gradlew testCivDebugUnitTest` — passes.
- [x] On-device (Pixel 9 Pro, ATAK CIV 5.7 dev): button turns red on touch-down, stays red across the whole hold, reverts to blue on release. No lag perceived. Operator confirmed responsiveness noticeably better.