### PR TITLE
fix(audio): link AudioTrack to AudioRecord session for AEC reference signal

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/audio/AudioCapture.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/AudioCapture.kt
@@ -39,6 +39,19 @@ class AudioCapture(
     // marker for field-debug; future plumbing can route to a Toast via
     // the AIDL listener. Audit H5.
     private val onCaptureError: (reason: String) -> Unit = {},
+    // Fires with the OS-assigned AudioRecord session id after
+    // startRecording() succeeds, and again with null when capture stops
+    // or fails after allocation. VoicePlant stores the current value so
+    // AudioPlayback can attach its AudioTrack to the same session via
+    // AudioTrack.Builder.setSessionId(id) — that shared session id is
+    // what gives Android's AcousticEchoCanceler (created against the
+    // capture session in [configureAudioEffects]) a real downlink
+    // reference signal to subtract from the mic input. Without shared
+    // session ids, AEC sees only the mic path and can't suppress a
+    // peer's voice echoing back through the operator's speakermic.
+    // Default no-op keeps the constructor usable in tests / historical
+    // callsites that don't route through VoicePlant.
+    private val onSessionIdChanged: (Int?) -> Unit = {},
 ) {
     private val channelMask =
         if (channels == 1) AudioFormat.CHANNEL_IN_MONO else AudioFormat.CHANNEL_IN_STEREO
@@ -131,6 +144,20 @@ class AudioCapture(
         }
         thread =
             Thread({ runReadLoop() }, "xv-mic-capture").also { it.start() }
+        // Bubble the OS-assigned capture session id up to the plant so
+        // AudioPlayback can bind its AudioTrack to the same session
+        // (setSessionId on AudioTrack). This is what closes the loop for
+        // AEC: the AcousticEchoCanceler created against this session id
+        // (see [configureAudioEffects]) then has a real downlink reference
+        // signal to subtract from the mic input. Session ids are not
+        // sensitive per CLAUDE.md — log unredacted for field debug.
+        val sid = r.audioSessionId
+        Log.i(TAG, "capture session id=$sid — linked for AEC")
+        try {
+            onSessionIdChanged(sid)
+        } catch (t: Throwable) {
+            Log.w(TAG, "onSessionIdChanged(start) threw", t)
+        }
         // The actually-routed input device may differ from the requested
         // preferredDevice — the OS picks routing per its policy. Log the
         // routed device so silent-mic bugs are diagnosable: if we asked
@@ -223,6 +250,14 @@ class AudioCapture(
             }
         }
         record = null
+        // Clear the plant's cached session id so a subsequent RX before
+        // the next TX doesn't try to attach an AudioTrack to a released
+        // AudioRecord session. Idempotent — plant just holds null.
+        try {
+            onSessionIdChanged(null)
+        } catch (t: Throwable) {
+            Log.w(TAG, "onSessionIdChanged(stop) threw", t)
+        }
         Log.i(TAG, "AudioRecord stopped")
     }
 

