### PR TITLE
fix(audio): AEC session linkage — active echo cancellation for close-proximity feedback

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/audio/AudioCapture.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/AudioCapture.kt
@@ -39,6 +39,19 @@ class AudioCapture(
     // marker for field-debug; future plumbing can route to a Toast via
     // the AIDL listener. Audit H5.
     private val onCaptureError: (reason: String) -> Unit = {},
+    // Fires with the OS-assigned AudioRecord session id after
+    // startRecording() succeeds, and again with null when capture stops
+    // or fails after allocation. VoicePlant stores the current value so
+    // AudioPlayback can attach its AudioTrack to the same session via
+    // AudioTrack.Builder.setSessionId(id) — that shared session id is
+    // what gives Android's AcousticEchoCanceler (created against the
+    // capture session in [configureAudioEffects]) a real downlink
+    // reference signal to subtract from the mic input. Without shared
+    // session ids, AEC sees only the mic path and can't suppress a
+    // peer's voice echoing back through the operator's speakermic.
+    // Default no-op keeps the constructor usable in tests / historical
+    // callsites that don't route through VoicePlant.
+    private val onSessionIdChanged: (Int?) -> Unit = {},
 ) {
     private val channelMask =
         if (channels == 1) AudioFormat.CHANNEL_IN_MONO else AudioFormat.CHANNEL_IN_STEREO
@@ -131,6 +144,20 @@ class AudioCapture(
         }
         thread =
             Thread({ runReadLoop() }, "xv-mic-capture").also { it.start() }
+        // Bubble the OS-assigned capture session id up to the plant so
+        // AudioPlayback can bind its AudioTrack to the same session
+        // (setSessionId on AudioTrack). This is what closes the loop for
+        // AEC: the AcousticEchoCanceler created against this session id
+        // (see [configureAudioEffects]) then has a real downlink reference
+        // signal to subtract from the mic input. Session ids are not
+        // sensitive per CLAUDE.md — log unredacted for field debug.
+        val sid = r.audioSessionId
+        Log.i(TAG, "capture session id=$sid — linked for AEC")
+        try {
+            onSessionIdChanged(sid)
+        } catch (t: Throwable) {
+            Log.w(TAG, "onSessionIdChanged(start) threw", t)
+        }
         // The actually-routed input device may differ from the requested
         // preferredDevice — the OS picks routing per its policy. Log the
         // routed device so silent-mic bugs are diagnosable: if we asked
@@ -223,6 +250,14 @@ class AudioCapture(
             }
         }
         record = null
+        // Clear the plant's cached session id so a subsequent RX before
+        // the next TX doesn't try to attach an AudioTrack to a released
+        // AudioRecord session. Idempotent — plant just holds null.
+        try {
+            onSessionIdChanged(null)
+        } catch (t: Throwable) {
+            Log.w(TAG, "onSessionIdChanged(stop) threw", t)
+        }
         Log.i(TAG, "AudioRecord stopped")
     }
 

