### PR TITLE
feat(audio): duck RX during TX to break close-proximity feedback loop

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/audio/AudioPlayback.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/AudioPlayback.kt
@@ -741,8 +741,90 @@ class AudioPlayback(
             }
     }
 
+    // ============================================================
+    // RX ducking during local TX — close-proximity feedback fix.
+    //
+    // When two operators stand near each other, A's PTT transmits
+    // their voice, B's device plays it out its speakermic, and that
+    // playback bleeds into A's mic. A re-transmits it and the loop
+    // closes; if the round-trip acoustic gain is above 1 the system
+    // howls.
+    //
+    // Android's on-device AcousticEchoCanceler only sees THIS
+    // device's own AudioTrack as the reference signal — it cannot
+    // cancel audio arriving from a different device's speaker. The
+    // only native-Android mechanism that reliably breaks this path
+    // is to duck the LOCAL RX playback whenever the LOCAL operator
+    // is TX-active: any peer voice that bleeds into our mic lands
+    // ~15 dB below the noise-gate threshold, round-trip gain drops
+    // well below 1, howl doesn't sustain.
+    //
+    // Scope:
+    //  - Applies only during actual TX-transmitting state, not
+    //    during TPT playback (TPT is our own confirmation tone and
+    //    the operator needs to hear it at full amplitude).
+    //  - Per-track via AudioTrack.setVolume — does NOT touch OS
+    //    stream/comm volume. Non-invasive; leaves the OS audio
+    //    policy untouched and only ducks the currently-live track.
+    //  - Local-only fix: this helps when the local operator is
+    //    TX-active. It does NOT help when both operators are in
+    //    RX simultaneously (no PTT active) and one starts howling
+    //    from residual playback. Peer would need to duck too for
+    //    that case — a per-device local fix by design.
+    //
+    // Called by TxController.startTransmitting / stopInternal via
+    // VoicePlant so the duck is symmetric with the actual on-air
+    // TX window.
+    // ============================================================
+
+    /**
+     * Duck the currently-live RX AudioTrack (if any) while the
+     * local operator is transmitting. [active] = true engages the
+     * duck (multiplies live-track volume by [TX_DUCK_GAIN]);
+     * [active] = false restores unity gain.
+     *
+     * Idempotent and race-safe: if no track exists yet, or if the
+     * track was rebuilt between engage and release, the release
+     * call still applies gain=1.0 to whatever track is live —
+     * matching the AudioTrack "no leftover volume state" invariant.
+     */
+    fun setTxActive(active: Boolean) {
+        val t = track
+        val gain = if (active) TX_DUCK_GAIN else 1.0f
+        if (t != null) {
+            try {
+                t.setVolume(gain)
+            } catch (e: IllegalStateException) {
+                // Track was released between the volatile read and
+                // the setVolume call. Nothing to duck. Not an error.
+                Log.d(TAG, "setTxActive($active): track transitioning, no-op", e)
+                return
+            }
+        }
+        if (active) {
+            Log.i(TAG, "RX duck engaged for TX (gain=$TX_DUCK_GAIN)")
+        } else {
+            Log.i(TAG, "RX duck released")
+        }
+    }
+
     companion object {
         private const val TAG = "XvAudioPlayback"
+
+        // Linear gain applied to the live RX AudioTrack while the
+        // local operator is TX-transmitting. 0.18 ≈ −15 dB, chosen
+        // so peer voices remain barely audible (operator can still
+        // hear that traffic is coming in on the other end) but
+        // sits well below what the mic's noise gate + vendor DSP
+        // treat as "loud playback" — round-trip acoustic gain in
+        // the close-proximity two-device path drops well below 1
+        // and the howl loop can't sustain.
+        //
+        // Starting value; field-tune from operator smoke reports.
+        // If peers report they can't hear inbound traffic at all
+        // during their own TX, raise (less duck). If echo bleed
+        // through the mic still triggers cascading feedback, lower.
+        const val TX_DUCK_GAIN = 0.18f
 
         private val BT_OUTPUT_TYPES =
             setOf(

--- a/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
@@ -233,6 +233,16 @@ class VoicePlant(
             sendTerminator = { slot -> callbacks.onTxTerminator(slot) },
             onPttStateChanged = { transmitting, slot ->
                 callbacks.onPttStateChanged(transmitting, slot)
+                // TX-state edge → duck the RX playback so a peer's
+                // voice bleeding out of our speakermic doesn't feed
+                // back into our mic and create a close-proximity
+                // howl. Fires on the same TX-transmitting edge as
+                // Telecom-end below — no new callback surface — so
+                // duck engage/release is symmetric with the real
+                // on-air window (not TPT, not PRIMING, not
+                // ACQUIRING_SCO). See AudioPlayback.setTxActive
+                // and TX_DUCK_GAIN for the rationale.
+                audioPlayback.setTxActive(transmitting)
                 // TX-state edge → end Telecom call when transmitting
                 // turns false. Covers latched mode (where pttUp is a
                 // no-op but stopInternal still fires this callback on


### PR DESCRIPTION
## Summary

Adds RX playback ducking on the local device while the local operator is TX-transmitting, to break the close-proximity multi-device acoustic feedback path Android's on-device AEC can't reach.

### Field context

Operator report 2026-07-08: "primary concern with the echo is when devices are close by, so I need some sort of DSP or audio suppression algorithm in place that can dynamically suppress audio echo feedbacks. Use native Android functionality."

The path we're targeting:

1. Operator A PTT-down transmits A's voice
2. Operator B's device plays A's voice through B's speakermic
3. A and B are standing close by; B's speakermic playback bleeds into A's mic
4. A retransmits; B hears themselves delayed
5. Round-trip gain > 1 turns this into a sustained howl

Android's `AcousticEchoCanceler` can't cancel this because its reference signal is that device's own `AudioTrack`, not the other device's speaker. Native Android has no first-class API for adaptive across-device cancel. The only native mechanism that reliably breaks the loop on this path is to duck the LOCAL RX playback whenever the LOCAL operator is TX-active. Peer voice bleed into our mic then lands well below the noise-gate + vendor DSP threshold, round-trip gain drops well below 1, and the cascade can't sustain.

### Implementation

- `AudioPlayback` gains a `TX_DUCK_GAIN` companion constant (`0.18f`, ~-15 dB) and a `setTxActive(active: Boolean)` method that calls `track.setVolume(...)` on the live track. Wrapped in a `try/catch(IllegalStateException)` for the concurrent-teardown race.
- `VoicePlant` calls `audioPlayback.setTxActive(transmitting)` from the existing `onPttStateChanged` callback — reuses that surface rather than adding a new one. The callback fires on the true TX-transmitting state edge (only `startTransmitting` fires `true`, only `stopInternal` fires `false` when `wasTransmitting`). PRIMING / TPT / ACQUIRING_SCO are excluded by design.

### Explicitly out of scope

- Does not touch `AudioManager.setStreamVolume` / OS media / comm volume. `AudioTrack.setVolume` is per-track and non-invasive.
- Does not change AEC/NS/AGC policy in `AudioCapture.configureAudioEffects()` or the `KNOWN_GOOD_DSP_DEVICE` list.
- Does not duck for TPT playback (our own confirmation tone stays at full amplitude).

### Log lines added

- Engage: `RX duck engaged for TX (gain=<n>)`
- Release: `RX duck released`

Trivial on-device diagnosis of "is ducking actually firing?" from logcat.

### Honest limitation

This only breaks the loop when the local operator is TX-active. It does NOT help when both peers are in RX simultaneously (neither PTT active) and one starts howling from residual playback bleed. For that case, each peer's device would need to duck too — this is a per-device local fix by design. The counterpart is that every operator running this build benefits their peers automatically as soon as they PTT.

### Rebase note

A parallel `fix/audio-share-aec-session` branch is also touching `AudioPlayback` (session-ID surface). The new duck method was placed as a clearly-marked block at the end of the class body (not mixed with constructor/builder) to minimize merge friction, but a manual rebase against that PR may still be needed depending on merge order.

## Test plan

- [x] `./gradlew ktlintCheck` — green
- [x] `./gradlew assembleCivDebug` — green
- [x] `./gradlew testCivDebugUnitTest` — green
- [ ] Smoke test on two devices standing within ~1 m of each other: operator A keys PTT, verify from logcat that `RX duck engaged` fires at TX start and `RX duck released` fires at TX end
- [ ] Confirm operator A can still hear B's peer voice at all during a rapid back-and-forth (RX volume is ducked, not muted)
- [ ] Confirm TPT tone is at full amplitude on A's device during A's own key-down (duck should not engage until state=TRANSMITTING)
- [ ] Field-tune `TX_DUCK_GAIN` from operator smoke reports — raise if peers say inbound is inaudible during their own TX, lower if bleed still triggers cascade

No unit test added: exercising `setTxActive` end-to-end requires a live `AudioTrack` to observe the `setVolume` call, which needs Robolectric shadow + the full `AudioPlayback` constructor mock chain (Router + BtAudioPolicy + ScoLink + AudioController). The task guidance permits skipping if the surface isn't clean; the two log lines cover on-device observability.