### PR TITLE
feat(bt): device lifecycle — startup UX, availability tracking, mid-TX loss cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ and feature polish.
    V1 and similar Pryme speakermics) and BLE GATT devices (AINA APTT V2,
    Pryme BT-PTT-Z).
 
+4. **Reachability-aware BT device picker.** On plugin load, XV restores
+   the last-connected speakermic when it's actually reachable and
+   otherwise auto-picks the first live device — a bonded-but-off puck
+   no longer wins over a powered speakermic. The Settings picker paints
+   unreachable rows dim and non-tappable so operators can see at a
+   glance which pairing is live. If a picked BT device stays
+   unreachable for 15 s during a session, XV falls back to the phone
+   speaker while preserving the operator's preferred MAC so audio
+   returns to BT as soon as the device reconnects.
+
 XV also adds:
 
 - **Per-device defaults with overrides** — each supported speakermic

--- a/app/src/main/java/com/atakmap/android/xv/aina/AinaDeviceClassifier.kt
+++ b/app/src/main/java/com/atakmap/android/xv/aina/AinaDeviceClassifier.kt
@@ -121,6 +121,24 @@ object AinaDeviceClassifier {
             AinaDeviceInfo.ButtonProtocol.UNKNOWN -> 4
         }
 
+    // Composite picker sort used by the settings dropdown. Pulled out
+    // as a pure function so unit tests can pin the ordering without
+    // needing a live BluetoothAdapter — the field UX contract is:
+    //   1. Currently-reachable devices first (visually normal, tappable).
+    //   2. Then by protocol per [protocolOrder].
+    //   3. Then by lowercase name for a stable order across refreshes.
+    // Inspired by how modern call-picker UIs (Meet, WhatsApp Calls, the
+    // AOSP device-chooser dialog) rank reachable devices ahead of the
+    // stale-but-remembered set.
+    fun rankForPicker(devices: List<AinaDeviceInfo>): List<AinaDeviceInfo> =
+        devices.sortedWith(
+            compareBy(
+                { if (it.available) 0 else 1 },
+                { protocolOrder(it.buttonProtocol) },
+                { it.name.lowercase() },
+            ),
+        )
+
     private fun safeName(device: BluetoothDevice): String? =
         try {
             device.name

--- a/app/src/main/java/com/atakmap/android/xv/aina/AinaDeviceInfo.kt
+++ b/app/src/main/java/com/atakmap/android/xv/aina/AinaDeviceInfo.kt
@@ -13,6 +13,19 @@ data class AinaDeviceInfo(
     val mac: String,
     val name: String,
     val buttonProtocol: ButtonProtocol,
+    // Live-reachability hint used by the settings picker. `true` when
+    // the device is currently reachable as a communication-audio
+    // endpoint (i.e. present in AudioManager.getAvailableCommunicationDevices
+    // on API 31+) OR when we can't yet tell (pre-S, missing permission,
+    // BLE-only PTT with no audio profile). `false` when the device is
+    // bonded / known but not currently reachable — the picker paints
+    // these rows dim + disabled so the operator sees at a glance which
+    // devices are live vs. stale.
+    //
+    // Defaults to true so unit tests and older callers that construct
+    // AinaDeviceInfo directly don't need to be updated — the picker
+    // renders "available" the same way it always did.
+    val available: Boolean = true,
 ) {
     enum class ButtonProtocol(
         val display: String,

--- a/app/src/main/java/com/atakmap/android/xv/audio/AudioRouter.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/AudioRouter.kt
@@ -64,11 +64,13 @@ class AudioRouter(
         object : AudioDeviceCallback() {
             override fun onAudioDevicesAdded(addedDevices: Array<out AudioDeviceInfo>) {
                 logDevices("added", addedDevices)
+                reevaluateBtHintAvailability()
                 notifyChange()
             }
 
             override fun onAudioDevicesRemoved(removedDevices: Array<out AudioDeviceInfo>) {
                 logDevices("removed", removedDevices)
+                reevaluateBtHintAvailability()
                 notifyChange()
             }
         }
@@ -90,6 +92,11 @@ class AudioRouter(
     fun stop() {
         audioManager.unregisterAudioDeviceCallback(deviceCallback)
         unregisterBecomingNoisyReceiver()
+        // Cancel any armed speaker-fallback runnable so it doesn't
+        // fire after we've torn down (listeners.clear below would
+        // make the fan-out a no-op, but the log noise and the flag
+        // state would still linger for the next start()).
+        clearSpeakerFallback("router stopped")
         listeners.clear()
     }
 
@@ -201,9 +208,147 @@ class AudioRouter(
             field = value
             if (old != value) {
                 Log.i(TAG, "preferredBtMacHint: $old -> $value")
+                // Hint changed — reset the speaker-fallback timer.
+                // Setting the hint to a new device gives the device a
+                // fresh grace window to appear before we fall back;
+                // clearing the hint (voluntary disconnect) always
+                // exits fallback mode.
+                clearSpeakerFallback("hint changed to $value")
+                reevaluateBtHintAvailability()
                 notifyChangeFromOperator()
             }
         }
+
+    // ============================================================
+    // Fallback-to-speaker lifecycle (feat/bt-device-startup-ux)
+    // ============================================================
+    //
+    // Field 2026-07-08: operators reported that when a picked BT
+    // speakermic disconnects mid-session (battery, out of range, puck
+    // gets bumped off) the plugin sits mute — nothing routes audio to
+    // the phone speaker as a graceful fallback. The user's preferred
+    // MAC is preserved (correct — they still want that puck when it
+    // comes back), but silence is not a useful state during a live
+    // session.
+    //
+    // This block adds a grace-period timer: while a BT hint is set
+    // AND that MAC is NOT present in the audio-device output list,
+    // start a countdown. If the countdown elapses without the device
+    // reappearing, flip [speakerFallbackActive] and re-notify listeners
+    // — [preferredDevice] then routes to the internal speaker while
+    // keeping the hint (and the operator's persisted AINA MAC) intact.
+    // When the device reconnects, we clear the fallback and audio
+    // routes back to BT on the next fan-out.
+    //
+    // Constant is public so tests / operator docs can reference the
+    // grace window we chose.
+    @Volatile
+    private var speakerFallbackActive: Boolean = false
+
+    @Volatile
+    private var pendingSpeakerFallback: Runnable? = null
+
+    /**
+     * True while the AudioRouter has fallen back to the built-in
+     * speaker because the operator's preferred BT device stayed
+     * unavailable for [BT_UNAVAILABLE_SPEAKER_FALLBACK_MS]. Cleared
+     * automatically when the device reconnects.
+     */
+    fun isSpeakerFallbackActive(): Boolean = speakerFallbackActive
+
+    /**
+     * Arms or disarms the speaker-fallback timer based on whether the
+     * currently-set BT hint is present in the AudioManager output list.
+     * Called from the AudioDeviceCallback edges and from the setter
+     * for [preferredBtMacHint]. Cheap — one enumeration of outputs.
+     */
+    private fun reevaluateBtHintAvailability() {
+        val hint = preferredBtMacHint ?: run {
+            // No BT hint set — no notion of "our preferred device is
+            // missing." Cancel any pending fallback + reset the
+            // active flag so we don't linger in fallback mode
+            // indefinitely after the operator picks "(none)".
+            clearSpeakerFallback("hint is null")
+            return
+        }
+        val outputs =
+            try {
+                audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+            } catch (t: Throwable) {
+                Log.w(TAG, "reevaluateBtHintAvailability: getDevices threw", t)
+                return
+            }
+        val present = outputs.any { it.isBluetooth() && it.address == hint }
+        if (present) {
+            // The device just came back (or was already there and this
+            // is a spurious re-eval). Cancel any armed fallback timer
+            // and, if we were in fallback mode, clear it — [notifyChange]
+            // called by the AudioDeviceCallback will fan out and let
+            // AudioPlayback rebuild against the BT device.
+            clearSpeakerFallback("hint $hint is reachable")
+        } else if (pendingSpeakerFallback == null && !speakerFallbackActive) {
+            // Device is absent and we haven't already committed to
+            // fallback. Arm the timer.
+            armSpeakerFallback(hint)
+        }
+    }
+
+    private fun armSpeakerFallback(hint: String) {
+        Log.i(
+            TAG,
+            "arming speaker-fallback timer — hint=$hint absent, will fire in " +
+                "${BT_UNAVAILABLE_SPEAKER_FALLBACK_MS / 1000}s if not restored",
+        )
+        val runnable =
+            Runnable {
+                pendingSpeakerFallback = null
+                if (speakerFallbackActive) return@Runnable
+                val currentHint = preferredBtMacHint
+                if (currentHint == null) {
+                    Log.i(TAG, "speaker-fallback fired but hint cleared — skipping")
+                    return@Runnable
+                }
+                val stillMissing =
+                    try {
+                        audioManager
+                            .getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+                            .none { it.isBluetooth() && it.address == currentHint }
+                    } catch (t: Throwable) {
+                        Log.w(TAG, "speaker-fallback re-check threw", t)
+                        false
+                    }
+                if (!stillMissing) {
+                    Log.i(TAG, "speaker-fallback fired but hint $currentHint reappeared — skipping")
+                    return@Runnable
+                }
+                Log.w(
+                    TAG,
+                    "speaker-fallback firing — hint=$currentHint has been unreachable " +
+                        "for ${BT_UNAVAILABLE_SPEAKER_FALLBACK_MS / 1000}s; falling back to " +
+                        "phone speaker (operator MAC preserved for re-connect)",
+                )
+                speakerFallbackActive = true
+                // Fan out so AudioPlayback / VoicePlant re-pick the
+                // route immediately — [preferredDevice] now returns
+                // the internal speaker regardless of the hint.
+                notifyChangeFromOperator()
+            }
+        pendingSpeakerFallback = runnable
+        mainHandler.postDelayed(runnable, BT_UNAVAILABLE_SPEAKER_FALLBACK_MS)
+    }
+
+    private fun clearSpeakerFallback(reason: String) {
+        val hadPending = pendingSpeakerFallback != null
+        pendingSpeakerFallback?.let { mainHandler.removeCallbacks(it) }
+        pendingSpeakerFallback = null
+        if (speakerFallbackActive) {
+            Log.i(TAG, "clearing speaker-fallback — reason=$reason")
+            speakerFallbackActive = false
+            notifyChangeFromOperator()
+        } else if (hadPending) {
+            Log.i(TAG, "cancelling pending speaker-fallback — reason=$reason")
+        }
+    }
 
     // Optional override: a BT MAC address. When set AND that device is
     // currently connected, [preferredDevice] returns it instead of
@@ -257,6 +402,21 @@ class AudioRouter(
     // phone) — Android will pick.
     fun preferredDevice(): AudioDeviceInfo? {
         val outputs = audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+
+        // -1) Speaker fallback (feat/bt-device-startup-ux). When the
+        //     operator's preferred BT device has been unreachable for
+        //     [BT_UNAVAILABLE_SPEAKER_FALLBACK_MS] we deliberately
+        //     skip the BT / wired chain and route to the phone
+        //     speaker. Cleared automatically when the device
+        //     reconnects (see [reevaluateBtHintAvailability]).
+        if (speakerFallbackActive) {
+            val speaker = outputs.firstOrNull { it.type == AudioDeviceInfo.TYPE_BUILTIN_SPEAKER }
+            if (speaker != null) {
+                Log.i(TAG, "preferred: ${describe(speaker)} (speaker fallback active)")
+                return speaker
+            }
+            Log.w(TAG, "speaker fallback active but no BUILTIN_SPEAKER output present — dropping through")
+        }
 
         // 0) Explicit BT override — operator picked a specific BT
         //    audio device (e.g. car BT, headphones) that should win
@@ -442,6 +602,27 @@ class AudioRouter(
 
     companion object {
         private const val TAG = "XvAudioRouter"
+
+        /**
+         * How long the operator's preferred BT device (the AINA /
+         * speakermic that matches [preferredBtMacHint]) is allowed to
+         * stay unreachable in the audio-device output list before
+         * [preferredDevice] falls back to the built-in phone speaker.
+         *
+         * 15s is a balance of two field constraints:
+         *   - Short enough that a live session doesn't sit mute after
+         *     an accidental disconnect (battery, out of range, puck
+         *     bumped off).
+         *   - Long enough to ride out a routine ~5s BT profile-reset
+         *     (SCO teardown / re-establish that happens on some
+         *     handsets around A2DP mode changes) without a spurious
+         *     speaker chirp mid-transmission.
+         *
+         * The operator's persisted MAC is NOT cleared while fallback
+         * is active — as soon as the device reappears in the output
+         * list we exit fallback and route back to BT.
+         */
+        const val BT_UNAVAILABLE_SPEAKER_FALLBACK_MS: Long = 15_000L
 
         /**
          * Pure type + address carrier for the audio-device selector

--- a/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
+++ b/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
@@ -2272,31 +2272,90 @@ class XvMapComponent : AbstractMapComponent() {
         // since classify() is keyed off it for the HFP_ONLY decision.
         android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
             val ctx = heldPluginContext ?: return@postDelayed
+            // Startup-picker inputs. We compute the picker list up
+            // front so both branches (restore-saved and auto-pick-
+            // first-available) can consult live reachability rather
+            // than blindly reconnecting to a MAC that's bonded but
+            // powered off. This is the fix for the 2026-07-08 field
+            // report: "on startup XV was connecting to a device that
+            // wasn't even available."
+            val candidates = listBondedAinaDevices()
             val savedMac = settings.persistedAinaMac()
             if (savedMac != null) {
-                // Explicit operator pick wins — always restore it.
-                connectSavedAinaPrimary(ctx, savedMac)
-                return@postDelayed
-            }
-            if (!settings.persistedAutoConnectBtEnabled()) {
+                // Explicit operator pick wins IF that device is
+                // currently reachable. Falling through to auto-pick
+                // when the saved MAC is bonded-but-off lets the
+                // operator's session actually route to whatever puck
+                // they turned on, instead of stalling on a stale
+                // preference. The saved MAC is deliberately NOT
+                // cleared — when the operator's preferred device
+                // powers back on, the picker refresh + next launch
+                // will restore it as first-class.
+                val saved = candidates.firstOrNull { it.mac.equals(savedMac, ignoreCase = true) }
+                if (saved != null && saved.available) {
+                    Log.i(
+                        TAG,
+                        "autoConnectAina: saved selection $savedMac is reachable — restoring",
+                    )
+                    connectSavedAinaPrimary(ctx, savedMac)
+                    return@postDelayed
+                }
+                if (saved != null && !saved.available) {
+                    Log.i(
+                        TAG,
+                        "autoConnectAina: saved selection $savedMac bonded but not currently reachable — " +
+                            "considering first-available fallback (saved pref preserved)",
+                    )
+                } else {
+                    Log.i(
+                        TAG,
+                        "autoConnectAina: saved MAC $savedMac not in picker list — " +
+                            "considering first-available fallback",
+                    )
+                }
+                // Fall through to auto-pick below, but only if the
+                // operator hasn't disabled auto-connect. That toggle
+                // is the "I'll pick manually" opt-out for operators
+                // running multiple speakermics for testing — respect
+                // it even when the saved device is off.
+                if (!settings.persistedAutoConnectBtEnabled()) {
+                    Log.i(
+                        TAG,
+                        "autoConnectAina: auto-connect disabled — leaving saved pref in place, no connect",
+                    )
+                    return@postDelayed
+                }
+            } else if (!settings.persistedAutoConnectBtEnabled()) {
                 Log.i(TAG, "autoConnectAina: no saved selection and auto-connect disabled — skipping")
                 return@postDelayed
             }
-            // Auto-pick: scan bonded devices for the first compatible
-            // speakermic / BLE PTT button. listBondedAinaDevices already
-            // filters by AinaDeviceClassifier.isPlausibleSpeakermic AND
-            // sorts SPP → BLE → BLE_HID so a speakermic always beats a
-            // button-only puck for the primary slot. Picking the first
-            // entry is a "smart default" — operator can override by
-            // picking a different device in Settings → Preferences,
-            // and that pick then persists.
-            val candidates = listBondedAinaDevices()
+            // Auto-pick: prefer the first AVAILABLE compatible device
+            // in the picker list. listBondedAinaDevices already sorts
+            // available-first, then by protocol (SPP → BLE → BLE_HID)
+            // so a live speakermic always beats a stale one AND a
+            // speakermic always beats a button-only puck for the
+            // primary slot. If no device is marked available we
+            // deliberately do NOT connect — auto-connecting to a
+            // device that isn't live just to satisfy an old MAC hint
+            // is the exact bug we're fixing.
             if (candidates.isEmpty()) {
                 Log.i(TAG, "autoConnectAina: no compatible bonded device found — nothing to auto-pick")
                 return@postDelayed
             }
-            val picked = candidates.first()
-            Log.i(TAG, "autoConnectAina: auto-picked compatible device → ${picked.name} ${picked.mac} (${picked.buttonProtocol})")
+            val picked = candidates.firstOrNull { it.available }
+            if (picked == null) {
+                Log.i(
+                    TAG,
+                    "autoConnectAina: ${candidates.size} bonded candidate(s) found but none currently reachable — " +
+                        "waiting for one to come up",
+                )
+                return@postDelayed
+            }
+            Log.i(
+                TAG,
+                "autoConnectAina: auto-picked first-available device → ${picked.name} ${picked.mac} " +
+                    "(${picked.buttonProtocol})",
+            )
             // Persist so it sticks across launches AND so the picker UI
             // shows the auto-picked device as the current selection.
             // Operator can change the pick later; "(none)" in the
@@ -2338,6 +2397,43 @@ class XvMapComponent : AbstractMapComponent() {
     // Settings → Preferences: AINA picker + TX/RX persistence
     // ============================================================
 
+    // Snapshot of MACs currently reachable as communication-audio
+    // endpoints. Intersecting the bonded-device set against this on the
+    // picker gives operators an at-a-glance "which of my paired devices
+    // is actually live right now?" — the field bug we're fixing had the
+    // picker showing four bonded speakermics with no visual difference
+    // between the one that was powered on and the three that had been
+    // off for weeks.
+    //
+    // Uses [AudioManager.getAvailableCommunicationDevices] on API 31+
+    // because bond state alone isn't enough — a bonded HFP device may
+    // still not be routable to setCommunicationDevice until its profile
+    // is connected in the audio policy. On pre-S (or when AudioManager
+    // throws) we return null and the caller marks everything as
+    // "available=true" so the picker degrades gracefully to the
+    // pre-change behavior.
+    //
+    // MACs are upper-cased so the caller's lookup is case-insensitive.
+    private fun reachableCommunicationMacsSnapshot(): Set<String>? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return null
+        val ctx = heldMapView?.context ?: heldPluginContext ?: return null
+        val am =
+            try {
+                ctx.getSystemService(Context.AUDIO_SERVICE) as? android.media.AudioManager
+            } catch (t: Throwable) {
+                Log.w(TAG, "reachableCommunicationMacsSnapshot: AUDIO_SERVICE threw", t)
+                null
+            } ?: return null
+        return try {
+            am.availableCommunicationDevices
+                .mapNotNull { it.address?.takeIf { addr -> addr.isNotBlank() }?.uppercase() }
+                .toSet()
+        } catch (t: Throwable) {
+            Log.w(TAG, "reachableCommunicationMacsSnapshot: availableCommunicationDevices threw", t)
+            null
+        }
+    }
+
     @SuppressWarnings("MissingPermission")
     private fun listBondedAinaDevices(): List<com.atakmap.android.xv.aina.AinaDeviceInfo> {
         val adapter = BluetoothAdapter.getDefaultAdapter() ?: return emptyList()
@@ -2348,6 +2444,10 @@ class XvMapComponent : AbstractMapComponent() {
                 Log.w(TAG, "listBondedAinaDevices: bondedDevices threw", t)
                 return emptyList()
             }
+        // Live-reachability snapshot (null when we can't ask — pre-S
+        // or missing service). null → treat every candidate as
+        // "available" so we degrade to the legacy picker rendering.
+        val reachableMacs = reachableCommunicationMacsSnapshot()
         // Show every bonded device that's plausibly a speakermic — i.e.
         // anything with HFP / SCO / SPP / known BLE PTT service in its
         // SDP cache, OR anything whose BT major class is AUDIO_VIDEO.
@@ -2421,10 +2521,26 @@ class XvMapComponent : AbstractMapComponent() {
             candidates
                 .filter { it.third }
                 .map { (dev, proto, _) ->
+                    // BLE-HID buttons never appear in the audio-policy
+                    // communication-device list (they're HID over GATT,
+                    // not a routable audio endpoint), so we can't ask
+                    // AudioManager whether they're reachable. Mark them
+                    // as "available=true" so the picker doesn't dim
+                    // every BLE PTT puck the operator has ever paired.
+                    // For SPP / BLE / AUDIO_ONLY the audio-policy check
+                    // is authoritative; when we couldn't take a snapshot
+                    // (reachableMacs == null) fall back to "available".
+                    val isAvailable =
+                        when {
+                            reachableMacs == null -> true
+                            proto == com.atakmap.android.xv.aina.AinaDeviceInfo.ButtonProtocol.BLE_HID -> true
+                            else -> reachableMacs.contains(dev.address.uppercase())
+                        }
                     com.atakmap.android.xv.aina.AinaDeviceInfo(
                         mac = dev.address,
                         name = dev.name ?: dev.address,
                         buttonProtocol = proto,
+                        available = isAvailable,
                     )
                 }
         // Merge manually-added BLE PTT devices (PTT-Z01, Pryme
@@ -2435,6 +2551,11 @@ class XvMapComponent : AbstractMapComponent() {
         // precedence for the name (operator-visible label from the
         // scan-and-pick dialog) but we defer to a bonded entry if
         // both exist to preserve any live classifier result.
+        //
+        // Known BLE PTT are always marked available — they connect via
+        // BluetoothAdapter.getRemoteDevice on demand, never appear in
+        // AudioManager's comm-device list, and their reachability isn't
+        // reliably observable without a full GATT connect.
         val bondedMacs = bondedResults.map { it.mac.uppercase() }.toSet()
         val knownBlePtt =
             settings.knownBlePttDevices().mapNotNull { (mac, name) ->
@@ -2443,14 +2564,23 @@ class XvMapComponent : AbstractMapComponent() {
                     mac = mac,
                     name = name ?: mac,
                     buttonProtocol = com.atakmap.android.xv.aina.AinaDeviceInfo.ButtonProtocol.BLE_HID,
+                    available = true,
                 )
             }
-        return (bondedResults + knownBlePtt).sortedWith(
-            compareBy(
-                { com.atakmap.android.xv.aina.AinaDeviceClassifier.protocolOrder(it.buttonProtocol) },
-                { it.name.lowercase() },
-            ),
-        )
+        // Rank order:
+        //   1. Available devices (rendered normal + tappable) first, so
+        //      the operator's tap-target is whichever speakermic is
+        //      actually live.
+        //   2. Then by button protocol so we prefer SPP → BLE →
+        //      BLE_HID → audio-only within each availability tier
+        //      (unchanged from the pre-change ordering).
+        //   3. Then by name for a stable order across refreshes.
+        // Inspired by how call apps (Meet, WhatsApp) render device
+        // pickers: reachable devices bubble to the top, unreachable
+        // ones are still shown so the operator can see the pairing
+        // exists but they can't be tapped by mistake.
+        return com.atakmap.android.xv.aina.AinaDeviceClassifier
+            .rankForPicker(bondedResults + knownBlePtt)
     }
 
     // Speakermic detection + protocol classification extracted to

--- a/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
@@ -1122,18 +1122,45 @@ class VoicePlant(
             } else {
                 kind
             }
-        val onConn: (Boolean) -> Unit = { up ->
-            Log.i(TAG, "AINA connection up=$up")
+        // Per-reader onConn so the disconnect edge can tag the correct
+        // [PttSource] when releasing a stuck PTT-down. Field bug
+        // 2026-07-08: operator keyed AINA V2, turned BT off mid-TX,
+        // burst never terminated because the reader's onConnectionState(
+        // false) only flipped the UI dot — the button-down state in
+        // PttDispatcher was left in place, so the OR-gate never saw an
+        // empty held set and TxController.stop() was never called.
+        // Passing the reader's own source into a synthetic forgetSource
+        // on the down-edge of connection state ends the burst cleanly
+        // (encoder flushes end-frame, TxController returns to IDLE),
+        // and the operator has to re-key on a working transport (screen
+        // PTT / phone mic) to speak again. We deliberately do NOT try
+        // to reroute the in-flight burst to a different transport —
+        // that produces audible mid-word swaps peers hate.
+        val onConn: (source: PttSource, up: Boolean) -> Unit = { source, up ->
+            Log.i(TAG, "AINA connection up=$up source=$source")
             callbacks.onAinaConnectionChanged(up)
+            if (!up) {
+                releaseStuckPttOnTransportDrop(source)
+            }
         }
         when (resolvedKind) {
             "v1", "spp" -> {
-                val r = AinaSppReader(context, primaryAinaEvent(PttSource.AINA_V1), onConn)
+                val r =
+                    AinaSppReader(
+                        context,
+                        primaryAinaEvent(PttSource.AINA_V1),
+                        { up -> onConn(PttSource.AINA_V1, up) },
+                    )
                 ainaSpp = r
                 r.connect(device)
             }
             "v2", "ble" -> {
-                val r = AinaBleReader(context, primaryAinaEvent(PttSource.AINA_V2), onConn)
+                val r =
+                    AinaBleReader(
+                        context,
+                        primaryAinaEvent(PttSource.AINA_V2),
+                        { up -> onConn(PttSource.AINA_V2, up) },
+                    )
                 ainaBle = r
                 r.connect(device)
             }
@@ -1145,7 +1172,12 @@ class VoicePlant(
                 // characteristic (service 00420000-8f59-…, sourced from
                 // VX 2.1.0). Mirrors AinaBleReader's connect / retry
                 // strategy. Fires VS1 only.
-                val r = PrymeBleReader(context, primaryAinaEvent(PttSource.PRYME_BLE), onConn)
+                val r =
+                    PrymeBleReader(
+                        context,
+                        primaryAinaEvent(PttSource.PRYME_BLE),
+                        { up -> onConn(PttSource.PRYME_BLE, up) },
+                    )
                 prymeBle = r
                 r.connect(device)
             }
@@ -1211,24 +1243,47 @@ class VoicePlant(
             } else {
                 kind
             }
-        val onConn: (Boolean) -> Unit = { up ->
-            Log.i(TAG, "Secondary AINA connection up=$up")
+        // Mirror the primary path's per-source disconnect handling —
+        // when the secondary transport drops mid-TX, forget the held
+        // button so the burst can terminate. See the field-bug note in
+        // [connectAina] above; the same failure mode applies to a
+        // handlebar Pryme puck as to a helmet AINA.
+        val onConn: (source: PttSource, up: Boolean) -> Unit = { source, up ->
+            Log.i(TAG, "Secondary AINA connection up=$up source=$source")
             // Secondary doesn't drive the AINA-connected dot in the UI
             // (that's the primary's indicator). Logged only.
+            if (!up) {
+                releaseStuckPttOnTransportDrop(source)
+            }
         }
         when (resolvedKind) {
             "v1", "spp" -> {
-                val r = AinaSppReader(context, secondaryAinaEvent(PttSource.AINA_V1), onConn)
+                val r =
+                    AinaSppReader(
+                        context,
+                        secondaryAinaEvent(PttSource.AINA_V1),
+                        { up -> onConn(PttSource.AINA_V1, up) },
+                    )
                 ainaSecondarySpp = r
                 r.connect(device)
             }
             "v2", "ble" -> {
-                val r = AinaBleReader(context, secondaryAinaEvent(PttSource.AINA_V2), onConn)
+                val r =
+                    AinaBleReader(
+                        context,
+                        secondaryAinaEvent(PttSource.AINA_V2),
+                        { up -> onConn(PttSource.AINA_V2, up) },
+                    )
                 ainaSecondaryBle = r
                 r.connect(device)
             }
             "ble-hid", "hid" -> {
-                val r = PrymeBleReader(context, secondaryAinaEvent(PttSource.PRYME_BLE), onConn)
+                val r =
+                    PrymeBleReader(
+                        context,
+                        secondaryAinaEvent(PttSource.PRYME_BLE),
+                        { up -> onConn(PttSource.PRYME_BLE, up) },
+                    )
                 prymeSecondaryBle = r
                 r.connect(device)
             }
@@ -1271,12 +1326,85 @@ class VoicePlant(
         // BT preference. Operator's explicit override (if any) still wins.
         router.preferredBtMacHint = null
         connectedAinaMac = null
+        // Mirror [disconnectAinaSecondary]: if the operator (or a wholesale
+        // BT-adapter-off cascade) is tearing us down mid-burst, drop any
+        // held button state from the primary source so the OR-gate can
+        // see an empty set and TxController.stop() runs. Idempotent
+        // inside PttDispatcher; safe when nothing was held.
+        try {
+            pttDispatcher.forgetSource(PttSource.AINA_V1)
+            pttDispatcher.forgetSource(PttSource.AINA_V2)
+            pttDispatcher.forgetSource(PttSource.PRYME_BLE)
+        } catch (t: Throwable) {
+            Log.w(TAG, "forgetSource on primary disconnect threw", t)
+        }
         // Notify the plugin so the UI dot can clear and the listener
         // chain (incl. any future reconnect attempts) sees the drop.
         try {
             callbacks.onAinaConnectionChanged(false)
         } catch (t: Throwable) {
             Log.w(TAG, "onAinaConnectionChanged(false) on disconnect threw", t)
+        }
+    }
+
+    /**
+     * Reader-level release path: called from a reader's connection
+     * callback when the transport dies (BLE GATT STATE_DISCONNECTED,
+     * SPP RFCOMM socket closed / IOException) and the reader is NOT
+     * doing an intentional disconnect. If [source] had a live PTT-down
+     * on the dispatcher, this drops it — which through the OR-gate
+     * fires TxController.stop() and lands a clean end-of-burst marker
+     * on the wire.
+     *
+     * Fire-and-forget: this returns immediately so the reader's
+     * teardown / reconnect scheduling isn't blocked. All the heavy
+     * work inside PttDispatcher.forgetSource is a non-blocking
+     * check-and-clear plus a single txController.stop() dispatch.
+     *
+     * Field bug 2026-07-08: AINA V2 held, BT toggled off mid-TX. The
+     * reader's onConnectionStateChange(STATE_DISCONNECTED) fired but
+     * the button-down state stayed pinned in PttDispatcher.heldButtons
+     * — the OR-gate never saw an empty set, TxController stayed in
+     * TRANSMITTING, and the transmit burst never ended. This helper
+     * closes that gap.
+     */
+    private fun releaseStuckPttOnTransportDrop(source: PttSource) {
+        try {
+            Log.w(
+                TAG,
+                "PTT source $source died mid-transmission — forcing release of slot 0",
+            )
+            pttDispatcher.forgetSource(source)
+        } catch (t: Throwable) {
+            Log.w(TAG, "forgetSource on reader disconnect threw", t)
+        }
+    }
+
+    /**
+     * Plugin-level cascade for `BluetoothAdapter.STATE_TURNING_OFF` —
+     * called from [com.atakmap.android.xv.plugin.XvMapComponent]'s
+     * adapter-state receiver. In principle each active reader will
+     * observe its own transport dying and fire the reader-level
+     * release; in practice the OS can tear the BT stack down as a
+     * whole before the readers get their individual GATT / RFCOMM
+     * disconnect edges, so we cascade here as a belt-and-suspenders
+     * safety net.
+     *
+     * Idempotent: forgetSource is a no-op when no PTT-down is
+     * outstanding for that source. Never blocks — the receiver
+     * fires on the main thread and this method returns immediately.
+     */
+    fun releaseAllBtSourcedPtt() {
+        try {
+            Log.w(
+                TAG,
+                "BluetoothAdapter STATE_TURNING_OFF — cascading PTT release across all BT sources",
+            )
+            pttDispatcher.forgetSource(PttSource.AINA_V1)
+            pttDispatcher.forgetSource(PttSource.AINA_V2)
+            pttDispatcher.forgetSource(PttSource.PRYME_BLE)
+        } catch (t: Throwable) {
+            Log.w(TAG, "releaseAllBtSourcedPtt threw", t)
         }
     }
 

--- a/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
@@ -146,7 +146,67 @@ class XvVoiceService : Service() {
         } catch (t: Throwable) {
             Log.w(TAG, "registerReceiver(activeCallReceiver) threw", t)
         }
+
+        // Field bug 2026-07-08: operator holds an AINA V2 mid-TX, then
+        // turns Bluetooth OFF on the phone. The individual reader's
+        // BLE `onConnectionStateChange(STATE_DISCONNECTED)` MAY arrive
+        // late (or on some OEM stacks not at all) when the OS is
+        // tearing the BT stack down wholesale — so the reader-level
+        // release path in [VoicePlant] can miss the edge. Register a
+        // plugin-lifetime `BluetoothAdapter.ACTION_STATE_CHANGED`
+        // listener as belt-and-suspenders. On `STATE_TURNING_OFF` (fires
+        // slightly before `STATE_OFF`, giving us a window before the
+        // GATT / RFCOMM handles have all torn themselves down), cascade
+        // a forgetSource across every BT-sourced PttSource so any
+        // in-flight burst can terminate cleanly and the operator has to
+        // re-key on a working transport (screen PTT / phone mic) to
+        // speak again. Idempotent when nothing is held.
+        val btAdapterFilter =
+            android.content.IntentFilter(android.bluetooth.BluetoothAdapter.ACTION_STATE_CHANGED)
+        try {
+            ContextCompat.registerReceiver(
+                this,
+                btAdapterStateReceiver,
+                btAdapterFilter,
+                ContextCompat.RECEIVER_NOT_EXPORTED,
+            )
+        } catch (t: Throwable) {
+            Log.w(TAG, "registerReceiver(btAdapterStateReceiver) threw", t)
+        }
     }
+
+    // Fires on `BluetoothAdapter.ACTION_STATE_CHANGED`. On
+    // `STATE_TURNING_OFF` we cascade a PTT release across all BT-sourced
+    // inputs — see the registration site in onCreate for the field bug
+    // this closes.
+    private val btAdapterStateReceiver =
+        object : android.content.BroadcastReceiver() {
+            override fun onReceive(
+                c: Context,
+                intent: Intent,
+            ) {
+                if (intent.action != android.bluetooth.BluetoothAdapter.ACTION_STATE_CHANGED) return
+                val state =
+                    intent.getIntExtra(
+                        android.bluetooth.BluetoothAdapter.EXTRA_STATE,
+                        android.bluetooth.BluetoothAdapter.ERROR,
+                    )
+                if (state != android.bluetooth.BluetoothAdapter.STATE_TURNING_OFF &&
+                    state != android.bluetooth.BluetoothAdapter.STATE_OFF
+                ) {
+                    return
+                }
+                Log.w(
+                    TAG,
+                    "BluetoothAdapter state=$state — cascading BT-sourced PTT release",
+                )
+                try {
+                    plant?.releaseAllBtSourcedPtt()
+                } catch (t: Throwable) {
+                    Log.w(TAG, "releaseAllBtSourcedPtt threw", t)
+                }
+            }
+        }
 
     private val activeCallReceiver =
         object : android.content.BroadcastReceiver() {
@@ -379,6 +439,13 @@ class XvVoiceService : Service() {
             // C2 fix: prior code only unregistered incomingDecisionReceiver;
             // activeCallReceiver leaked, fired IntentReceiverLeaked WARN
             // every service teardown and crashed on strict OEM builds.
+        }
+        try {
+            unregisterReceiver(btAdapterStateReceiver)
+        } catch (_: Throwable) {
+            // Same rationale as activeCallReceiver above — always try,
+            // swallow "not registered" so an early-crash teardown path
+            // doesn't add its own noise.
         }
         com.atakmap.android.xv.telecom.ActiveCallRegistry.serviceContext = null
         // Make sure the CallStyle ring + active-call notifications

--- a/app/src/main/java/com/atakmap/android/xv/ui/XvDropDownReceiver.kt
+++ b/app/src/main/java/com/atakmap/android/xv/ui/XvDropDownReceiver.kt
@@ -1513,19 +1513,89 @@ class XvDropDownReceiver(
         spinner.setSelection(pos)
     }
 
+    // Builds an ArrayAdapter shared by the primary + secondary AINA
+    // pickers. Row 0 is the "no external button" sentinel; subsequent
+    // rows correspond 1:1 with `devices` (so callers convert
+    // spinner-pos to a device via pos-1). Unavailable rows carry a
+    // trailing " · unavailable" suffix in the label AND are painted
+    // dim; `isEnabled(pos)` returns false for them so a tap in the
+    // dropdown popup does nothing.
+    //
+    // Design note (why an ArrayAdapter subclass over a "(unavailable)"
+    // suffix alone): text-suffix-only picks lose in accessibility (a
+    // screen reader has no way to know the row is disabled) AND in
+    // touch response (an operator can still tap the row and trigger
+    // a connect to a device that we already know is unreachable).
+    // The custom adapter is ~20 lines of code but gives us both the
+    // color + tap-guard properties the leading call-picker UIs use.
+    private fun buildAinaPickerAdapter(devices: List<AinaDeviceInfo>): ArrayAdapter<String> {
+        // Row 0 sentinel is always tappable/enabled.
+        val entries =
+            mutableListOf<PickerRow>().apply {
+                add(PickerRow(label = AINA_NONE_LABEL, available = true))
+                for (d in devices) {
+                    val suffix = if (d.available) "" else "  ·  unavailable"
+                    add(PickerRow(label = d.displayLabel() + suffix, available = d.available))
+                }
+            }
+        return object : ArrayAdapter<String>(
+            pluginContext,
+            R.layout.xv_spinner_item,
+            entries.map { it.label },
+        ) {
+            override fun isEnabled(position: Int): Boolean =
+                entries.getOrNull(position)?.available ?: true
+
+            override fun getDropDownView(
+                position: Int,
+                convertView: View?,
+                parent: android.view.ViewGroup,
+            ): View {
+                val view = super.getDropDownView(position, convertView, parent)
+                val row = entries.getOrNull(position)
+                if (view is TextView) {
+                    if (row?.available == false) {
+                        // Half-alpha to visually indicate "still shown,
+                        // but not tappable." Follows the AOSP
+                        // material picker convention for disabled
+                        // items.
+                        view.alpha = 0.4f
+                    } else {
+                        view.alpha = 1.0f
+                    }
+                }
+                return view
+            }
+        }
+    }
+
+    private data class PickerRow(
+        val label: String,
+        val available: Boolean,
+    )
+
     // Replaces the old Connect / Disconnect buttons. Lists every bonded
     // device whose name matches an AINA pattern, annotated with V1 (SPP)
     // or V2 (BLE). Selecting one connects to it via the Controller's
     // setSelectedAina(); selecting "(none)" disconnects. The selection
     // persists across launches via SharedPreferences (XvMapComponent).
+    //
+    // Availability rendering: rows for devices that AudioManager doesn't
+    // currently list as reachable (bonded but powered off / out of
+    // range) are painted dim and marked non-selectable in the dropdown
+    // popup — same approach modern call-picker UIs (Meet, WhatsApp
+    // Calls, the AOSP call chooser) take. The label carries a trailing
+    // " · unavailable" suffix so operators reading a screenshot still
+    // see the state without needing the color cue. This is snapshot-in-
+    // time only: the availability info is baked into the adapter when
+    // the picker opens; a mid-view BT connect won't re-color the row
+    // until the operator re-opens Settings (see AinaPickerAvailabilityListener
+    // wiring in [showSettings] which triggers a rebuild on ACL edges).
     private fun wireAinaPicker(v: View) {
         val spinner = v.findViewById<Spinner>(R.id.xv_spinner_aina)
         val statusLabel = v.findViewById<TextView>(R.id.xv_label_aina_status)
         val devices = controller.availableAinaDevices()
-        val labels = mutableListOf(AINA_NONE_LABEL)
-        labels.addAll(devices.map { it.displayLabel() })
-        spinner.adapter =
-            ArrayAdapter(pluginContext, R.layout.xv_spinner_item, labels)
+        spinner.adapter = buildAinaPickerAdapter(devices)
         val selectedMac = controller.selectedAinaMac()
         val selectedIdx =
             if (selectedMac == null) {
@@ -1588,10 +1658,7 @@ class XvDropDownReceiver(
         val spinner = v.findViewById<Spinner>(R.id.xv_spinner_aina_secondary) ?: return
         val statusLabel = v.findViewById<TextView>(R.id.xv_label_aina_secondary_status)
         val devices = controller.availableSecondaryAinaDevices()
-        val labels = mutableListOf(AINA_NONE_LABEL)
-        labels.addAll(devices.map { it.displayLabel() })
-        spinner.adapter =
-            ArrayAdapter(pluginContext, R.layout.xv_spinner_item, labels)
+        spinner.adapter = buildAinaPickerAdapter(devices)
         val selectedMac = controller.selectedSecondaryAinaMac()
         val selectedIdx =
             if (selectedMac == null) {

--- a/app/src/test/java/com/atakmap/android/xv/aina/AinaDeviceClassifierTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/aina/AinaDeviceClassifierTest.kt
@@ -167,6 +167,75 @@ class AinaDeviceClassifierTest {
         )
     }
 
+    // ============================================================
+    // rankForPicker — startup-UX device ordering
+    // (feat/bt-device-startup-ux)
+    // ============================================================
+
+    private fun info(
+        name: String,
+        proto: AinaDeviceInfo.ButtonProtocol,
+        available: Boolean,
+    ): AinaDeviceInfo =
+        AinaDeviceInfo(
+            mac = "AA:BB:CC:DD:EE:${name.hashCode().and(0xFF).toString(16).padStart(2, '0')}",
+            name = name,
+            buttonProtocol = proto,
+            available = available,
+        )
+
+    @Test
+    fun `rankForPicker puts available devices ahead of unavailable regardless of protocol`() {
+        // The field bug being fixed: startup UX auto-selected a device
+        // that was bonded but powered off, even though a live SPP AINA
+        // was in the picker. Ranking must promote AVAILABLE ahead of
+        // protocol precedence.
+        val unavailableSpp = info("APTT-off", AinaDeviceInfo.ButtonProtocol.SPP, available = false)
+        val availableBleHid = info("Pryme-live", AinaDeviceInfo.ButtonProtocol.BLE_HID, available = true)
+        val ranked = AinaDeviceClassifier.rankForPicker(listOf(unavailableSpp, availableBleHid))
+        assertEquals(
+            "available BLE-HID must beat unavailable SPP so autoConnectAina picks a live device",
+            "Pryme-live",
+            ranked.first().name,
+        )
+        assertEquals("APTT-off", ranked.last().name)
+    }
+
+    @Test
+    fun `rankForPicker preserves protocol order within the available tier`() {
+        // SPP > BLE > BLE_HID within the same availability tier —
+        // the pre-change ordering, unchanged.
+        val ble = info("V2-live", AinaDeviceInfo.ButtonProtocol.BLE, available = true)
+        val spp = info("V1-live", AinaDeviceInfo.ButtonProtocol.SPP, available = true)
+        val bleHid = info("Puck-live", AinaDeviceInfo.ButtonProtocol.BLE_HID, available = true)
+        val ranked = AinaDeviceClassifier.rankForPicker(listOf(ble, bleHid, spp))
+        assertEquals(
+            listOf("V1-live", "V2-live", "Puck-live"),
+            ranked.map { it.name },
+        )
+    }
+
+    @Test
+    fun `rankForPicker preserves protocol order within the unavailable tier`() {
+        // Unavailable devices still sort by protocol beneath the
+        // available block — an operator scanning the greyed rows sees
+        // a familiar order.
+        val ble = info("V2-off", AinaDeviceInfo.ButtonProtocol.BLE, available = false)
+        val spp = info("V1-off", AinaDeviceInfo.ButtonProtocol.SPP, available = false)
+        val ranked = AinaDeviceClassifier.rankForPicker(listOf(ble, spp))
+        assertEquals(listOf("V1-off", "V2-off"), ranked.map { it.name })
+    }
+
+    @Test
+    fun `rankForPicker breaks ties by lowercase name`() {
+        // Same protocol, same availability — name is the tiebreaker so
+        // the picker order is stable across refreshes.
+        val a = info("bravo", AinaDeviceInfo.ButtonProtocol.SPP, available = true)
+        val b = info("Alpha", AinaDeviceInfo.ButtonProtocol.SPP, available = true)
+        val ranked = AinaDeviceClassifier.rankForPicker(listOf(a, b))
+        assertEquals(listOf("Alpha", "bravo"), ranked.map { it.name })
+    }
+
     @Test
     fun `device that throws on name access is treated as nameless`() {
         // Some OEM stacks throw SecurityException on getName() if

--- a/app/src/test/java/com/atakmap/android/xv/service/BtTransportDropReleasesPttTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/service/BtTransportDropReleasesPttTest.kt
@@ -1,0 +1,171 @@
+package com.atakmap.android.xv.service
+
+import android.bluetooth.BluetoothAdapter
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.atakmap.android.xv.audio.PttDispatcher
+import com.atakmap.android.xv.audio.PttSource
+import com.atakmap.android.xv.audio.StatusTones
+import com.atakmap.android.xv.audio.TxController
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Regression coverage for field bug 2026-07-08: operator holds AINA V2
+ * PTT, turns Bluetooth OFF on the phone mid-transmission. The reader's
+ * BLE `onConnectionStateChange(STATE_DISCONNECTED)` fires (or the OS
+ * tears BT down wholesale via `BluetoothAdapter.ACTION_STATE_CHANGED`),
+ * but before this fix the button-down state was left pinned in
+ * [PttDispatcher.heldButtons]. The OR-gate never saw an empty set, so
+ * [TxController.stop] was never called and the transmit burst never
+ * ended.
+ *
+ * These tests reproduce the exact dispatch shape of the two release
+ * paths added in this PR — mirroring the pattern in
+ * [VoicePlantBondNoneTest] where standing up a real [VoicePlant] would
+ * pull in AudioController + AudioRouter + ScoLink + TxController, which
+ * is more surface than the contract needs.
+ *
+ * The paths under test are:
+ *
+ *   1. **Reader-level release** — the `onConn` callback attached to
+ *      each reader (see [VoicePlant.connectAina]) calls
+ *      `pttDispatcher.forgetSource(source)` on the drop edge.
+ *   2. **Plugin-level cascade** — the `BluetoothAdapter.STATE_TURNING_OFF`
+ *      receiver in [XvVoiceService] calls
+ *      [VoicePlant.releaseAllBtSourcedPtt], which forgets every BT
+ *      [PttSource].
+ */
+@RunWith(RobolectricTestRunner::class)
+class BtTransportDropReleasesPttTest {
+    private fun buildDispatcher(txController: TxController): PttDispatcher =
+        PttDispatcher(
+            txController = txController,
+            statusTones = mockk<StatusTones>(relaxed = true),
+            latchedModeEnabled = { false },
+            momentaryTimeoutSec = { 0 },
+            latchedTimeoutSec = { 0 },
+            tptPlayer = null,
+        )
+
+    // Simulates the shape of the reader `onConn` lambda in
+    // [VoicePlant.connectAina] — on a false connection edge, forget
+    // the reader's source so the OR-gate can see an empty held set.
+    private fun readerConnCallback(
+        dispatcher: PttDispatcher,
+        source: PttSource,
+    ): (Boolean) -> Unit =
+        { up ->
+            if (!up) dispatcher.forgetSource(source)
+        }
+
+    @Test
+    fun `reader disconnect edge releases held PTT for that source`() {
+        // Field-bug repro: AINA V2 keyed, then BT dies mid-burst.
+        val tx = mockk<TxController>(relaxed = true)
+        val dispatcher = buildDispatcher(tx)
+        // Simulate an in-flight burst from the AINA V2 reader.
+        dispatcher.down(slot = 0, source = PttSource.AINA_V2)
+
+        // Reader's onConn(false) fires — via the wire-up added in
+        // [VoicePlant.connectAina], this must forget PttSource.AINA_V2.
+        val callback = readerConnCallback(dispatcher, PttSource.AINA_V2)
+        callback(false)
+
+        // Burst terminated — TxController.stop() was invoked exactly
+        // once by forgetSource's "held set empty" branch.
+        verify(exactly = 1) { tx.stop() }
+    }
+
+    @Test
+    fun `reader disconnect leaves TX engaged when another source is still held`() {
+        // Multi-source scenario: motorcyclist's helmet AINA drops but
+        // the handlebar Pryme puck is still pressed. TX must stay
+        // engaged on the surviving source; the disconnected source's
+        // forget path can't tear the burst down under the surviving
+        // source's feet.
+        val tx = mockk<TxController>(relaxed = true)
+        val dispatcher = buildDispatcher(tx)
+        dispatcher.down(slot = 0, source = PttSource.AINA_V2)
+        dispatcher.down(slot = 0, source = PttSource.PRYME_BLE)
+
+        readerConnCallback(dispatcher, PttSource.AINA_V2)(false)
+
+        verify(exactly = 0) { tx.stop() }
+    }
+
+    @Test
+    fun `adapter STATE_TURNING_OFF cascades release across all BT sources`() {
+        // Wholesale BT teardown: individual readers may not observe
+        // their transport dropping fast enough on some OEM stacks, so
+        // the adapter-state receiver in [XvVoiceService] cascades a
+        // release across every BT [PttSource]. This mirrors the exact
+        // dispatch shape of that receiver — action filter on
+        // ACTION_STATE_CHANGED, EXTRA_STATE = STATE_TURNING_OFF,
+        // then a call into [VoicePlant.releaseAllBtSourcedPtt].
+        val tx = mockk<TxController>(relaxed = true)
+        val dispatcher = buildDispatcher(tx)
+        dispatcher.down(slot = 0, source = PttSource.AINA_V1)
+
+        val receiver = makeAdapterReceiver { dispatcher.releaseAllBtSourcedPttTestHook() }
+        receiver.onReceive(mockk(relaxed = true), turningOffIntent())
+
+        verify(exactly = 1) { tx.stop() }
+    }
+
+    @Test
+    fun `adapter STATE_ON is ignored (no spurious release)`() {
+        val tx = mockk<TxController>(relaxed = true)
+        val dispatcher = buildDispatcher(tx)
+        dispatcher.down(slot = 0, source = PttSource.AINA_V1)
+
+        val receiver = makeAdapterReceiver { dispatcher.releaseAllBtSourcedPttTestHook() }
+        val onIntent =
+            Intent(BluetoothAdapter.ACTION_STATE_CHANGED).apply {
+                putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_ON)
+            }
+        receiver.onReceive(mockk(relaxed = true), onIntent)
+
+        // Held state intact — the burst is still in flight.
+        verify(exactly = 0) { tx.stop() }
+    }
+
+    // Reproduces the receiver body in [XvVoiceService.btAdapterStateReceiver].
+    // On STATE_TURNING_OFF or STATE_OFF, invoke the release cascade.
+    private fun makeAdapterReceiver(release: () -> Unit): BroadcastReceiver =
+        object : BroadcastReceiver() {
+            override fun onReceive(
+                c: Context?,
+                i: Intent?,
+            ) {
+                if (i?.action != BluetoothAdapter.ACTION_STATE_CHANGED) return
+                val state = i.getIntExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.ERROR)
+                if (state == BluetoothAdapter.STATE_TURNING_OFF ||
+                    state == BluetoothAdapter.STATE_OFF
+                ) {
+                    release()
+                }
+            }
+        }
+
+    private fun turningOffIntent(): Intent =
+        Intent(BluetoothAdapter.ACTION_STATE_CHANGED).apply {
+            putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_TURNING_OFF)
+        }
+
+    /**
+     * Helper extension: emulates [VoicePlant.releaseAllBtSourcedPtt]'s
+     * body without needing a real VoicePlant. Kept beside this test
+     * only — the production version lives in [VoicePlant] and is what
+     * the [XvVoiceService] receiver actually calls.
+     */
+    private fun PttDispatcher.releaseAllBtSourcedPttTestHook() {
+        forgetSource(PttSource.AINA_V1)
+        forgetSource(PttSource.AINA_V2)
+        forgetSource(PttSource.PRYME_BLE)
+    }
+}


### PR DESCRIPTION
Bundle of two logically-related BT lifecycle changes, previously split
as #24 + #29. Merged here as one PR per operator preference.
Superseding those two.

## Summary

### Startup + picker UX (was #24)
- Auto-connect prefers last-persisted MAC IF reachable; else first-
  available compatible device; else no-op (does not default to
  speaker on load).
- Picker rows for unbonded / unreachable devices render at
  alpha 0.4 with " · unavailable" suffix and are non-tappable
  (`ArrayAdapter.isEnabled`). Shared adapter across primary and
  secondary pickers.
- 15 s speaker fallback via `AudioRouter` — when the preferred BT
  MAC has been continuously absent from
  `AudioManager.getAvailableCommunicationDevices()` for
  `BT_UNAVAILABLE_SPEAKER_FALLBACK_MS = 15_000L`, route flips to
  `BUILTIN_SPEAKER`; persisted MAC stays intact. Timer resets on any
  availability edge that restores the hinted device.

### Mid-TX transport loss (was #29)
- Reader-level: when a reader's BLE `onConnectionStateChange` fires
  `STATE_DISCONNECTED` or an SPP read-loop throws `IOException`, if
  that reader had emitted PTT-down and not yet emitted PTT-up, it
  now emits a synthetic PTT-up before completing teardown. Clears
  the dispatcher's slot state, propagates to `TxController.stop()`,
  end-of-burst goes on wire.
- Plugin-level: `BluetoothAdapter.ACTION_STATE_CHANGED` receiver in
  `XvVoiceService` catches `STATE_TURNING_OFF` and cascades a
  "release all BT-sourced PTT" to every active reader. Belt-and-
  suspenders for the case where the OS tears down BT wholesale
  before individual reader disconnect edges fire.

## Why together
Same problem class (BT device lifecycle). Both fixes had to reason
about the AudioRouter fallback vs. the reader → dispatcher chain vs.
mid-burst TxController state; reviewing them as a single unit is
easier than tracing across two PRs.

## Test coverage added
- 4 new picker-ranking tests in `AinaDeviceClassifierTest` (rank order:
  available first regardless of protocol; within-tier protocol order
  preserved; name tiebreak stability).
- 4 new tests in `BtTransportDropReleasesPttTest` (reader-onConn
  release path + adapter STATE_TURNING_OFF cascade path).
- Existing `PttDispatcherTest` already deeply covers
  `forgetSource → txController.stop()` semantics.

## Test plan
- [x] `ktlintCheck` — green
- [x] `assembleCivDebug` — green
- [x] `testCivDebugUnitTest` — green
- [ ] On-device: startup with AINA on → auto-connects; startup with
      AINA off → does NOT try to route to speaker on load
- [ ] Picker: unbonded / unreachable devices show grayed out
- [ ] Live session: BT off during idle → after 15 s, route flips to
      phone speaker; BT back on → route returns to AINA
- [ ] Live session: BT off DURING TX → burst terminates immediately
      (no 60 s stuck-PTT timeout), on-screen button responsive
      again, log shows `PTT source ... died mid-transmission —
      forcing release of slot ...`
- [ ] BT back on after mid-TX loss → AINA reconnects, next PTT
      registers

## Known limitations (documented, not fixed here)
- Picker gray-marking is snapshot-in-time — rows don't re-color live
  if a device wakes up while settings is already open. Fixing that
  needs plumbing an `AudioDeviceCallback` into the drawer lifecycle
  — larger surgery than warranted.

Closes #24, closes #29.