--- a/app/src/main/java/com/atakmap/android/xv/audio/AudioPlayback.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/AudioPlayback.kt
@@ -80,6 +80,19 @@ class AudioPlayback(
     // produce 2-3 BONKs in a row before PRIMING finally observes
     // non-silent samples. Active=true on enter, false on exit.
     private val onScoHotChanged: (active: Boolean) -> Unit = {},
+    // Returns the OS-assigned AudioRecord session id currently in use
+    // by AudioCapture, or null when no capture is active. When non-null,
+    // AudioTrack.Builder.setSessionId(id) is called so the RX playback
+    // path shares a session with the mic path — that shared session id
+    // gives Android's AcousticEchoCanceler (attached to the capture
+    // session in AudioCapture.configureAudioEffects) a real downlink
+    // reference signal to subtract from the mic input. Without shared
+    // session ids, AEC has no visibility into what's coming out of the
+    // speaker and can't suppress a peer's voice echoing back through
+    // the operator's speakermic. Limitation: the very first RX before
+    // any TX still races (no capture session exists yet); the field
+    // bug is warm back-and-forth, which this covers.
+    private val captureSessionIdProvider: () -> Int? = { null },
 ) : AudioRouter.RouteListener {
     private val channelMask =
         if (channels == 1) AudioFormat.CHANNEL_OUT_MONO else AudioFormat.CHANNEL_OUT_STEREO
@@ -579,15 +592,37 @@ class AudioPlayback(
                 .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
                 .setChannelMask(channelMask)
                 .build()
+        // If AudioCapture has an active session, bind the AudioTrack to
+        // the same session id so Android's AcousticEchoCanceler (attached
+        // to the capture session in AudioCapture.configureAudioEffects)
+        // has a real downlink reference signal to subtract from the mic
+        // input. First RX before any TX still races (captureSessionId
+        // == null); on any RX burst that follows a PTT press, AEC is
+        // now looking at the same session pair. Session ids are not
+        // sensitive per CLAUDE.md — log unredacted for field debug.
+        val captureSessionId =
+            try {
+                captureSessionIdProvider()
+            } catch (t: Throwable) {
+                Log.w(TAG, "captureSessionIdProvider threw", t)
+                null
+            }
         val newTrack =
             try {
-                AudioTrack
-                    .Builder()
-                    .setAudioAttributes(attrs)
-                    .setAudioFormat(format)
-                    .setBufferSizeInBytes(minBufferBytes)
-                    .setTransferMode(AudioTrack.MODE_STREAM)
-                    .build()
+                val b =
+                    AudioTrack
+                        .Builder()
+                        .setAudioAttributes(attrs)
+                        .setAudioFormat(format)
+                        .setBufferSizeInBytes(minBufferBytes)
+                        .setTransferMode(AudioTrack.MODE_STREAM)
+                if (captureSessionId != null && captureSessionId != 0) {
+                    b.setSessionId(captureSessionId)
+                    Log.i(TAG, "AudioTrack using capture session id=$captureSessionId for AEC linkage")
+                } else {
+                    Log.i(TAG, "AudioTrack built with fresh session (no capture session yet — first RX or post-stop)")
+                }
+                b.build()
             } catch (t: Throwable) {
                 Log.e(TAG, "AudioTrack build failed (useSco=$useSco)", t)
                 return

--- a/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
@@ -167,6 +167,31 @@ class VoicePlant(
             preferredDeviceForTones = { router.preferredDevice() },
         ).also { it.primeMediaPath() }
 
+    // Session id of the currently-live AudioCapture, or null when no
+    // capture is running. Published by AudioCapture.start() (via the
+    // onSessionIdChanged callback wired below) and cleared by
+    // AudioCapture.stop(). AudioPlayback consults it when building a
+    // fresh AudioTrack so RX playback shares a session with the mic
+    // path — Android's AcousticEchoCanceler (attached to the capture
+    // session in AudioCapture.configureAudioEffects) then has a real
+    // downlink reference signal to subtract from the mic input, which
+    // is what stops the operator's peer from hearing themselves
+    // through the operator's own speakermic on a warm back-and-forth.
+    // Volatile: TX thread writes (AudioCapture.start/stop runs on the
+    // caller thread; TxController drives the lifecycle from its own
+    // executor), RX thread reads (playPcm delivery landing on the
+    // Mumble decoder thread).
+    @Volatile private var currentCaptureSessionId: Int? = null
+
+    /** Called by AudioCapture on start()/stop() so AudioPlayback can
+     *  bind its AudioTrack to the same audio session. Public API is
+     *  package-scoped-by-convention — external callers should never
+     *  touch this. */
+    internal fun setCurrentCaptureSessionId(id: Int?) {
+        currentCaptureSessionId = id
+        Log.i(TAG, "currentCaptureSessionId → $id")
+    }
+
     private val audioPlayback: AudioPlayback =
         AudioPlayback(
             controller = audioController,
@@ -185,6 +210,13 @@ class VoicePlant(
             // cost. Especially helps slow combos (Duo+V1) where the
             // mic returns silence for 1-3 s after a cold SCO setup.
             onScoHotChanged = { active -> txController.preWarmMic(active) },
+            // AEC session linkage. When a capture is live, AudioTrack
+            // is built against the same session id so the AEC effect
+            // (attached to the capture session in AudioCapture) has a
+            // real reference signal. First RX before any TX still
+            // races — this covers the warm back-and-forth case which
+            // is the field bug.
+            captureSessionIdProvider = { currentCaptureSessionId },
         ).also { router.start(it) }
 
     private val statusTones = StatusTones(tptPlayer = tptPlayer, enabled = { statusTonesEnabled })
@@ -224,6 +256,11 @@ class VoicePlant(
                     context = context,
                     onFrame = onFrame,
                     onCaptureError = { reason -> callbacks.onCaptureError(reason) },
+                    // Publish the OS-assigned capture session id up so
+                    // AudioPlayback can share it with its AudioTrack. See
+                    // [currentCaptureSessionId] docstring for the AEC
+                    // rationale.
+                    onSessionIdChanged = { id -> setCurrentCaptureSessionId(id) },
                 )
             },
             opusEncoderFactory = { ConcentusOpusEncoder() as OpusEncoder },


### PR DESCRIPTION
## Summary

Native `AcousticEchoCanceler` is Android's dedicated active-echo-
cancellation DSP. It runs continuously on the mic capture, subtracting
the RX playback signal from what the mic hears. This is exactly what
we want for the "peer hears themselves" feedback path.

XV has been attaching `AcousticEchoCanceler` to the `AudioRecord` since
day one (`AudioCapture.kt:314`), but it was effectively a no-op:

- On many Android implementations, AEC needs the reference signal
  (RX playback) and the input (mic capture) on the SAME `audioSessionId`
  or it has no signal to subtract.
- `AudioPlayback.kt:582-590` built the RX `AudioTrack` with
  `AudioTrack.Builder()` — no `.setSessionId(...)`. It got a fresh
  generated session. AEC on the record side never saw the AudioTrack's
  data as its reference.

Result today: AEC is "enabled" but doing nothing against XV's own RX,
and the vendor DSP in the speakermic alone hasn't been sufficient on
close-proximity multi-device use.

## Fix

Public-API-clean inverted plumbing (there is no public
`AudioRecord.Builder.setSessionId(int)` — that constructor variant is
`@SystemApi` only):

1. `AudioCapture` allocates its `AudioRecord` in the natural way (OS
   assigns a session ID).
2. After `startRecording()` succeeds, the session ID bubbles up to
   `VoicePlant` via a new `onSessionIdChanged` callback.
3. `VoicePlant` stores the current capture session ID as a
   `@Volatile Int?`.
4. `AudioPlayback` reads that field via a provider closure when
   building each `AudioTrack`; if non-null, calls
   `AudioTrack.Builder.setSessionId(id)`.

Net effect: any RX burst that follows a PTT press builds its
`AudioTrack` on the same session that `AcousticEchoCanceler` is
already attached to. AEC has a real reference signal, active echo
cancellation actually runs.

## Why this and not RX ducking

An earlier revision of this PR (removed 2026-07-08 per operator
decision) also included RX ducking during TX — dropping the local RX
playback ~15 dB while transmitting. That's a blunt attenuation, not an
active cancellation, and it comes with UX cost (peer voice audibly
drops every time you key). Operator's preference: active suppression
via native AEC, not manual ducking. That's what this PR is.

## Per-device — no peer coordination

The fix is entirely local. Each operator who upgrades stops leaking
echo *from their device*. Peers do not need to be running the same
build to benefit from your fix.

The one path this doesn't cover: if a peer runs an old build and stands
next to you, they can still retransmit *your* voice back to you as
echo. That's inherent — no fix on your side can reach into their
device.

## Known limitation

Does not cover the first-RX-before-any-TX case. When no capture has
run yet, `currentCaptureSessionId` is null and the very first cold RX
gets a fresh session with no AEC linkage. Field pattern is warm
back-and-forth, which the fix does cover. Documented in code
comments.

## Test coverage

None added. `AudioTrack.Builder` + `setSessionId` are JNI-backed and
can't be meaningfully exercised without a live Android runtime.
Existing suites remain green.

## Test plan

- [x] `ktlintCheck` — green
- [x] `assembleCivDebug` — green
- [x] `testCivDebugUnitTest` — green
- [ ] On-device: after any PTT press, next RX burst logs
      `AudioTrack using capture session id=<N> for AEC linkage`
- [ ] On-device close-proximity: peer stops hearing themselves loop
      back on the next round

Closes #27 (already closed as superseded).