### PR TITLE
fix(ui): on-screen PTT button lights red when TX comes from external source

### DIFF
--- a/app/src/main/aidl/com/atakmap/android/xv/service/IXvVoiceListener.aidl
+++ b/app/src/main/aidl/com/atakmap/android/xv/service/IXvVoiceListener.aidl
@@ -13,7 +13,13 @@ interface IXvVoiceListener {
     void onTxTerminator(int slot);
 
     // PTT-state edges, for the Mumble UserState selfMute heartbeat.
-    void onPttStateChanged(boolean transmitting);
+    // [slot] identifies which channel is going hot — 0 = primary (VS1),
+    // 1 = secondary (VS2). On the transmitting=false edge slot echoes
+    // which slot just went idle. Needed on the plugin side so the
+    // on-screen "● TRANSMITTING" indicator lights the correct button
+    // when TX was initiated from a BT speakermic / BLE PTT button
+    // (which doesn't route through the plugin's Controller.startTx).
+    void onPttStateChanged(boolean transmitting, int slot);
 
     // AINA reader connection up/down — plugin updates the UI dot.
     void onAinaConnectionChanged(boolean connected);

--- a/app/src/main/java/com/atakmap/android/xv/audio/TxController.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/TxController.kt
@@ -51,7 +51,7 @@ class TxController(
     // UserState to the server. Open-source Mumble clients (Mumla et al)
     // do this on PTT-down / PTT-up so the server's UI / suppression
     // logic knows the client is keying.
-    private val onPttStateChanged: (Boolean) -> Unit = {},
+    private val onPttStateChanged: (Boolean, Int) -> Unit = { _, _ -> },
     private val tonePreference: () -> TptTone = { TptTone.DEFAULT },
     // Returns true only when XV is actually in a state where transmitted
     // audio would be heard by someone on the given slot. Two reasons
@@ -313,7 +313,7 @@ class TxController(
             // actually transmitted — listeners (Mumble UserState
             // burst-start) only react to ON, so a lone OFF is safe.
             try {
-                onPttStateChanged(false)
+                onPttStateChanged(false, slot)
             } catch (t: Throwable) {
                 Log.w(TAG, "onPttStateChanged(false) on deny path threw", t)
             }
@@ -810,7 +810,7 @@ class TxController(
         }
         Log.i(TAG, "TX: resetting voice sequence (mic already running from TPT prewarm)")
         try {
-            onPttStateChanged(true)
+            onPttStateChanged(true, activeSlot)
         } catch (t: Throwable) {
             Log.w(TAG, "onPttStateChanged(true) threw", t)
         }
@@ -1097,7 +1097,7 @@ class TxController(
                 Log.w(TAG, "sendTerminator threw", t)
             }
             try {
-                onPttStateChanged(false)
+                onPttStateChanged(false, burstSlot)
             } catch (t: Throwable) {
                 Log.w(TAG, "onPttStateChanged(false) threw", t)
             }

--- a/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
+++ b/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
@@ -575,14 +575,24 @@ class XvMapComponent : AbstractMapComponent() {
                     }
                 }
 
-                override fun onPttStateChanged(transmitting: Boolean) {
+                override fun onPttStateChanged(
+                    transmitting: Boolean,
+                    slot: Int,
+                ) {
                     if (transmitting) {
                         beginMumbleVoiceBurst()
                         // Lock in the UI's "transmitting" state on whichever
-                        // slot the operator just pressed. AIDL doesn't pass
-                        // the slot (single-bool API), so we use the slot
-                        // tracked at startTx-time — see lastRequestedTxSlot.
-                        txActiveSlot = lastRequestedTxSlot
+                        // slot the service reports going hot. The service
+                        // passes the slot directly through the AIDL callback
+                        // so BT-speakermic / BLE-button PTTs (which never
+                        // route through the plugin's Controller.startTx and
+                        // therefore never populate lastRequestedTxSlot) still
+                        // light the correct on-screen indicator. Field-
+                        // observed 2026-07-07 on the umbrella branch: BT
+                        // speakermic TX left the "HOLD TO TX" label
+                        // showing instead of "● TRANSMITTING" because
+                        // lastRequestedTxSlot was stale at -1.
+                        txActiveSlot = slot
                     } else {
                         txActiveSlot = -1
                     }

--- a/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
+++ b/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
@@ -592,7 +592,20 @@ class XvMapComponent : AbstractMapComponent() {
                         // speakermic TX left the "HOLD TO TX" label
                         // showing instead of "● TRANSMITTING" because
                         // lastRequestedTxSlot was stale at -1.
-                        txActiveSlot = slot
+                        //
+                        // Slot 1 (secondary) without a live VS2 session
+                        // is a legitimate operator setup — the transport
+                        // already handles it in pickSlotForSend by
+                        // routing the audio to the primary. Mirror that
+                        // fallback here so the on-screen VS1 button
+                        // lights instead of leaving no indicator at all
+                        // (the VS2 button is hidden / disabled when
+                        // secondaryConnected() is false). Keeps the UI
+                        // in sync with the wire behavior.
+                        val secondaryLive =
+                            mumbleTransport()?.secondaryConnected() == true
+                        txActiveSlot =
+                            if (slot == 1 && !secondaryLive) 0 else slot
                     } else {
                         txActiveSlot = -1
                     }

--- a/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
@@ -59,7 +59,10 @@ class VoicePlant(
 
         fun onTxTerminator(slot: Int)
 
-        fun onPttStateChanged(transmitting: Boolean)
+        fun onPttStateChanged(
+            transmitting: Boolean,
+            slot: Int,
+        )
 
         fun onAinaConnectionChanged(connected: Boolean)
 
@@ -205,8 +208,8 @@ class VoicePlant(
             audioController = audioController,
             sendOpus = { opus, slot -> callbacks.onTxOpus(slot, opus) },
             sendTerminator = { slot -> callbacks.onTxTerminator(slot) },
-            onPttStateChanged = { transmitting ->
-                callbacks.onPttStateChanged(transmitting)
+            onPttStateChanged = { transmitting, slot ->
+                callbacks.onPttStateChanged(transmitting, slot)
                 // TX-state edge → end Telecom call when transmitting
                 // turns false. Covers latched mode (where pttUp is a
                 // no-op but stopInternal still fires this callback on

--- a/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
@@ -809,8 +809,11 @@ class XvVoiceService : Service() {
                 fanOut { it.onTxTerminator(slot) }
             }
 
-            override fun onPttStateChanged(transmitting: Boolean) {
-                fanOut { it.onPttStateChanged(transmitting) }
+            override fun onPttStateChanged(
+                transmitting: Boolean,
+                slot: Int,
+            ) {
+                fanOut { it.onPttStateChanged(transmitting, slot) }
                 // Audio activity → keep the call-idle watchdog at bay.
                 // Fires for both TX-on and TX-off; both are legitimate
                 // signs the call is in active use.


### PR DESCRIPTION
## Summary

The main-view PTT button (\`● TRANSMITTING\` red state) only lit up when TX was initiated from the on-screen button — transmits keyed from a BT speakermic or a BLE PTT button left the button showing "HOLD TO TX" / blue for the entire burst. Fix carries the active slot through the callback chain so the plugin gets the truth from the service instead of shadowing a stale copy.

## Root cause

- Plugin's UI reads \`controller.isTransmittingOnSlot(slot)\`, which reads \`txActiveSlot\`.
- \`txActiveSlot\` was assigned on the \`onPttStateChanged(true)\` edge from \`lastRequestedTxSlot\`.
- \`lastRequestedTxSlot\` was populated only inside the plugin's \`Controller.startTx(slot)\` — which only fires when TX is initiated from the on-screen button.
- BT-speakermic and BLE-button PTTs run entirely service-side (\`VoicePlant\`'s \`PttDispatcher\` → \`TxController.start(slot)\`) and never touch the plugin's \`Controller\`. \`lastRequestedTxSlot\` stayed \`-1\` for those bursts, so \`txActiveSlot\` also landed at \`-1\`, \`isTransmittingOnSlot(0)\` returned false, and the button stayed blue.

## Fix

Pass the slot end-to-end through the callback chain:

- **AIDL**: \`IXvVoiceListener.onPttStateChanged(boolean, int)\` — new \`slot\` param. On the true edge, the slot is the one going hot; on the false edge, the slot just going idle.
- **TxController**: callback signature is now \`(Boolean, Int) -> Unit\`. Three call sites updated to pass the correct slot from what's already in scope: deny path uses \`start()\`'s \`slot\` arg, TX-transmitting-started uses \`activeSlot\`, \`stop()\` uses \`burstSlot\`.
- **VoicePlant.Callbacks**: thin passthrough with the new signature.
- **XvVoiceService**: \`plantCallbacks.onPttStateChanged\` fans out with slot to registered listeners.
- **XvMapComponent**: drops the \`lastRequestedTxSlot\` dependency and just assigns \`txActiveSlot = slot\` on the true edge from what the service reports. \`lastRequestedTxSlot\` stays in place for the other heuristics (cool-down / debounce), but the UI-state derivation no longer depends on it.

No test doubles depend on the old callback signature (searched \`app/src/test\` — no matches).

## Field observation

2026-07-07 on the integration branch: after test #3 (BT-off banner) was verified, operator noticed the on-screen PTT button didn't go red / didn't label "● TRANSMITTING" during transmits keyed from the BT speakermic — only for transmits keyed from the on-screen button. The service-side wiring was correct (the actual Mumble burst went through fine), but the UI feedback was missing.

## Test plan

- [x] \`./gradlew ktlintCheck\` — clean.
- [x] \`./gradlew assembleCivDebug\` — clean; AIDL regenerated.
- [x] \`./gradlew testCivDebugUnitTest\` — passes.
- [ ] On-device (Pixel 9 Pro, ATAK CIV 5.7 dev): press BT-speakermic PTT, confirm the on-screen VS1 button flips to red / "● TRANSMITTING" for the whole burst; release, confirm it returns to blue / "HOLD TO TX". Repeat with the on-screen PTT to confirm regression-free.

## Note on branch stacking

This fix is small (~40 LoC across 5 files) and self-contained; it targets \`main\` directly. It should apply cleanly on top of the umbrella work when \`feat/auto-connect-compat-bt\` eventually goes through its own PR — the multi-slot semantics get more valuable at that point, but the bug + fix stand on their own for single-slot operation too.