### PR TITLE
fix(audio): restore volume-button behavior after Telecom cool-down

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/audio/AudioControllerImpl.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/AudioControllerImpl.kt
@@ -8,6 +8,7 @@ import android.media.AudioManager
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import java.util.concurrent.CopyOnWriteArraySet
 
 /**
@@ -314,7 +315,7 @@ class AudioControllerImpl(
     private fun suspendInternal() {
         preSuspendState = currentState
         when (currentState) {
-            AudioState.RX -> releaseRxFocus()
+            AudioState.RX -> releaseRxFocusImmediate()
             AudioState.TX -> releaseTxAndScoAndMode()
             AudioState.RX_TX -> {
                 releaseTxAndScoAndMode()
@@ -323,6 +324,26 @@ class AudioControllerImpl(
             else -> {}
         }
         transitionTo(AudioState.SUSPENDED)
+    }
+
+    // System-suspend variant of [releaseRxFocus]. The regular teardown
+    // path schedules the phone-mode restore SCO_COOL_DOWN_MS in the
+    // future so a rapid re-engage lands warm; but on focus-loss we
+    // just handed the audio session to whatever the system granted
+    // focus to — most commonly Telephony placing MODE_IN_CALL for an
+    // incoming phone call. A deferred restore that fires while the
+    // phone call is mid-audio blows away MODE_IN_CALL (setting it back
+    // to MODE_NORMAL) and clobbers STREAM_VOICE_CALL's volume mid-
+    // call — the operator sees "volume buttons regressed / call
+    // audio suddenly quiet or mis-routed" a few seconds into the
+    // phone call. Match TX's suspend behavior: cancel any pending
+    // deferred restore and apply the pre-engage state immediately so
+    // whatever the system does next starts from a clean baseline.
+    private fun releaseRxFocusImmediate() {
+        rxFocusRequest?.let { audioManager.abandonAudioFocusRequest(it) }
+        rxFocusRequest = null
+        phoneModeHandler.removeCallbacks(phoneModeReleaseRunnable)
+        applyPhoneModeRestore()
     }
 
     // Bring STREAM_VOICE_CALL up to a usable level on engage. On
@@ -521,6 +542,21 @@ class AudioControllerImpl(
                     .build(),
             ).setOnAudioFocusChangeListener(focusListener)
             .build()
+
+    // Test seams. Real focus-loss dispatch is a system callback delivered
+    // through the AudioFocusRequest's registered listener — Robolectric's
+    // AudioManager shadow does not deliver those callbacks synchronously
+    // through the request round-trip we make in [buildRxFocusRequest] /
+    // [buildTxFocusRequest], so the unit test needs a direct hook to
+    // exercise the suspend path. Kept package-private via
+    // [VisibleForTesting] so production code cannot accidentally reach
+    // through and short-circuit the focus-loss contract.
+
+    /** Test hook: dispatch a synthetic focus-loss event to [focusListener]. */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    internal fun simulateFocusLossForTest() {
+        focusListener.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS_TRANSIENT)
+    }
 
     companion object {
         private const val TAG = "XvAudio"

--- a/app/src/test/java/com/atakmap/android/xv/audio/AudioControllerImplSuspendTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/audio/AudioControllerImplSuspendTest.kt
@@ -1,0 +1,142 @@
+package com.atakmap.android.xv.audio
+
+import android.content.Context
+import android.media.AudioManager
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+/**
+ * Coverage for [AudioControllerImpl]'s system-suspend behavior — the
+ * path that fires when Android telephony (or any higher-priority focus
+ * holder) yanks focus mid-RX.
+ *
+ * The regression this pins: the earlier suspend path funnelled through
+ * the same [releaseRxFocus] helper the orderly teardown uses, which
+ * schedules a phone-mode restore SCO_COOL_DOWN_MS in the future. When
+ * that deferred restore fired mid phone-call, it forced
+ * [AudioManager.mode] back to MODE_NORMAL and clobbered
+ * STREAM_VOICE_CALL's volume while the phone call was still active —
+ * the operator observed "volume buttons regressed / call audio suddenly
+ * wrong" a few seconds into the phone call. The corrected suspend path
+ * restores immediately (matching TX's suspend semantics) so the system
+ * takes over from a clean baseline with no future runnables outstanding.
+ *
+ * Robolectric provides the AudioManager shadow that persists mode /
+ * stream-volume writes in-process, so we can assert against real
+ * observable side effects instead of mocking every AudioManager call.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AudioControllerImplSuspendTest {
+    private lateinit var ctx: Context
+    private lateinit var audioManager: AudioManager
+
+    @Before
+    fun setup() {
+        ctx = ApplicationProvider.getApplicationContext()
+        audioManager = ctx.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        // Establish a known pre-engage baseline. The regression is
+        // specifically about clobbering the operator's pre-engage
+        // volume + mode after focus-loss, so both must be observable.
+        audioManager.mode = AudioManager.MODE_NORMAL
+        // STREAM_VOICE_CALL max on Robolectric shadow is high; use a
+        // low current value so bumpVoiceCallVolumeIfLow does bump.
+        audioManager.setStreamVolume(AudioManager.STREAM_VOICE_CALL, 2, 0)
+    }
+
+    @Test
+    fun `focus-loss during RX restores mode immediately — no deferred runnable`() {
+        val controller = AudioControllerImpl(ctx)
+
+        // Enter RX — controller captures pre-engage mode (NORMAL) +
+        // pre-engage STREAM_VOICE_CALL volume (2) + engages
+        // MODE_IN_COMMUNICATION + bumps voice-call volume.
+        assertEquals(
+            "enterRx must grant focus on the Robolectric shadow",
+            true,
+            controller.enterRx(),
+        )
+        assertEquals(AudioState.RX, controller.state)
+        assertEquals(
+            "MODE_IN_COMMUNICATION must be engaged after enterRx",
+            AudioManager.MODE_IN_COMMUNICATION,
+            audioManager.mode,
+        )
+
+        // System (typically Telecom placing an incoming phone call)
+        // yanks focus. The old code path scheduled a deferred restore
+        // that would fire mid-call and clobber Telephony's mode +
+        // stream volume. The fix restores immediately so nothing is
+        // outstanding to blow away the phone call's audio state.
+        controller.simulateFocusLossForTest()
+
+        assertEquals(
+            "focus loss must transition the controller into SUSPENDED",
+            AudioState.SUSPENDED,
+            controller.state,
+        )
+        assertEquals(
+            "phone-mode restore MUST run synchronously in the suspend " +
+                "path — a deferred runnable would fire mid phone-call and " +
+                "overwrite Telephony's MODE_IN_CALL back to MODE_NORMAL, " +
+                "which the operator perceives as \"volume buttons regressed\"",
+            AudioManager.MODE_NORMAL,
+            audioManager.mode,
+        )
+        assertEquals(
+            "STREAM_VOICE_CALL must be restored to the pre-engage level in " +
+                "the same synchronous step — a deferred restore would fire " +
+                "several seconds into the phone call and yank the call's " +
+                "volume out from under the user",
+            2,
+            audioManager.getStreamVolume(AudioManager.STREAM_VOICE_CALL),
+        )
+
+        // Guard against a stray deferred runnable that would later fire
+        // and re-clobber whatever the system has set. Drain the main
+        // Looper — if anything was scheduled by the suspend path, it
+        // will run now and we can detect it by observing state churn.
+        val priorMode = audioManager.mode
+        val priorVol = audioManager.getStreamVolume(AudioManager.STREAM_VOICE_CALL)
+        shadowOf(android.os.Looper.getMainLooper()).idle()
+        assertEquals(
+            "no follow-up runnable may fire after suspend — mode must not change",
+            priorMode,
+            audioManager.mode,
+        )
+        assertEquals(
+            "no follow-up runnable may fire after suspend — volume must not change",
+            priorVol,
+            audioManager.getStreamVolume(AudioManager.STREAM_VOICE_CALL),
+        )
+    }
+
+    @Test
+    fun `orderly returnToIdle from RX still uses cool-down (behavioural regression guard)`() {
+        // Belt-and-suspenders: make sure the fix only touched the
+        // system-suspend path. The regular teardown path (peer-voice
+        // burst ended → AudioPlayback.teardown → returnToIdle) must
+        // still defer the restore so a rapid re-engage lands warm.
+        val controller = AudioControllerImpl(ctx)
+        assertEquals(true, controller.enterRx())
+        assertEquals(AudioManager.MODE_IN_COMMUNICATION, audioManager.mode)
+
+        controller.returnToIdle()
+        assertEquals(AudioState.IDLE, controller.state)
+        // Cool-down is armed → mode + volume must remain engaged
+        // until the deferred runnable fires. Deferred = not yet run,
+        // so mode stays IN_COMMUNICATION at this synchronous point.
+        assertEquals(
+            "returnToIdle from RX must arm a deferred restore (mode " +
+                "still IN_COMMUNICATION until cool-down fires); the fix " +
+                "must not have collapsed this path into an immediate " +
+                "restore",
+            AudioManager.MODE_IN_COMMUNICATION,
+            audioManager.mode,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Field 2026-07-08 operator complaint: "there seems to be an issue with the volume buttons regressing." XV does not intercept `KEYCODE_VOLUME_*` — the regression is behavioral, not a physical-key intercept.
- Root cause: `AudioControllerImpl.suspendInternal()`'s RX branch routed through the same `releaseRxFocus()` helper the orderly teardown uses. That helper schedules a phone-mode restore `SCO_COOL_DOWN_MS` in the future — the correct behavior when a peer-voice burst ends, but the wrong behavior when the system yanks focus for an incoming phone call. The deferred restore then fires several seconds into the phone call and slams `AudioManager.mode` back to `MODE_NORMAL` (from Telephony's `MODE_IN_CALL`) plus clobbers `STREAM_VOICE_CALL` volume back to the pre-XV level. Because `XvVoiceService`'s `MediaSession` keeps volume keys routed to `STREAM_VOICE_CALL` throughout, the operator sees the level jump mid-call and the buttons appear to be adjusting the "wrong" thing.
- Fix (`app/src/main/java/com/atakmap/android/xv/audio/AudioControllerImpl.kt`): add `releaseRxFocusImmediate()` that mirrors the TX suspend helper — cancel any pending phone-mode restore, then apply the pre-engage state synchronously — and route only `suspendInternal`'s RX branch through it. `RX_TX` already reached `applyPhoneModeRestore` immediately via `releaseTxAndScoAndMode`; `TX` already did the right thing; only the RX branch was misrouted. Orderly `returnToIdle` paths still arm the cool-down so a peer burst within 5 s avoids the mode-flip stutter.

Hypothesis matched: closest to #2 (mode never returns from `MODE_IN_COMMUNICATION` — actually the opposite direction: mode gets forced OUT of a foreign `MODE_IN_CALL` mid phone-call). Also drags in #1 (`STREAM_VOICE_CALL` volume clobbered mid-call).

## Test plan

- [x] `./gradlew ktlintCheck`
- [x] `./gradlew assembleCivDebug`
- [x] `./gradlew testCivDebugUnitTest`
- [x] New `AudioControllerImplSuspendTest` pins the corrected suspend semantics — asserts that simulated focus loss during RX restores mode + STREAM_VOICE_CALL volume synchronously with no deferred runnable outstanding, and that the orderly `returnToIdle` path still defers the restore (regression guard).
- [x] Confirmed the test catches the regression: reverting the one-line dispatch change (`releaseRxFocusImmediate()` → `releaseRxFocus()`) makes the suspend test fail; re-applying makes it pass.
- [ ] Operator smoke: on a phone with Telephony wired up, engage XV (any peer voice traffic or an outbound PTT), let ATAK settle into RX or IDLE, then place / receive a real phone call. Confirm the phone call's audio stays routed correctly for the full ~10 s (previously the audio mode + volume flipped 5 s in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)