### PR TITLE
chore(deps): Kotlin 2.4 group + Gradle 9 (if compatible)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.google.protobuf.gradle.id
 import java.util.Properties
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("com.android.application")
@@ -194,9 +195,6 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "17"
-    }
     testOptions {
         unitTests.isIncludeAndroidResources = true
         unitTests.isReturnDefaultValues = true
@@ -221,6 +219,16 @@ android {
     }
 }
 
+// Kotlin 2.4 removed the `kotlinOptions { jvmTarget = "17" }` DSL that lived
+// inside `android {}`. Configure the JVM target via the top-level `kotlin`
+// extension's `compilerOptions`, which is the supported path from KGP 2.0
+// onward and is stable through 2.4.
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
 dependencies {
     if (!devKitMode) {
         compileOnly(files("libs/main.jar"))
@@ -233,11 +241,14 @@ dependencies {
         testCompileOnly(files("libs/main.jar"))
     }
 
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:2.2.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:2.4.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.11.0")
 
+    // core-ktx is intentionally held at 1.13.1: the Dependabot bump to 1.19.0
+    // demands compileSdk 37 + AGP 9.1.0, which is well outside the scope of a
+    // chore(deps) group. Revisit alongside a coordinated AGP/compileSdk bump.
     implementation("androidx.core:core-ktx:1.13.1")
-    implementation("androidx.appcompat:appcompat:1.7.0")
+    implementation("androidx.appcompat:appcompat:1.7.1")
 
     // Pure-Java Opus codec. Slow vs native opus but no NDK setup; fine
     // for Phase 1 RX validation. Replace with native build later.
@@ -256,10 +267,10 @@ dependencies {
     implementation("com.google.protobuf:protobuf-javalite:4.35.1")
 
     testImplementation("junit:junit:4.13.2")
-    testImplementation("io.mockk:mockk:1.13.11")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
-    testImplementation("androidx.test:core:1.6.1")
-    testImplementation("org.robolectric:robolectric:4.13")
+    testImplementation("io.mockk:mockk:1.14.11")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
+    testImplementation("androidx.test:core:1.7.0")
+    testImplementation("org.robolectric:robolectric:4.16.1")
 }
 
 ktlint {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,9 +53,9 @@ buildscript {
 
 plugins {
     id("com.android.application") version "8.7.3" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.4.0" apply false
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0" apply false
-    id("com.google.protobuf") version "0.9.4" apply false
+    id("com.google.protobuf") version "0.10.0" apply false
 }
 
 // =====================================================================


### PR DESCRIPTION
## Summary

Consolidates the two remaining Dependabot bumps into one branch and lands
whatever survives the verification matrix.

Landed (from Dependabot PR #11, `gradle-minor-and-patch` group):

- Kotlin android plugin + stdlib   2.2.0 -> 2.4.0
- kotlinx-coroutines-android/-test 1.8.1 -> 1.11.0
- androidx.appcompat:appcompat     1.7.0 -> 1.7.1
- io.mockk:mockk                   1.13.11 -> 1.14.11
- androidx.test:core               1.6.1 -> 1.7.0
- org.robolectric:robolectric      4.13 -> 4.16.1
- com.google.protobuf gradle plugin 0.9.4 -> 0.10.0
- Migrated `android { kotlinOptions { jvmTarget = "17" } }` to the
  top-level `kotlin.compilerOptions.jvmTarget = JvmTarget.JVM_17`
  extension, which is the KGP 2.0+ path stable through 2.4.

Held / skipped:

- **androidx.core:core-ktx 1.13.1 (Dependabot proposes 1.19.0).** 1.19.0
  demands compileSdk 37 and AGP 9.1.0; XV builds against compileSdk 34
  on AGP 8.7.3. That's an AGP + compileSdk upgrade, not a chore(deps).
  Comment left in `app/build.gradle.kts` next to the pinned line.
- **Gradle wrapper 8.14.3 -> 9.6.1 (Dependabot PR #12).** Attempted in
  this branch and rolled back. `atak-gradle-takdev.jar` — tested against
  both the 5.6.0.17 and 5.7.0.3 SDK jars — fails at
  `processCivDebugMainManifest` with `groovy/util/XmlParser`. Gradle 9
  removed the built-in Groovy stdlib from the plugin classpath and the
  takdev jar has an unpatched dependency on it. Neither SDK ships a
  fixed takdev jar today, so the wrapper bump has to wait on an SDK-side
  fix. No shim (e.g. injecting a Groovy jar) was introduced.

## Verification matrix

Two rows: Phase 1 alone (this branch's actual state) and Phase 1 +
Gradle 9 (attempted, rolled back).

| scenario                | 5.6 debug | 5.6 release | 5.7 debug | 5.7 release | unit tests | ktlint |
| ----------------------- | --------- | ----------- | --------- | ----------- | ---------- | ------ |
| Phase 1 only (shipped)  | PASS      | PASS        | PASS      | PASS        | PASS       | PASS   |
| Phase 1 + Gradle 9      | FAIL      | NOT RUN     | FAIL      | NOT RUN     | NOT RUN    | NOT RUN |

Phase 1 + Gradle 9 FAILs: both fail identically at
`processCivDebugMainManifest -> groovy/util/XmlParser` with either SDK's
takdev jar; subsequent tasks not attempted.

Baseline swaps between 5.6 and 5.7 used `./gradlew --stop`, replacement
of `app/libs/main.jar`, and the `-PatakBaselineVersion=5.7.0` +
`-Ptakdev.plugin=<5.7 SDK jar>` overrides.

## Notes for review

- R8 emits `An error occurred when parsing kotlin metadata` warnings
  during `assembleCivRelease`. Cause: AGP 8.7.3's bundled R8 predates
  the Kotlin 2.4 metadata format. Minification still completes and the
  APK assembles; downstream loading unaffected. AGP already flags a
  need for 9.1.0 for the newest core-ktx, so this and the Gradle 9 gap
  and the R8 warnings will all resolve together in a future coordinated
  AGP / compileSdk / core-ktx bump.
- No `versionCode` / `versionName` changes.
- No `.github/workflows/codeql.yml` reintroduction; only `ci.yml` and
  `semgrep.yml` remain.
- No changes to `local.properties`, `keystore.properties`, or
  `app/libs/`.

## Test plan

- [ ] `./gradlew ktlintCheck` clean on 5.6 baseline
- [ ] `./gradlew assembleCivDebug` clean on 5.6 baseline
- [ ] `./gradlew assembleCivRelease` clean on 5.6 baseline
- [ ] `./gradlew testCivDebugUnitTest` clean on 5.6 baseline
- [ ] `./gradlew assembleCivDebug -PatakBaselineVersion=5.7.0 -Ptakdev.plugin=...5.7 SDK jar` clean
- [ ] `./gradlew assembleCivRelease -PatakBaselineVersion=5.7.0 -Ptakdev.plugin=...5.7 SDK jar` clean

Recommendation: merge Phase 1 alone. Close Dependabot PR #11 in favor of
this. Leave Dependabot PR #12 (Gradle wrapper 9.x) open but do not merge
until an SDK-side takdev jar ships that works on Gradle 9.