### PR TITLE
fix(aina): release PTT + end burst when BT transport dies mid-TX

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
@@ -1122,18 +1122,45 @@ class VoicePlant(
             } else {
                 kind
             }
-        val onConn: (Boolean) -> Unit = { up ->
-            Log.i(TAG, "AINA connection up=$up")
+        // Per-reader onConn so the disconnect edge can tag the correct
+        // [PttSource] when releasing a stuck PTT-down. Field bug
+        // 2026-07-08: operator keyed AINA V2, turned BT off mid-TX,
+        // burst never terminated because the reader's onConnectionState(
+        // false) only flipped the UI dot — the button-down state in
+        // PttDispatcher was left in place, so the OR-gate never saw an
+        // empty held set and TxController.stop() was never called.
+        // Passing the reader's own source into a synthetic forgetSource
+        // on the down-edge of connection state ends the burst cleanly
+        // (encoder flushes end-frame, TxController returns to IDLE),
+        // and the operator has to re-key on a working transport (screen
+        // PTT / phone mic) to speak again. We deliberately do NOT try
+        // to reroute the in-flight burst to a different transport —
+        // that produces audible mid-word swaps peers hate.
+        val onConn: (source: PttSource, up: Boolean) -> Unit = { source, up ->
+            Log.i(TAG, "AINA connection up=$up source=$source")
             callbacks.onAinaConnectionChanged(up)
+            if (!up) {
+                releaseStuckPttOnTransportDrop(source)
+            }
         }
         when (resolvedKind) {
             "v1", "spp" -> {
-                val r = AinaSppReader(context, primaryAinaEvent(PttSource.AINA_V1), onConn)
+                val r =
+                    AinaSppReader(
+                        context,
+                        primaryAinaEvent(PttSource.AINA_V1),
+                        { up -> onConn(PttSource.AINA_V1, up) },
+                    )
                 ainaSpp = r
                 r.connect(device)
             }
             "v2", "ble" -> {
-                val r = AinaBleReader(context, primaryAinaEvent(PttSource.AINA_V2), onConn)
+                val r =
+                    AinaBleReader(
+                        context,
+                        primaryAinaEvent(PttSource.AINA_V2),
+                        { up -> onConn(PttSource.AINA_V2, up) },
+                    )
                 ainaBle = r
                 r.connect(device)
             }
@@ -1145,7 +1172,12 @@ class VoicePlant(
                 // characteristic (service 00420000-8f59-…, sourced from
                 // VX 2.1.0). Mirrors AinaBleReader's connect / retry
                 // strategy. Fires VS1 only.
-                val r = PrymeBleReader(context, primaryAinaEvent(PttSource.PRYME_BLE), onConn)
+                val r =
+                    PrymeBleReader(
+                        context,
+                        primaryAinaEvent(PttSource.PRYME_BLE),
+                        { up -> onConn(PttSource.PRYME_BLE, up) },
+                    )
                 prymeBle = r
                 r.connect(device)
             }
@@ -1211,24 +1243,47 @@ class VoicePlant(
             } else {
                 kind
             }
-        val onConn: (Boolean) -> Unit = { up ->
-            Log.i(TAG, "Secondary AINA connection up=$up")
+        // Mirror the primary path's per-source disconnect handling —
+        // when the secondary transport drops mid-TX, forget the held
+        // button so the burst can terminate. See the field-bug note in
+        // [connectAina] above; the same failure mode applies to a
+        // handlebar Pryme puck as to a helmet AINA.
+        val onConn: (source: PttSource, up: Boolean) -> Unit = { source, up ->
+            Log.i(TAG, "Secondary AINA connection up=$up source=$source")
             // Secondary doesn't drive the AINA-connected dot in the UI
             // (that's the primary's indicator). Logged only.
+            if (!up) {
+                releaseStuckPttOnTransportDrop(source)
+            }
         }
         when (resolvedKind) {
             "v1", "spp" -> {
-                val r = AinaSppReader(context, secondaryAinaEvent(PttSource.AINA_V1), onConn)
+                val r =
+                    AinaSppReader(
+                        context,
+                        secondaryAinaEvent(PttSource.AINA_V1),
+                        { up -> onConn(PttSource.AINA_V1, up) },
+                    )
                 ainaSecondarySpp = r
                 r.connect(device)
             }
             "v2", "ble" -> {
-                val r = AinaBleReader(context, secondaryAinaEvent(PttSource.AINA_V2), onConn)
+                val r =
+                    AinaBleReader(
+                        context,
+                        secondaryAinaEvent(PttSource.AINA_V2),
+                        { up -> onConn(PttSource.AINA_V2, up) },
+                    )
                 ainaSecondaryBle = r
                 r.connect(device)
             }
             "ble-hid", "hid" -> {
-                val r = PrymeBleReader(context, secondaryAinaEvent(PttSource.PRYME_BLE), onConn)
+                val r =
+                    PrymeBleReader(
+                        context,
+                        secondaryAinaEvent(PttSource.PRYME_BLE),
+                        { up -> onConn(PttSource.PRYME_BLE, up) },
+                    )
                 prymeSecondaryBle = r
                 r.connect(device)
             }
@@ -1271,12 +1326,85 @@ class VoicePlant(
         // BT preference. Operator's explicit override (if any) still wins.
         router.preferredBtMacHint = null
         connectedAinaMac = null
+        // Mirror [disconnectAinaSecondary]: if the operator (or a wholesale
+        // BT-adapter-off cascade) is tearing us down mid-burst, drop any
+        // held button state from the primary source so the OR-gate can
+        // see an empty set and TxController.stop() runs. Idempotent
+        // inside PttDispatcher; safe when nothing was held.
+        try {
+            pttDispatcher.forgetSource(PttSource.AINA_V1)
+            pttDispatcher.forgetSource(PttSource.AINA_V2)
+            pttDispatcher.forgetSource(PttSource.PRYME_BLE)
+        } catch (t: Throwable) {
+            Log.w(TAG, "forgetSource on primary disconnect threw", t)
+        }
         // Notify the plugin so the UI dot can clear and the listener
         // chain (incl. any future reconnect attempts) sees the drop.
         try {
             callbacks.onAinaConnectionChanged(false)
         } catch (t: Throwable) {
             Log.w(TAG, "onAinaConnectionChanged(false) on disconnect threw", t)
+        }
+    }
+
+    /**
+     * Reader-level release path: called from a reader's connection
+     * callback when the transport dies (BLE GATT STATE_DISCONNECTED,
+     * SPP RFCOMM socket closed / IOException) and the reader is NOT
+     * doing an intentional disconnect. If [source] had a live PTT-down
+     * on the dispatcher, this drops it — which through the OR-gate
+     * fires TxController.stop() and lands a clean end-of-burst marker
+     * on the wire.
+     *
+     * Fire-and-forget: this returns immediately so the reader's
+     * teardown / reconnect scheduling isn't blocked. All the heavy
+     * work inside PttDispatcher.forgetSource is a non-blocking
+     * check-and-clear plus a single txController.stop() dispatch.
+     *
+     * Field bug 2026-07-08: AINA V2 held, BT toggled off mid-TX. The
+     * reader's onConnectionStateChange(STATE_DISCONNECTED) fired but
+     * the button-down state stayed pinned in PttDispatcher.heldButtons
+     * — the OR-gate never saw an empty set, TxController stayed in
+     * TRANSMITTING, and the transmit burst never ended. This helper
+     * closes that gap.
+     */
+    private fun releaseStuckPttOnTransportDrop(source: PttSource) {
+        try {
+            Log.w(
+                TAG,
+                "PTT source $source died mid-transmission — forcing release of slot 0",
+            )
+            pttDispatcher.forgetSource(source)
+        } catch (t: Throwable) {
+            Log.w(TAG, "forgetSource on reader disconnect threw", t)
+        }
+    }
+
+    /**
+     * Plugin-level cascade for `BluetoothAdapter.STATE_TURNING_OFF` —
+     * called from [com.atakmap.android.xv.plugin.XvMapComponent]'s
+     * adapter-state receiver. In principle each active reader will
+     * observe its own transport dying and fire the reader-level
+     * release; in practice the OS can tear the BT stack down as a
+     * whole before the readers get their individual GATT / RFCOMM
+     * disconnect edges, so we cascade here as a belt-and-suspenders
+     * safety net.
+     *
+     * Idempotent: forgetSource is a no-op when no PTT-down is
+     * outstanding for that source. Never blocks — the receiver
+     * fires on the main thread and this method returns immediately.
+     */
+    fun releaseAllBtSourcedPtt() {
+        try {
+            Log.w(
+                TAG,
+                "BluetoothAdapter STATE_TURNING_OFF — cascading PTT release across all BT sources",
+            )
+            pttDispatcher.forgetSource(PttSource.AINA_V1)
+            pttDispatcher.forgetSource(PttSource.AINA_V2)
+            pttDispatcher.forgetSource(PttSource.PRYME_BLE)
+        } catch (t: Throwable) {
+            Log.w(TAG, "releaseAllBtSourcedPtt threw", t)
         }
     }
 

--- a/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
@@ -146,7 +146,67 @@ class XvVoiceService : Service() {
         } catch (t: Throwable) {
             Log.w(TAG, "registerReceiver(activeCallReceiver) threw", t)
         }
+
+        // Field bug 2026-07-08: operator holds an AINA V2 mid-TX, then
+        // turns Bluetooth OFF on the phone. The individual reader's
+        // BLE `onConnectionStateChange(STATE_DISCONNECTED)` MAY arrive
+        // late (or on some OEM stacks not at all) when the OS is
+        // tearing the BT stack down wholesale — so the reader-level
+        // release path in [VoicePlant] can miss the edge. Register a
+        // plugin-lifetime `BluetoothAdapter.ACTION_STATE_CHANGED`
+        // listener as belt-and-suspenders. On `STATE_TURNING_OFF` (fires
+        // slightly before `STATE_OFF`, giving us a window before the
+        // GATT / RFCOMM handles have all torn themselves down), cascade
+        // a forgetSource across every BT-sourced PttSource so any
+        // in-flight burst can terminate cleanly and the operator has to
+        // re-key on a working transport (screen PTT / phone mic) to
+        // speak again. Idempotent when nothing is held.
+        val btAdapterFilter =
+            android.content.IntentFilter(android.bluetooth.BluetoothAdapter.ACTION_STATE_CHANGED)
+        try {
+            ContextCompat.registerReceiver(
+                this,
+                btAdapterStateReceiver,
+                btAdapterFilter,
+                ContextCompat.RECEIVER_NOT_EXPORTED,
+            )
+        } catch (t: Throwable) {
+            Log.w(TAG, "registerReceiver(btAdapterStateReceiver) threw", t)
+        }
     }
+
+    // Fires on `BluetoothAdapter.ACTION_STATE_CHANGED`. On
+    // `STATE_TURNING_OFF` we cascade a PTT release across all BT-sourced
+    // inputs — see the registration site in onCreate for the field bug
+    // this closes.
+    private val btAdapterStateReceiver =
+        object : android.content.BroadcastReceiver() {
+            override fun onReceive(
+                c: Context,
+                intent: Intent,
+            ) {
+                if (intent.action != android.bluetooth.BluetoothAdapter.ACTION_STATE_CHANGED) return
+                val state =
+                    intent.getIntExtra(
+                        android.bluetooth.BluetoothAdapter.EXTRA_STATE,
+                        android.bluetooth.BluetoothAdapter.ERROR,
+                    )
+                if (state != android.bluetooth.BluetoothAdapter.STATE_TURNING_OFF &&
+                    state != android.bluetooth.BluetoothAdapter.STATE_OFF
+                ) {
+                    return
+                }
+                Log.w(
+                    TAG,
+                    "BluetoothAdapter state=$state — cascading BT-sourced PTT release",
+                )
+                try {
+                    plant?.releaseAllBtSourcedPtt()
+                } catch (t: Throwable) {
+                    Log.w(TAG, "releaseAllBtSourcedPtt threw", t)
+                }
+            }
+        }
 
     private val activeCallReceiver =
         object : android.content.BroadcastReceiver() {
@@ -379,6 +439,13 @@ class XvVoiceService : Service() {
             // C2 fix: prior code only unregistered incomingDecisionReceiver;
             // activeCallReceiver leaked, fired IntentReceiverLeaked WARN
             // every service teardown and crashed on strict OEM builds.
+        }
+        try {
+            unregisterReceiver(btAdapterStateReceiver)
+        } catch (_: Throwable) {
+            // Same rationale as activeCallReceiver above — always try,
+            // swallow "not registered" so an early-crash teardown path
+            // doesn't add its own noise.
         }
         com.atakmap.android.xv.telecom.ActiveCallRegistry.serviceContext = null
         // Make sure the CallStyle ring + active-call notifications

--- a/app/src/test/java/com/atakmap/android/xv/service/BtTransportDropReleasesPttTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/service/BtTransportDropReleasesPttTest.kt
@@ -1,0 +1,171 @@
+package com.atakmap.android.xv.service
+
+import android.bluetooth.BluetoothAdapter
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.atakmap.android.xv.audio.PttDispatcher
+import com.atakmap.android.xv.audio.PttSource
+import com.atakmap.android.xv.audio.StatusTones
+import com.atakmap.android.xv.audio.TxController
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Regression coverage for field bug 2026-07-08: operator holds AINA V2
+ * PTT, turns Bluetooth OFF on the phone mid-transmission. The reader's
+ * BLE `onConnectionStateChange(STATE_DISCONNECTED)` fires (or the OS
+ * tears BT down wholesale via `BluetoothAdapter.ACTION_STATE_CHANGED`),
+ * but before this fix the button-down state was left pinned in
+ * [PttDispatcher.heldButtons]. The OR-gate never saw an empty set, so
+ * [TxController.stop] was never called and the transmit burst never
+ * ended.
+ *
+ * These tests reproduce the exact dispatch shape of the two release
+ * paths added in this PR — mirroring the pattern in
+ * [VoicePlantBondNoneTest] where standing up a real [VoicePlant] would
+ * pull in AudioController + AudioRouter + ScoLink + TxController, which
+ * is more surface than the contract needs.
+ *
+ * The paths under test are:
+ *
+ *   1. **Reader-level release** — the `onConn` callback attached to
+ *      each reader (see [VoicePlant.connectAina]) calls
+ *      `pttDispatcher.forgetSource(source)` on the drop edge.
+ *   2. **Plugin-level cascade** — the `BluetoothAdapter.STATE_TURNING_OFF`
+ *      receiver in [XvVoiceService] calls
+ *      [VoicePlant.releaseAllBtSourcedPtt], which forgets every BT
+ *      [PttSource].
+ */
+@RunWith(RobolectricTestRunner::class)
+class BtTransportDropReleasesPttTest {
+    private fun buildDispatcher(txController: TxController): PttDispatcher =
+        PttDispatcher(
+            txController = txController,
+            statusTones = mockk<StatusTones>(relaxed = true),
+            latchedModeEnabled = { false },
+            momentaryTimeoutSec = { 0 },
+            latchedTimeoutSec = { 0 },
+            tptPlayer = null,
+        )
+
+    // Simulates the shape of the reader `onConn` lambda in
+    // [VoicePlant.connectAina] — on a false connection edge, forget
+    // the reader's source so the OR-gate can see an empty held set.
+    private fun readerConnCallback(
+        dispatcher: PttDispatcher,
+        source: PttSource,
+    ): (Boolean) -> Unit =
+        { up ->
+            if (!up) dispatcher.forgetSource(source)
+        }
+
+    @Test
+    fun `reader disconnect edge releases held PTT for that source`() {
+        // Field-bug repro: AINA V2 keyed, then BT dies mid-burst.
+        val tx = mockk<TxController>(relaxed = true)
+        val dispatcher = buildDispatcher(tx)
+        // Simulate an in-flight burst from the AINA V2 reader.
+        dispatcher.down(slot = 0, source = PttSource.AINA_V2)
+
+        // Reader's onConn(false) fires — via the wire-up added in
+        // [VoicePlant.connectAina], this must forget PttSource.AINA_V2.
+        val callback = readerConnCallback(dispatcher, PttSource.AINA_V2)
+        callback(false)
+
+        // Burst terminated — TxController.stop() was invoked exactly
+        // once by forgetSource's "held set empty" branch.
+        verify(exactly = 1) { tx.stop() }
+    }
+
+    @Test
+    fun `reader disconnect leaves TX engaged when another source is still held`() {
+        // Multi-source scenario: motorcyclist's helmet AINA drops but
+        // the handlebar Pryme puck is still pressed. TX must stay
+        // engaged on the surviving source; the disconnected source's
+        // forget path can't tear the burst down under the surviving
+        // source's feet.
+        val tx = mockk<TxController>(relaxed = true)
+        val dispatcher = buildDispatcher(tx)
+        dispatcher.down(slot = 0, source = PttSource.AINA_V2)
+        dispatcher.down(slot = 0, source = PttSource.PRYME_BLE)
+
+        readerConnCallback(dispatcher, PttSource.AINA_V2)(false)
+
+        verify(exactly = 0) { tx.stop() }
+    }
+
+    @Test
+    fun `adapter STATE_TURNING_OFF cascades release across all BT sources`() {
+        // Wholesale BT teardown: individual readers may not observe
+        // their transport dropping fast enough on some OEM stacks, so
+        // the adapter-state receiver in [XvVoiceService] cascades a
+        // release across every BT [PttSource]. This mirrors the exact
+        // dispatch shape of that receiver — action filter on
+        // ACTION_STATE_CHANGED, EXTRA_STATE = STATE_TURNING_OFF,
+        // then a call into [VoicePlant.releaseAllBtSourcedPtt].
+        val tx = mockk<TxController>(relaxed = true)
+        val dispatcher = buildDispatcher(tx)
+        dispatcher.down(slot = 0, source = PttSource.AINA_V1)
+
+        val receiver = makeAdapterReceiver { dispatcher.releaseAllBtSourcedPttTestHook() }
+        receiver.onReceive(mockk(relaxed = true), turningOffIntent())
+
+        verify(exactly = 1) { tx.stop() }
+    }
+
+    @Test
+    fun `adapter STATE_ON is ignored (no spurious release)`() {
+        val tx = mockk<TxController>(relaxed = true)
+        val dispatcher = buildDispatcher(tx)
+        dispatcher.down(slot = 0, source = PttSource.AINA_V1)
+
+        val receiver = makeAdapterReceiver { dispatcher.releaseAllBtSourcedPttTestHook() }
+        val onIntent =
+            Intent(BluetoothAdapter.ACTION_STATE_CHANGED).apply {
+                putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_ON)
+            }
+        receiver.onReceive(mockk(relaxed = true), onIntent)
+
+        // Held state intact — the burst is still in flight.
+        verify(exactly = 0) { tx.stop() }
+    }
+
+    // Reproduces the receiver body in [XvVoiceService.btAdapterStateReceiver].
+    // On STATE_TURNING_OFF or STATE_OFF, invoke the release cascade.
+    private fun makeAdapterReceiver(release: () -> Unit): BroadcastReceiver =
+        object : BroadcastReceiver() {
+            override fun onReceive(
+                c: Context?,
+                i: Intent?,
+            ) {
+                if (i?.action != BluetoothAdapter.ACTION_STATE_CHANGED) return
+                val state = i.getIntExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.ERROR)
+                if (state == BluetoothAdapter.STATE_TURNING_OFF ||
+                    state == BluetoothAdapter.STATE_OFF
+                ) {
+                    release()
+                }
+            }
+        }
+
+    private fun turningOffIntent(): Intent =
+        Intent(BluetoothAdapter.ACTION_STATE_CHANGED).apply {
+            putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_TURNING_OFF)
+        }
+
+    /**
+     * Helper extension: emulates [VoicePlant.releaseAllBtSourcedPtt]'s
+     * body without needing a real VoicePlant. Kept beside this test
+     * only — the production version lives in [VoicePlant] and is what
+     * the [XvVoiceService] receiver actually calls.
+     */
+    private fun PttDispatcher.releaseAllBtSourcedPttTestHook() {
+        forgetSource(PttSource.AINA_V1)
+        forgetSource(PttSource.AINA_V2)
+        forgetSource(PttSource.PRYME_BLE)
+    }
+}


### PR DESCRIPTION
## Summary

Field bug 2026-07-08: operator holds AINA V2 PTT, then turns Bluetooth off on the phone while still holding the button. Before this fix, the PTT-down state was left pinned on the (now-dead) BT source in `PttDispatcher.heldButtons`, so the OR-gate never saw an empty held set, `TxController` stayed in TRANSMITTING, and the transmit burst never terminated (no end marker on the wire, encoder state stuck).

Two release paths, belt-and-suspenders:

- **Reader-level**: each primary/secondary reader's `onConn` callback now tags its own `PttSource` and fires `PttDispatcher.forgetSource` on the disconnect edge. `forgetSource` already cascades to `TxController.stop()` when the forgotten source was the only holder. Fire-and-forget from inside the reader callback — reader teardown / reconnect scheduling is not blocked. `disconnectAina()` also gains the same forget cascade so operator-initiated disconnects mid-hold work identically to the `disconnectAinaSecondary` path that already had it.
- **Plugin-lifetime cascade**: `XvVoiceService` now hosts a `BluetoothAdapter.ACTION_STATE_CHANGED` receiver that on `STATE_TURNING_OFF` / `STATE_OFF` cascades a release across every BT-sourced `PttSource` via `VoicePlant.releaseAllBtSourcedPtt`. Catches the case where the OS tears the BT stack down wholesale before individual reader disconnect edges fire.

We deliberately do NOT try to reroute the in-flight burst to the phone mic — that produces audible mid-word transport swaps peers hate. Operator has to re-key on a working transport (on-screen PTT / phone mic) to speak again; the routing agent's normal path handles fallback on the next key.

## Loss modes covered

- **Adapter STATE_TURNING_OFF** — belt-and-suspenders receiver fires before per-reader edges land.
- **BLE GATT `STATE_DISCONNECTED`** — reader-level release via `onConnectionStateChange`.
- **SPP RFCOMM socket closed / IOException** — reader-level release via read-loop exit → `onConnectionState(false)`.
- **Speakermic powered off** — same reader-level edge as out-of-range.
- **Out-of-range** — reader-level edge fires promptly; adapter cascade is a no-op because adapter stayed ON.

## Test plan

- [x] `./gradlew ktlintCheck` — passes
- [x] `./gradlew assembleCivDebug` — passes
- [x] `./gradlew testCivDebugUnitTest` — passes (new `BtTransportDropReleasesPttTest` — 4 tests, all green; existing `PttDispatcherTest` unchanged and green)
- [ ] Field: hold AINA V2 PTT, toggle BT off; verify transmit burst terminates and re-key works
- [ ] Field: hold AINA V1 (SPP) PTT, walk out of BR/EDR range; verify burst terminates via read-loop exit path
- [ ] Field: motorcyclist multi-source — hold both primary AINA and secondary Pryme, disconnect primary; verify TX stays engaged on the surviving Pryme

🤖 Generated with [Claude Code](https://claude.com/claude-code)