### PR TITLE
feat(bt): startup device UX — available-first + grayed-unavailable + speaker fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ and feature polish.
    V1 and similar Pryme speakermics) and BLE GATT devices (AINA APTT V2,
    Pryme BT-PTT-Z).
 
+4. **Reachability-aware BT device picker.** On plugin load, XV restores
+   the last-connected speakermic when it's actually reachable and
+   otherwise auto-picks the first live device — a bonded-but-off puck
+   no longer wins over a powered speakermic. The Settings picker paints
+   unreachable rows dim and non-tappable so operators can see at a
+   glance which pairing is live. If a picked BT device stays
+   unreachable for 15 s during a session, XV falls back to the phone
+   speaker while preserving the operator's preferred MAC so audio
+   returns to BT as soon as the device reconnects.
+
 XV also adds:
 
 - **Per-device defaults with overrides** — each supported speakermic

--- a/app/src/main/java/com/atakmap/android/xv/aina/AinaDeviceClassifier.kt
+++ b/app/src/main/java/com/atakmap/android/xv/aina/AinaDeviceClassifier.kt
@@ -121,6 +121,24 @@ object AinaDeviceClassifier {
             AinaDeviceInfo.ButtonProtocol.UNKNOWN -> 4
         }
 
+    // Composite picker sort used by the settings dropdown. Pulled out
+    // as a pure function so unit tests can pin the ordering without
+    // needing a live BluetoothAdapter — the field UX contract is:
+    //   1. Currently-reachable devices first (visually normal, tappable).
+    //   2. Then by protocol per [protocolOrder].
+    //   3. Then by lowercase name for a stable order across refreshes.
+    // Inspired by how modern call-picker UIs (Meet, WhatsApp Calls, the
+    // AOSP device-chooser dialog) rank reachable devices ahead of the
+    // stale-but-remembered set.
+    fun rankForPicker(devices: List<AinaDeviceInfo>): List<AinaDeviceInfo> =
+        devices.sortedWith(
+            compareBy(
+                { if (it.available) 0 else 1 },
+                { protocolOrder(it.buttonProtocol) },
+                { it.name.lowercase() },
+            ),
+        )
+
     private fun safeName(device: BluetoothDevice): String? =
         try {
             device.name

--- a/app/src/main/java/com/atakmap/android/xv/aina/AinaDeviceInfo.kt
+++ b/app/src/main/java/com/atakmap/android/xv/aina/AinaDeviceInfo.kt
@@ -13,6 +13,19 @@ data class AinaDeviceInfo(
     val mac: String,
     val name: String,
     val buttonProtocol: ButtonProtocol,
+    // Live-reachability hint used by the settings picker. `true` when
+    // the device is currently reachable as a communication-audio
+    // endpoint (i.e. present in AudioManager.getAvailableCommunicationDevices
+    // on API 31+) OR when we can't yet tell (pre-S, missing permission,
+    // BLE-only PTT with no audio profile). `false` when the device is
+    // bonded / known but not currently reachable — the picker paints
+    // these rows dim + disabled so the operator sees at a glance which
+    // devices are live vs. stale.
+    //
+    // Defaults to true so unit tests and older callers that construct
+    // AinaDeviceInfo directly don't need to be updated — the picker
+    // renders "available" the same way it always did.
+    val available: Boolean = true,
 ) {
     enum class ButtonProtocol(
         val display: String,

--- a/app/src/main/java/com/atakmap/android/xv/audio/AudioRouter.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/AudioRouter.kt
@@ -64,11 +64,13 @@ class AudioRouter(
         object : AudioDeviceCallback() {
             override fun onAudioDevicesAdded(addedDevices: Array<out AudioDeviceInfo>) {
                 logDevices("added", addedDevices)
+                reevaluateBtHintAvailability()
                 notifyChange()
             }
 
             override fun onAudioDevicesRemoved(removedDevices: Array<out AudioDeviceInfo>) {
                 logDevices("removed", removedDevices)
+                reevaluateBtHintAvailability()
                 notifyChange()
             }
         }
@@ -90,6 +92,11 @@ class AudioRouter(
     fun stop() {
         audioManager.unregisterAudioDeviceCallback(deviceCallback)
         unregisterBecomingNoisyReceiver()
+        // Cancel any armed speaker-fallback runnable so it doesn't
+        // fire after we've torn down (listeners.clear below would
+        // make the fan-out a no-op, but the log noise and the flag
+        // state would still linger for the next start()).
+        clearSpeakerFallback("router stopped")
         listeners.clear()
     }
 
@@ -201,9 +208,147 @@ class AudioRouter(
             field = value
             if (old != value) {
                 Log.i(TAG, "preferredBtMacHint: $old -> $value")
+                // Hint changed — reset the speaker-fallback timer.
+                // Setting the hint to a new device gives the device a
+                // fresh grace window to appear before we fall back;
+                // clearing the hint (voluntary disconnect) always
+                // exits fallback mode.
+                clearSpeakerFallback("hint changed to $value")
+                reevaluateBtHintAvailability()
                 notifyChangeFromOperator()
             }
         }
+
+    // ============================================================
+    // Fallback-to-speaker lifecycle (feat/bt-device-startup-ux)
+    // ============================================================
+    //
+    // Field 2026-07-08: operators reported that when a picked BT
+    // speakermic disconnects mid-session (battery, out of range, puck
+    // gets bumped off) the plugin sits mute — nothing routes audio to
+    // the phone speaker as a graceful fallback. The user's preferred
+    // MAC is preserved (correct — they still want that puck when it
+    // comes back), but silence is not a useful state during a live
+    // session.
+    //
+    // This block adds a grace-period timer: while a BT hint is set
+    // AND that MAC is NOT present in the audio-device output list,
+    // start a countdown. If the countdown elapses without the device
+    // reappearing, flip [speakerFallbackActive] and re-notify listeners
+    // — [preferredDevice] then routes to the internal speaker while
+    // keeping the hint (and the operator's persisted AINA MAC) intact.
+    // When the device reconnects, we clear the fallback and audio
+    // routes back to BT on the next fan-out.
+    //
+    // Constant is public so tests / operator docs can reference the
+    // grace window we chose.
+    @Volatile
+    private var speakerFallbackActive: Boolean = false
+
+    @Volatile
+    private var pendingSpeakerFallback: Runnable? = null
+
+    /**
+     * True while the AudioRouter has fallen back to the built-in
+     * speaker because the operator's preferred BT device stayed
+     * unavailable for [BT_UNAVAILABLE_SPEAKER_FALLBACK_MS]. Cleared
+     * automatically when the device reconnects.
+     */
+    fun isSpeakerFallbackActive(): Boolean = speakerFallbackActive
+
+    /**
+     * Arms or disarms the speaker-fallback timer based on whether the
+     * currently-set BT hint is present in the AudioManager output list.
+     * Called from the AudioDeviceCallback edges and from the setter
+     * for [preferredBtMacHint]. Cheap — one enumeration of outputs.
+     */
+    private fun reevaluateBtHintAvailability() {
+        val hint = preferredBtMacHint ?: run {
+            // No BT hint set — no notion of "our preferred device is
+            // missing." Cancel any pending fallback + reset the
+            // active flag so we don't linger in fallback mode
+            // indefinitely after the operator picks "(none)".
+            clearSpeakerFallback("hint is null")
+            return
+        }
+        val outputs =
+            try {
+                audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+            } catch (t: Throwable) {
+                Log.w(TAG, "reevaluateBtHintAvailability: getDevices threw", t)
+                return
+            }
+        val present = outputs.any { it.isBluetooth() && it.address == hint }
+        if (present) {
+            // The device just came back (or was already there and this
+            // is a spurious re-eval). Cancel any armed fallback timer
+            // and, if we were in fallback mode, clear it — [notifyChange]
+            // called by the AudioDeviceCallback will fan out and let
+            // AudioPlayback rebuild against the BT device.
+            clearSpeakerFallback("hint $hint is reachable")
+        } else if (pendingSpeakerFallback == null && !speakerFallbackActive) {
+            // Device is absent and we haven't already committed to
+            // fallback. Arm the timer.
+            armSpeakerFallback(hint)
+        }
+    }
+
+    private fun armSpeakerFallback(hint: String) {
+        Log.i(
+            TAG,
+            "arming speaker-fallback timer — hint=$hint absent, will fire in " +
+                "${BT_UNAVAILABLE_SPEAKER_FALLBACK_MS / 1000}s if not restored",
+        )
+        val runnable =
+            Runnable {
+                pendingSpeakerFallback = null
+                if (speakerFallbackActive) return@Runnable
+                val currentHint = preferredBtMacHint
+                if (currentHint == null) {
+                    Log.i(TAG, "speaker-fallback fired but hint cleared — skipping")
+                    return@Runnable
+                }
+                val stillMissing =
+                    try {
+                        audioManager
+                            .getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+                            .none { it.isBluetooth() && it.address == currentHint }
+                    } catch (t: Throwable) {
+                        Log.w(TAG, "speaker-fallback re-check threw", t)
+                        false
+                    }
+                if (!stillMissing) {
+                    Log.i(TAG, "speaker-fallback fired but hint $currentHint reappeared — skipping")
+                    return@Runnable
+                }
+                Log.w(
+                    TAG,
+                    "speaker-fallback firing — hint=$currentHint has been unreachable " +
+                        "for ${BT_UNAVAILABLE_SPEAKER_FALLBACK_MS / 1000}s; falling back to " +
+                        "phone speaker (operator MAC preserved for re-connect)",
+                )
+                speakerFallbackActive = true
+                // Fan out so AudioPlayback / VoicePlant re-pick the
+                // route immediately — [preferredDevice] now returns
+                // the internal speaker regardless of the hint.
+                notifyChangeFromOperator()
+            }
+        pendingSpeakerFallback = runnable
+        mainHandler.postDelayed(runnable, BT_UNAVAILABLE_SPEAKER_FALLBACK_MS)
+    }
+
+    private fun clearSpeakerFallback(reason: String) {
+        val hadPending = pendingSpeakerFallback != null
+        pendingSpeakerFallback?.let { mainHandler.removeCallbacks(it) }
+        pendingSpeakerFallback = null
+        if (speakerFallbackActive) {
+            Log.i(TAG, "clearing speaker-fallback — reason=$reason")
+            speakerFallbackActive = false
+            notifyChangeFromOperator()
+        } else if (hadPending) {
+            Log.i(TAG, "cancelling pending speaker-fallback — reason=$reason")
+        }
+    }
 
     // Optional override: a BT MAC address. When set AND that device is
     // currently connected, [preferredDevice] returns it instead of
@@ -257,6 +402,21 @@ class AudioRouter(
     // phone) — Android will pick.
     fun preferredDevice(): AudioDeviceInfo? {
         val outputs = audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+
+        // -1) Speaker fallback (feat/bt-device-startup-ux). When the
+        //     operator's preferred BT device has been unreachable for
+        //     [BT_UNAVAILABLE_SPEAKER_FALLBACK_MS] we deliberately
+        //     skip the BT / wired chain and route to the phone
+        //     speaker. Cleared automatically when the device
+        //     reconnects (see [reevaluateBtHintAvailability]).
+        if (speakerFallbackActive) {
+            val speaker = outputs.firstOrNull { it.type == AudioDeviceInfo.TYPE_BUILTIN_SPEAKER }
+            if (speaker != null) {
+                Log.i(TAG, "preferred: ${describe(speaker)} (speaker fallback active)")
+                return speaker
+            }
+            Log.w(TAG, "speaker fallback active but no BUILTIN_SPEAKER output present — dropping through")
+        }
 
         // 0) Explicit BT override — operator picked a specific BT
         //    audio device (e.g. car BT, headphones) that should win
@@ -442,6 +602,27 @@ class AudioRouter(
 
     companion object {
         private const val TAG = "XvAudioRouter"
+
+        /**
+         * How long the operator's preferred BT device (the AINA /
+         * speakermic that matches [preferredBtMacHint]) is allowed to
+         * stay unreachable in the audio-device output list before
+         * [preferredDevice] falls back to the built-in phone speaker.
+         *
+         * 15s is a balance of two field constraints:
+         *   - Short enough that a live session doesn't sit mute after
+         *     an accidental disconnect (battery, out of range, puck
+         *     bumped off).
+         *   - Long enough to ride out a routine ~5s BT profile-reset
+         *     (SCO teardown / re-establish that happens on some
+         *     handsets around A2DP mode changes) without a spurious
+         *     speaker chirp mid-transmission.
+         *
+         * The operator's persisted MAC is NOT cleared while fallback
+         * is active — as soon as the device reappears in the output
+         * list we exit fallback and route back to BT.
+         */
+        const val BT_UNAVAILABLE_SPEAKER_FALLBACK_MS: Long = 15_000L
 
         /**
          * Pure type + address carrier for the audio-device selector

--- a/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
+++ b/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
@@ -2272,31 +2272,90 @@ class XvMapComponent : AbstractMapComponent() {
         // since classify() is keyed off it for the HFP_ONLY decision.
         android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
             val ctx = heldPluginContext ?: return@postDelayed
+            // Startup-picker inputs. We compute the picker list up
+            // front so both branches (restore-saved and auto-pick-
+            // first-available) can consult live reachability rather
+            // than blindly reconnecting to a MAC that's bonded but
+            // powered off. This is the fix for the 2026-07-08 field
+            // report: "on startup XV was connecting to a device that
+            // wasn't even available."
+            val candidates = listBondedAinaDevices()
             val savedMac = settings.persistedAinaMac()
             if (savedMac != null) {
-                // Explicit operator pick wins — always restore it.
-                connectSavedAinaPrimary(ctx, savedMac)
-                return@postDelayed
-            }
-            if (!settings.persistedAutoConnectBtEnabled()) {
+                // Explicit operator pick wins IF that device is
+                // currently reachable. Falling through to auto-pick
+                // when the saved MAC is bonded-but-off lets the
+                // operator's session actually route to whatever puck
+                // they turned on, instead of stalling on a stale
+                // preference. The saved MAC is deliberately NOT
+                // cleared — when the operator's preferred device
+                // powers back on, the picker refresh + next launch
+                // will restore it as first-class.
+                val saved = candidates.firstOrNull { it.mac.equals(savedMac, ignoreCase = true) }
+                if (saved != null && saved.available) {
+                    Log.i(
+                        TAG,
+                        "autoConnectAina: saved selection $savedMac is reachable — restoring",
+                    )
+                    connectSavedAinaPrimary(ctx, savedMac)
+                    return@postDelayed
+                }
+                if (saved != null && !saved.available) {
+                    Log.i(
+                        TAG,
+                        "autoConnectAina: saved selection $savedMac bonded but not currently reachable — " +
+                            "considering first-available fallback (saved pref preserved)",
+                    )
+                } else {
+                    Log.i(
+                        TAG,
+                        "autoConnectAina: saved MAC $savedMac not in picker list — " +
+                            "considering first-available fallback",
+                    )
+                }
+                // Fall through to auto-pick below, but only if the
+                // operator hasn't disabled auto-connect. That toggle
+                // is the "I'll pick manually" opt-out for operators
+                // running multiple speakermics for testing — respect
+                // it even when the saved device is off.
+                if (!settings.persistedAutoConnectBtEnabled()) {
+                    Log.i(
+                        TAG,
+                        "autoConnectAina: auto-connect disabled — leaving saved pref in place, no connect",
+                    )
+                    return@postDelayed
+                }
+            } else if (!settings.persistedAutoConnectBtEnabled()) {
                 Log.i(TAG, "autoConnectAina: no saved selection and auto-connect disabled — skipping")
                 return@postDelayed
             }
-            // Auto-pick: scan bonded devices for the first compatible
-            // speakermic / BLE PTT button. listBondedAinaDevices already
-            // filters by AinaDeviceClassifier.isPlausibleSpeakermic AND
-            // sorts SPP → BLE → BLE_HID so a speakermic always beats a
-            // button-only puck for the primary slot. Picking the first
-            // entry is a "smart default" — operator can override by
-            // picking a different device in Settings → Preferences,
-            // and that pick then persists.
-            val candidates = listBondedAinaDevices()
+            // Auto-pick: prefer the first AVAILABLE compatible device
+            // in the picker list. listBondedAinaDevices already sorts
+            // available-first, then by protocol (SPP → BLE → BLE_HID)
+            // so a live speakermic always beats a stale one AND a
+            // speakermic always beats a button-only puck for the
+            // primary slot. If no device is marked available we
+            // deliberately do NOT connect — auto-connecting to a
+            // device that isn't live just to satisfy an old MAC hint
+            // is the exact bug we're fixing.
             if (candidates.isEmpty()) {
                 Log.i(TAG, "autoConnectAina: no compatible bonded device found — nothing to auto-pick")
                 return@postDelayed
             }
-            val picked = candidates.first()
-            Log.i(TAG, "autoConnectAina: auto-picked compatible device → ${picked.name} ${picked.mac} (${picked.buttonProtocol})")
+            val picked = candidates.firstOrNull { it.available }
+            if (picked == null) {
+                Log.i(
+                    TAG,
+                    "autoConnectAina: ${candidates.size} bonded candidate(s) found but none currently reachable — " +
+                        "waiting for one to come up",
+                )
+                return@postDelayed
+            }
+            Log.i(
+                TAG,
+                "autoConnectAina: auto-picked first-available device → ${picked.name} ${picked.mac} " +
+                    "(${picked.buttonProtocol})",
+            )
             // Persist so it sticks across launches AND so the picker UI
             // shows the auto-picked device as the current selection.
             // Operator can change the pick later; "(none)" in the
@@ -2338,6 +2397,43 @@ class XvMapComponent : AbstractMapComponent() {
     // Settings → Preferences: AINA picker + TX/RX persistence
     // ============================================================
 
+    // Snapshot of MACs currently reachable as communication-audio
+    // endpoints. Intersecting the bonded-device set against this on the
+    // picker gives operators an at-a-glance "which of my paired devices
+    // is actually live right now?" — the field bug we're fixing had the
+    // picker showing four bonded speakermics with no visual difference
+    // between the one that was powered on and the three that had been
+    // off for weeks.
+    //
+    // Uses [AudioManager.getAvailableCommunicationDevices] on API 31+
+    // because bond state alone isn't enough — a bonded HFP device may
+    // still not be routable to setCommunicationDevice until its profile
+    // is connected in the audio policy. On pre-S (or when AudioManager
+    // throws) we return null and the caller marks everything as
+    // "available=true" so the picker degrades gracefully to the
+    // pre-change behavior.
+    //
+    // MACs are upper-cased so the caller's lookup is case-insensitive.
+    private fun reachableCommunicationMacsSnapshot(): Set<String>? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return null
+        val ctx = heldMapView?.context ?: heldPluginContext ?: return null
+        val am =
+            try {
+                ctx.getSystemService(Context.AUDIO_SERVICE) as? android.media.AudioManager
+            } catch (t: Throwable) {
+                Log.w(TAG, "reachableCommunicationMacsSnapshot: AUDIO_SERVICE threw", t)
+                null
+            } ?: return null
+        return try {
+            am.availableCommunicationDevices
+                .mapNotNull { it.address?.takeIf { addr -> addr.isNotBlank() }?.uppercase() }
+                .toSet()
+        } catch (t: Throwable) {
+            Log.w(TAG, "reachableCommunicationMacsSnapshot: availableCommunicationDevices threw", t)
+            null
+        }
+    }
+
     @SuppressWarnings("MissingPermission")
     private fun listBondedAinaDevices(): List<com.atakmap.android.xv.aina.AinaDeviceInfo> {
         val adapter = BluetoothAdapter.getDefaultAdapter() ?: return emptyList()
@@ -2348,6 +2444,10 @@ class XvMapComponent : AbstractMapComponent() {
                 Log.w(TAG, "listBondedAinaDevices: bondedDevices threw", t)
                 return emptyList()
             }
+        // Live-reachability snapshot (null when we can't ask — pre-S
+        // or missing service). null → treat every candidate as
+        // "available" so we degrade to the legacy picker rendering.
+        val reachableMacs = reachableCommunicationMacsSnapshot()
         // Show every bonded device that's plausibly a speakermic — i.e.
         // anything with HFP / SCO / SPP / known BLE PTT service in its
         // SDP cache, OR anything whose BT major class is AUDIO_VIDEO.
@@ -2421,10 +2521,26 @@ class XvMapComponent : AbstractMapComponent() {
             candidates
                 .filter { it.third }
                 .map { (dev, proto, _) ->
+                    // BLE-HID buttons never appear in the audio-policy
+                    // communication-device list (they're HID over GATT,
+                    // not a routable audio endpoint), so we can't ask
+                    // AudioManager whether they're reachable. Mark them
+                    // as "available=true" so the picker doesn't dim
+                    // every BLE PTT puck the operator has ever paired.
+                    // For SPP / BLE / AUDIO_ONLY the audio-policy check
+                    // is authoritative; when we couldn't take a snapshot
+                    // (reachableMacs == null) fall back to "available".
+                    val isAvailable =
+                        when {
+                            reachableMacs == null -> true
+                            proto == com.atakmap.android.xv.aina.AinaDeviceInfo.ButtonProtocol.BLE_HID -> true
+                            else -> reachableMacs.contains(dev.address.uppercase())
+                        }
                     com.atakmap.android.xv.aina.AinaDeviceInfo(
                         mac = dev.address,
                         name = dev.name ?: dev.address,
                         buttonProtocol = proto,
+                        available = isAvailable,
                     )
                 }
         // Merge manually-added BLE PTT devices (PTT-Z01, Pryme
@@ -2435,6 +2551,11 @@ class XvMapComponent : AbstractMapComponent() {
         // precedence for the name (operator-visible label from the
         // scan-and-pick dialog) but we defer to a bonded entry if
         // both exist to preserve any live classifier result.
+        //
+        // Known BLE PTT are always marked available — they connect via
+        // BluetoothAdapter.getRemoteDevice on demand, never appear in
+        // AudioManager's comm-device list, and their reachability isn't
+        // reliably observable without a full GATT connect.
         val bondedMacs = bondedResults.map { it.mac.uppercase() }.toSet()
         val knownBlePtt =
             settings.knownBlePttDevices().mapNotNull { (mac, name) ->
@@ -2443,14 +2564,23 @@ class XvMapComponent : AbstractMapComponent() {
                     mac = mac,
                     name = name ?: mac,
                     buttonProtocol = com.atakmap.android.xv.aina.AinaDeviceInfo.ButtonProtocol.BLE_HID,
+                    available = true,
                 )
             }
-        return (bondedResults + knownBlePtt).sortedWith(
-            compareBy(
-                { com.atakmap.android.xv.aina.AinaDeviceClassifier.protocolOrder(it.buttonProtocol) },
-                { it.name.lowercase() },
-            ),
-        )
+        // Rank order:
+        //   1. Available devices (rendered normal + tappable) first, so
+        //      the operator's tap-target is whichever speakermic is
+        //      actually live.
+        //   2. Then by button protocol so we prefer SPP → BLE →
+        //      BLE_HID → audio-only within each availability tier
+        //      (unchanged from the pre-change ordering).
+        //   3. Then by name for a stable order across refreshes.
+        // Inspired by how call apps (Meet, WhatsApp) render device
+        // pickers: reachable devices bubble to the top, unreachable
+        // ones are still shown so the operator can see the pairing
+        // exists but they can't be tapped by mistake.
+        return com.atakmap.android.xv.aina.AinaDeviceClassifier
+            .rankForPicker(bondedResults + knownBlePtt)
     }
 
     // Speakermic detection + protocol classification extracted to

--- a/app/src/main/java/com/atakmap/android/xv/ui/XvDropDownReceiver.kt
+++ b/app/src/main/java/com/atakmap/android/xv/ui/XvDropDownReceiver.kt
@@ -1513,19 +1513,89 @@ class XvDropDownReceiver(
         spinner.setSelection(pos)
     }
 
+    // Builds an ArrayAdapter shared by the primary + secondary AINA
+    // pickers. Row 0 is the "no external button" sentinel; subsequent
+    // rows correspond 1:1 with `devices` (so callers convert
+    // spinner-pos to a device via pos-1). Unavailable rows carry a
+    // trailing " · unavailable" suffix in the label AND are painted
+    // dim; `isEnabled(pos)` returns false for them so a tap in the
+    // dropdown popup does nothing.
+    //
+    // Design note (why an ArrayAdapter subclass over a "(unavailable)"
+    // suffix alone): text-suffix-only picks lose in accessibility (a
+    // screen reader has no way to know the row is disabled) AND in
+    // touch response (an operator can still tap the row and trigger
+    // a connect to a device that we already know is unreachable).
+    // The custom adapter is ~20 lines of code but gives us both the
+    // color + tap-guard properties the leading call-picker UIs use.
+    private fun buildAinaPickerAdapter(devices: List<AinaDeviceInfo>): ArrayAdapter<String> {
+        // Row 0 sentinel is always tappable/enabled.
+        val entries =
+            mutableListOf<PickerRow>().apply {
+                add(PickerRow(label = AINA_NONE_LABEL, available = true))
+                for (d in devices) {
+                    val suffix = if (d.available) "" else "  ·  unavailable"
+                    add(PickerRow(label = d.displayLabel() + suffix, available = d.available))
+                }
+            }
+        return object : ArrayAdapter<String>(
+            pluginContext,
+            R.layout.xv_spinner_item,
+            entries.map { it.label },
+        ) {
+            override fun isEnabled(position: Int): Boolean =
+                entries.getOrNull(position)?.available ?: true
+
+            override fun getDropDownView(
+                position: Int,
+                convertView: View?,
+                parent: android.view.ViewGroup,
+            ): View {
+                val view = super.getDropDownView(position, convertView, parent)
+                val row = entries.getOrNull(position)
+                if (view is TextView) {
+                    if (row?.available == false) {
+                        // Half-alpha to visually indicate "still shown,
+                        // but not tappable." Follows the AOSP
+                        // material picker convention for disabled
+                        // items.
+                        view.alpha = 0.4f
+                    } else {
+                        view.alpha = 1.0f
+                    }
+                }
+                return view
+            }
+        }
+    }
+
+    private data class PickerRow(
+        val label: String,
+        val available: Boolean,
+    )
+
     // Replaces the old Connect / Disconnect buttons. Lists every bonded
     // device whose name matches an AINA pattern, annotated with V1 (SPP)
     // or V2 (BLE). Selecting one connects to it via the Controller's
     // setSelectedAina(); selecting "(none)" disconnects. The selection
     // persists across launches via SharedPreferences (XvMapComponent).
+    //
+    // Availability rendering: rows for devices that AudioManager doesn't
+    // currently list as reachable (bonded but powered off / out of
+    // range) are painted dim and marked non-selectable in the dropdown
+    // popup — same approach modern call-picker UIs (Meet, WhatsApp
+    // Calls, the AOSP call chooser) take. The label carries a trailing
+    // " · unavailable" suffix so operators reading a screenshot still
+    // see the state without needing the color cue. This is snapshot-in-
+    // time only: the availability info is baked into the adapter when
+    // the picker opens; a mid-view BT connect won't re-color the row
+    // until the operator re-opens Settings (see AinaPickerAvailabilityListener
+    // wiring in [showSettings] which triggers a rebuild on ACL edges).
     private fun wireAinaPicker(v: View) {
         val spinner = v.findViewById<Spinner>(R.id.xv_spinner_aina)
         val statusLabel = v.findViewById<TextView>(R.id.xv_label_aina_status)
         val devices = controller.availableAinaDevices()
-        val labels = mutableListOf(AINA_NONE_LABEL)
-        labels.addAll(devices.map { it.displayLabel() })
-        spinner.adapter =
-            ArrayAdapter(pluginContext, R.layout.xv_spinner_item, labels)
+        spinner.adapter = buildAinaPickerAdapter(devices)
         val selectedMac = controller.selectedAinaMac()
         val selectedIdx =
             if (selectedMac == null) {
@@ -1588,10 +1658,7 @@ class XvDropDownReceiver(
         val spinner = v.findViewById<Spinner>(R.id.xv_spinner_aina_secondary) ?: return
         val statusLabel = v.findViewById<TextView>(R.id.xv_label_aina_secondary_status)
         val devices = controller.availableSecondaryAinaDevices()
-        val labels = mutableListOf(AINA_NONE_LABEL)
-        labels.addAll(devices.map { it.displayLabel() })
-        spinner.adapter =
-            ArrayAdapter(pluginContext, R.layout.xv_spinner_item, labels)
+        spinner.adapter = buildAinaPickerAdapter(devices)
         val selectedMac = controller.selectedSecondaryAinaMac()
         val selectedIdx =
             if (selectedMac == null) {

--- a/app/src/test/java/com/atakmap/android/xv/aina/AinaDeviceClassifierTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/aina/AinaDeviceClassifierTest.kt
@@ -167,6 +167,75 @@ class AinaDeviceClassifierTest {
         )
     }
 
+    // ============================================================
+    // rankForPicker — startup-UX device ordering
+    // (feat/bt-device-startup-ux)
+    // ============================================================
+
+    private fun info(
+        name: String,
+        proto: AinaDeviceInfo.ButtonProtocol,
+        available: Boolean,
+    ): AinaDeviceInfo =
+        AinaDeviceInfo(
+            mac = "AA:BB:CC:DD:EE:${name.hashCode().and(0xFF).toString(16).padStart(2, '0')}",
+            name = name,
+            buttonProtocol = proto,
+            available = available,
+        )
+
+    @Test
+    fun `rankForPicker puts available devices ahead of unavailable regardless of protocol`() {
+        // The field bug being fixed: startup UX auto-selected a device
+        // that was bonded but powered off, even though a live SPP AINA
+        // was in the picker. Ranking must promote AVAILABLE ahead of
+        // protocol precedence.
+        val unavailableSpp = info("APTT-off", AinaDeviceInfo.ButtonProtocol.SPP, available = false)
+        val availableBleHid = info("Pryme-live", AinaDeviceInfo.ButtonProtocol.BLE_HID, available = true)
+        val ranked = AinaDeviceClassifier.rankForPicker(listOf(unavailableSpp, availableBleHid))
+        assertEquals(
+            "available BLE-HID must beat unavailable SPP so autoConnectAina picks a live device",
+            "Pryme-live",
+            ranked.first().name,
+        )
+        assertEquals("APTT-off", ranked.last().name)
+    }
+
+    @Test
+    fun `rankForPicker preserves protocol order within the available tier`() {
+        // SPP > BLE > BLE_HID within the same availability tier —
+        // the pre-change ordering, unchanged.
+        val ble = info("V2-live", AinaDeviceInfo.ButtonProtocol.BLE, available = true)
+        val spp = info("V1-live", AinaDeviceInfo.ButtonProtocol.SPP, available = true)
+        val bleHid = info("Puck-live", AinaDeviceInfo.ButtonProtocol.BLE_HID, available = true)
+        val ranked = AinaDeviceClassifier.rankForPicker(listOf(ble, bleHid, spp))
+        assertEquals(
+            listOf("V1-live", "V2-live", "Puck-live"),
+            ranked.map { it.name },
+        )
+    }
+
+    @Test
+    fun `rankForPicker preserves protocol order within the unavailable tier`() {
+        // Unavailable devices still sort by protocol beneath the
+        // available block — an operator scanning the greyed rows sees
+        // a familiar order.
+        val ble = info("V2-off", AinaDeviceInfo.ButtonProtocol.BLE, available = false)
+        val spp = info("V1-off", AinaDeviceInfo.ButtonProtocol.SPP, available = false)
+        val ranked = AinaDeviceClassifier.rankForPicker(listOf(ble, spp))
+        assertEquals(listOf("V1-off", "V2-off"), ranked.map { it.name })
+    }
+
+    @Test
+    fun `rankForPicker breaks ties by lowercase name`() {
+        // Same protocol, same availability — name is the tiebreaker so
+        // the picker order is stable across refreshes.
+        val a = info("bravo", AinaDeviceInfo.ButtonProtocol.SPP, available = true)
+        val b = info("Alpha", AinaDeviceInfo.ButtonProtocol.SPP, available = true)
+        val ranked = AinaDeviceClassifier.rankForPicker(listOf(a, b))
+        assertEquals(listOf("Alpha", "bravo"), ranked.map { it.name })
+    }
+
     @Test
     fun `device that throws on name access is treated as nameless`() {
         // Some OEM stacks throw SecurityException on getName() if


### PR DESCRIPTION
## Summary

Field 2026-07-08 report: on plugin load XV auto-selected a bonded BT
speakermic that wasn't currently powered, even when a different
bonded device was live. Mid-session disconnects also left audio
routed to a dead endpoint instead of falling back to the phone
speaker. This PR reworks the BT device startup UX to match how
modern call-picker UIs (Meet, WhatsApp Calls, the AOSP device
chooser) handle reachability.

### What changed

- **Reachability detection.** `XvMapComponent.listBondedAinaDevices`
  now intersects the bonded set with
  `AudioManager.getAvailableCommunicationDevices()` on API 31+. Each
  `AinaDeviceInfo` carries an `available: Boolean` field. BLE-HID
  buttons short-circuit to `available=true` because they never
  appear in the comm-device list (HID over GATT, not routable
  audio). On pre-S / missing service we degrade to
  `available=true` so nothing regresses.
- **Ranking.** Extracted `AinaDeviceClassifier.rankForPicker` as a
  pure function ordering by (available ↓, protocolOrder, name↓).
  Pinned by four new unit tests in `AinaDeviceClassifierTest`.
- **Picker rendering.** `XvDropDownReceiver.buildAinaPickerAdapter`
  paints unavailable rows dim (`alpha = 0.4f`), disables tap via
  `ArrayAdapter.isEnabled`, and suffixes the label with
  " · unavailable" for legibility without color. Both primary and
  secondary AINA pickers share the adapter.
- **Startup auto-connect.** `autoConnectAina` prefers the persisted
  MAC if it's reachable; otherwise falls back to the first available
  compatible device; otherwise skips (does NOT default to speaker on
  load — only during a live session). The persisted MAC is
  preserved across a bonded-but-off state so the next reachable
  window restores it as the top pick.
- **Speaker fallback lifecycle.** `AudioRouter` arms a grace-period
  timer whenever `preferredBtMacHint` is set but the hint MAC isn't
  in the audio-device output list. If the device stays absent for
  `BT_UNAVAILABLE_SPEAKER_FALLBACK_MS` (15 s), `preferredDevice`
  flips to `BUILTIN_SPEAKER` while keeping the hint intact so
  reconnection auto-resumes BT routing. The timer resets on any
  `AudioDeviceCallback` edge that restores the hinted device.

### Constants / knobs

- `AudioRouter.BT_UNAVAILABLE_SPEAKER_FALLBACK_MS = 15_000L` — short
  enough that a live session doesn't sit mute after an accidental
  disconnect, long enough to ride out a routine ~5s BT profile-reset
  without a spurious speaker chirp.

### Non-goals

- Does NOT bump `versionCode` / `versionName`.
- Does NOT touch `build.gradle.kts`, `gradle/wrapper`, or
  `.github/workflows/`.
- Curated hardware list unchanged.

### Known limitations (honest)

- Availability is a snapshot in time — the picker is refreshed on
  open + on BT state-change intents, but a device that comes online
  while the settings drawer is already sitting open won't re-color
  its row until the operator reopens the picker. Live re-coloring
  would require tying the adapter to `AudioDeviceCallback`
  notifications from the plugin process, which is a bigger surgery.
- The speaker fallback lives inside `AudioRouter` and is gated on
  `preferredBtMacHint`. If the operator picked "(none)" and is
  running screen-only PTT, the fallback path is inert — which is
  the correct behavior, but worth noting.

## Test plan

- [x] `./gradlew ktlintCheck` — green
- [x] `./gradlew testCivDebugUnitTest` — green, includes 4 new
      `rankForPicker` cases (available-first, within-tier ordering,
      name tiebreak)
- [x] `./gradlew assembleCivDebug` — green
- [ ] Field verification: bonded-but-off puck alongside a live
      speakermic; confirm live device is auto-selected on plugin
      load and the off puck shows dim in the picker
- [ ] Field verification: power down active speakermic mid-session,
      confirm audio flips to phone speaker after ~15s and returns
      to BT on reconnect without operator intervention

Generated with Claude Code