--- a/app/src/main/java/com/atakmap/android/xv/audio/AudioPlayback.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/AudioPlayback.kt
@@ -80,6 +80,19 @@ class AudioPlayback(
     // produce 2-3 BONKs in a row before PRIMING finally observes
     // non-silent samples. Active=true on enter, false on exit.
     private val onScoHotChanged: (active: Boolean) -> Unit = {},
+    // Returns the OS-assigned AudioRecord session id currently in use
+    // by AudioCapture, or null when no capture is active. When non-null,
+    // AudioTrack.Builder.setSessionId(id) is called so the RX playback
+    // path shares a session with the mic path — that shared session id
+    // gives Android's AcousticEchoCanceler (attached to the capture
+    // session in AudioCapture.configureAudioEffects) a real downlink
+    // reference signal to subtract from the mic input. Without shared
+    // session ids, AEC has no visibility into what's coming out of the
+    // speaker and can't suppress a peer's voice echoing back through
+    // the operator's speakermic. Limitation: the very first RX before
+    // any TX still races (no capture session exists yet); the field
+    // bug is warm back-and-forth, which this covers.
+    private val captureSessionIdProvider: () -> Int? = { null },
 ) : AudioRouter.RouteListener {
     private val channelMask =
         if (channels == 1) AudioFormat.CHANNEL_OUT_MONO else AudioFormat.CHANNEL_OUT_STEREO
@@ -579,15 +592,37 @@ class AudioPlayback(
                 .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
                 .setChannelMask(channelMask)
                 .build()
+        // If AudioCapture has an active session, bind the AudioTrack to
+        // the same session id so Android's AcousticEchoCanceler (attached
+        // to the capture session in AudioCapture.configureAudioEffects)
+        // has a real downlink reference signal to subtract from the mic
+        // input. First RX before any TX still races (captureSessionId
+        // == null); on any RX burst that follows a PTT press, AEC is
+        // now looking at the same session pair. Session ids are not
+        // sensitive per CLAUDE.md — log unredacted for field debug.
+        val captureSessionId =
+            try {
+                captureSessionIdProvider()
+            } catch (t: Throwable) {
+                Log.w(TAG, "captureSessionIdProvider threw", t)
+                null
+            }
         val newTrack =
             try {
-                AudioTrack
-                    .Builder()
-                    .setAudioAttributes(attrs)
-                    .setAudioFormat(format)
-                    .setBufferSizeInBytes(minBufferBytes)
-                    .setTransferMode(AudioTrack.MODE_STREAM)
-                    .build()
+                val b =
+                    AudioTrack
+                        .Builder()
+                        .setAudioAttributes(attrs)
+                        .setAudioFormat(format)
+                        .setBufferSizeInBytes(minBufferBytes)
+                        .setTransferMode(AudioTrack.MODE_STREAM)
+                if (captureSessionId != null && captureSessionId != 0) {
+                    b.setSessionId(captureSessionId)
+                    Log.i(TAG, "AudioTrack using capture session id=$captureSessionId for AEC linkage")
+                } else {
+                    Log.i(TAG, "AudioTrack built with fresh session (no capture session yet — first RX or post-stop)")
+                }
+                b.build()
             } catch (t: Throwable) {
                 Log.e(TAG, "AudioTrack build failed (useSco=$useSco)", t)
                 return

--- a/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
@@ -167,6 +167,31 @@ class VoicePlant(
             preferredDeviceForTones = { router.preferredDevice() },
         ).also { it.primeMediaPath() }
 
+    // Session id of the currently-live AudioCapture, or null when no
+    // capture is running. Published by AudioCapture.start() (via the
+    // onSessionIdChanged callback wired below) and cleared by
+    // AudioCapture.stop(). AudioPlayback consults it when building a
+    // fresh AudioTrack so RX playback shares a session with the mic
+    // path — Android's AcousticEchoCanceler (attached to the capture
+    // session in AudioCapture.configureAudioEffects) then has a real
+    // downlink reference signal to subtract from the mic input, which
+    // is what stops the operator's peer from hearing themselves
+    // through the operator's own speakermic on a warm back-and-forth.
+    // Volatile: TX thread writes (AudioCapture.start/stop runs on the
+    // caller thread; TxController drives the lifecycle from its own
+    // executor), RX thread reads (playPcm delivery landing on the
+    // Mumble decoder thread).
+    @Volatile private var currentCaptureSessionId: Int? = null
+
+    /** Called by AudioCapture on start()/stop() so AudioPlayback can
+     *  bind its AudioTrack to the same audio session. Public API is
+     *  package-scoped-by-convention — external callers should never
+     *  touch this. */
+    internal fun setCurrentCaptureSessionId(id: Int?) {
+        currentCaptureSessionId = id
+        Log.i(TAG, "currentCaptureSessionId → $id")
+    }
+
     private val audioPlayback: AudioPlayback =
         AudioPlayback(
             controller = audioController,
@@ -185,6 +210,13 @@ class VoicePlant(
             // cost. Especially helps slow combos (Duo+V1) where the
             // mic returns silence for 1-3 s after a cold SCO setup.
             onScoHotChanged = { active -> txController.preWarmMic(active) },
+            // AEC session linkage. When a capture is live, AudioTrack
+            // is built against the same session id so the AEC effect
+            // (attached to the capture session in AudioCapture) has a
+            // real reference signal. First RX before any TX still
+            // races — this covers the warm back-and-forth case which
+            // is the field bug.
+            captureSessionIdProvider = { currentCaptureSessionId },
         ).also { router.start(it) }
 
     private val statusTones = StatusTones(tptPlayer = tptPlayer, enabled = { statusTonesEnabled })
@@ -224,6 +256,11 @@ class VoicePlant(
                     context = context,
                     onFrame = onFrame,
                     onCaptureError = { reason -> callbacks.onCaptureError(reason) },
+                    // Publish the OS-assigned capture session id up so
+                    // AudioPlayback can share it with its AudioTrack. See
+                    // [currentCaptureSessionId] docstring for the AEC
+                    // rationale.
+                    onSessionIdChanged = { id -> setCurrentCaptureSessionId(id) },
                 )
             },
             opusEncoderFactory = { ConcentusOpusEncoder() as OpusEncoder },


### PR DESCRIPTION
## Summary

- Android's AcousticEchoCanceler is attached in `AudioCapture.configureAudioEffects` against the mic's `AudioRecord.audioSessionId`, but `AudioPlayback` built its `AudioTrack` against a fresh, independent session. AEC then had no downlink reference signal — a peer's voice coming back through the operator's speakermic leaked into the mic on warm back-and-forth, and the peer heard themselves.
- Fix: invert the plumbing. `AudioCapture` allocates its `AudioRecord` normally (the OS assigns a session id — the sessionId-taking `AudioRecord` ctor is `@SystemApi` and off-limits). It then publishes that session id up to `VoicePlant`, and `AudioPlayback` binds its `AudioTrack` via the public `AudioTrack.Builder.setSessionId(int)` when a capture session is known.
- AEC/NS/AGC attach policy is untouched — it already reads `record.audioSessionId`.

## Changes

- `app/src/main/java/com/atakmap/android/xv/audio/AudioCapture.kt`
  - New `onSessionIdChanged: (Int?) -> Unit` constructor param (default no-op).
  - After `startRecording()` succeeds, fires with `record.audioSessionId`.
  - In `stop()`, fires with `null`.
- `app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt`
  - `@Volatile currentCaptureSessionId: Int?` + `internal fun setCurrentCaptureSessionId(id: Int?)`.
  - `audioCaptureFactory` wires the callback to the setter.
  - `AudioPlayback` constructor gets `captureSessionIdProvider = { currentCaptureSessionId }`.
- `app/src/main/java/com/atakmap/android/xv/audio/AudioPlayback.kt`
  - New `captureSessionIdProvider: () -> Int?` constructor param (default `{ null }`).
  - `startTrack`: reads provider; when non-null and non-zero, calls `.setSessionId(id)` on `AudioTrack.Builder`. When null, current behavior (fresh session).

## Observable behavior change

On any RX burst that follows a PTT press, the AudioTrack is now built against the same audio session id Android's AEC is watching for reference. AEC finally has a real downlink signal to subtract from the mic input, so the peer stops hearing themselves through the operator's speakermic.

## Known limitation

The very first RX-before-any-TX still races the same way as today — no capture session exists yet, so the `AudioTrack` gets a fresh session and AEC has nothing to subtract on that first cold burst. The field bug is warm back-and-forth, which this covers. Documenting rather than fixing because a session-up-front approach would need the `@SystemApi` `AudioRecord(int sessionId)` constructor (verified missing from `android-34.jar` / `android-36.jar` public API) or reflection — neither is acceptable here.

## Verification

- `./gradlew ktlintCheck` — pass
- `./gradlew assembleCivDebug` — pass
- `./gradlew testCivDebugUnitTest` — pass

## Test coverage

No new unit tests. `AudioTrack.Builder` + `setSessionId` can't be meaningfully exercised outside a live Android runtime (JNI-backed constructors), and the task guidance says to skip rather than stand up a new test module. Existing suites remain green.

## Test plan

- [ ] Cold-boot device with an AINA V2 speakermic; connect to a channel; have a peer transmit → verify no echo effect on peer side (unchanged first-RX behavior).
- [ ] Press PTT and hold for ~1 s (talk); release; peer immediately transmits back within the SCO_HOT window → verify peer no longer hears their own voice reflected back.
- [ ] Same test on the built-in phone speaker path (no SCO): same expected result on the warm-back-and-forth case.
- [ ] Confirm logcat shows `AudioTrack using capture session id=<N> for AEC linkage` on RX bursts that follow a TX, and `capture session id=<N> — linked for AEC` on TX starts.