### PR TITLE
fix(bt): primary auto-pick prefers speakermic over button-only puck

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/aina/AinaDeviceClassifier.kt
+++ b/app/src/main/java/com/atakmap/android/xv/aina/AinaDeviceClassifier.kt
@@ -139,6 +139,28 @@ object AinaDeviceClassifier {
             ),
         )
 
+    // Choose the auto-connect candidate for the PRIMARY slot from a
+    // ranked device list. Primary is where XV routes speakermic audio;
+    // BLE_HID pucks (Pryme BT-PTT and similar HID-over-GATT buttons)
+    // have no speaker / mic and belong in the SECONDARY slot alongside
+    // the on-screen PTT, so we filter them out here even when they're
+    // the only currently-"available" device.
+    //
+    // BLE_HID availability is hard-coded true in listBondedAinaDevices
+    // (there's no comm-device signal we can query for a HID puck), so
+    // without this filter a bonded-but-off Pryme wins auto-pick whenever
+    // the operator's AINA is powered down at plugin load. Reported by
+    // operator 2026-07-10.
+    //
+    // Expects [ranked] to already be sorted by [rankForPicker]. Returns
+    // null if no non-BLE_HID device is currently available — the caller
+    // should NOT fall back to picking a BLE_HID (the operator explicitly
+    // does not want the button-only puck driving primary audio).
+    fun pickPrimary(ranked: List<AinaDeviceInfo>): AinaDeviceInfo? =
+        ranked.firstOrNull {
+            it.available && it.buttonProtocol != AinaDeviceInfo.ButtonProtocol.BLE_HID
+        }
+
     private fun safeName(device: BluetoothDevice): String? =
         try {
             device.name

--- a/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
+++ b/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
@@ -2329,25 +2329,26 @@ class XvMapComponent : AbstractMapComponent() {
                 Log.i(TAG, "autoConnectAina: no saved selection and auto-connect disabled — skipping")
                 return@postDelayed
             }
-            // Auto-pick: prefer the first AVAILABLE compatible device
-            // in the picker list. listBondedAinaDevices already sorts
-            // available-first, then by protocol (SPP → BLE → BLE_HID)
-            // so a live speakermic always beats a stale one AND a
-            // speakermic always beats a button-only puck for the
-            // primary slot. If no device is marked available we
-            // deliberately do NOT connect — auto-connecting to a
-            // device that isn't live just to satisfy an old MAC hint
-            // is the exact bug we're fixing.
+            // Auto-pick: prefer the first AVAILABLE speakermic-class
+            // device (SPP / BLE / AUDIO_ONLY) in the picker list.
+            // BLE_HID pucks are button-only and are handled by
+            // autoConnectAinaSecondary — they must never win the
+            // primary slot even when they're the only "available"
+            // candidate. BLE_HID availability is unobservable so
+            // those rows are always marked available=true; without
+            // the filter, a bonded-but-off Pryme puck was winning
+            // firstOrNull { available } whenever the operator's AINA
+            // was powered down at plugin load (reported 2026-07-10).
             if (candidates.isEmpty()) {
                 Log.i(TAG, "autoConnectAina: no compatible bonded device found — nothing to auto-pick")
                 return@postDelayed
             }
-            val picked = candidates.firstOrNull { it.available }
+            val picked = com.atakmap.android.xv.aina.AinaDeviceClassifier.pickPrimary(candidates)
             if (picked == null) {
                 Log.i(
                     TAG,
-                    "autoConnectAina: ${candidates.size} bonded candidate(s) found but none currently reachable — " +
-                        "waiting for one to come up",
+                    "autoConnectAina: ${candidates.size} bonded candidate(s) but no available speakermic " +
+                        "(button-only pucks are ineligible for primary) — waiting for a speakermic to come up",
                 )
                 return@postDelayed
             }

--- a/app/src/test/java/com/atakmap/android/xv/aina/AinaDeviceClassifierTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/aina/AinaDeviceClassifierTest.kt
@@ -236,6 +236,76 @@ class AinaDeviceClassifierTest {
         assertEquals(listOf("Alpha", "bravo"), ranked.map { it.name })
     }
 
+    // ============================================================
+    // pickPrimary — auto-connect for the PRIMARY speakermic slot
+    // (fix/primary-picks-speakermic-over-button)
+    // ============================================================
+
+    @Test
+    fun `pickPrimary skips available BLE_HID puck when speakermic is off`() {
+        // The 2026-07-10 field report: bonded Pryme puck (BLE_HID) is
+        // always marked available=true because HID pucks don't appear
+        // in AudioManager.getAvailableCommunicationDevices, so the old
+        // firstOrNull { available } auto-picked the puck as PRIMARY
+        // whenever the operator's AINA was powered off at plugin load.
+        // pickPrimary must filter BLE_HID out entirely — the puck is
+        // the SECONDARY slot's problem, not primary's.
+        val puckLive = info("Pryme-live", AinaDeviceInfo.ButtonProtocol.BLE_HID, available = true)
+        val ainaOff = info("APTT-off", AinaDeviceInfo.ButtonProtocol.SPP, available = false)
+        val ranked = AinaDeviceClassifier.rankForPicker(listOf(puckLive, ainaOff))
+        assertEquals(
+            "no available speakermic → pickPrimary returns null instead of the button-only puck",
+            null,
+            AinaDeviceClassifier.pickPrimary(ranked),
+        )
+    }
+
+    @Test
+    fun `pickPrimary picks the available speakermic when both puck and AINA are live`() {
+        val puck = info("Pryme-live", AinaDeviceInfo.ButtonProtocol.BLE_HID, available = true)
+        val aina = info("APTT-live", AinaDeviceInfo.ButtonProtocol.BLE, available = true)
+        val ranked = AinaDeviceClassifier.rankForPicker(listOf(puck, aina))
+        assertEquals(
+            "speakermic beats button-only puck for primary",
+            "APTT-live",
+            AinaDeviceClassifier.pickPrimary(ranked)?.name,
+        )
+    }
+
+    @Test
+    fun `pickPrimary prefers SPP over BLE when both are available`() {
+        // Within the eligible-for-primary tier, the picker's protocol
+        // order (SPP → BLE → AUDIO_ONLY) must round-trip through
+        // pickPrimary. This is the historical AINA V1 preference —
+        // when both a V1 and a V2 are on, take V1 for auto-pick.
+        val v2 = info("APTT-V2", AinaDeviceInfo.ButtonProtocol.BLE, available = true)
+        val v1 = info("APTT-V1", AinaDeviceInfo.ButtonProtocol.SPP, available = true)
+        val ranked = AinaDeviceClassifier.rankForPicker(listOf(v2, v1))
+        assertEquals("APTT-V1", AinaDeviceClassifier.pickPrimary(ranked)?.name)
+    }
+
+    @Test
+    fun `pickPrimary returns null when all candidates are unavailable`() {
+        // No live speakermic and no live puck — nothing to connect. The
+        // caller must NOT fall back to an unavailable device just to
+        // satisfy an old MAC hint (that was the original 2026-07-08 bug
+        // this whole auto-pick path was fixing).
+        val ainaOff = info("APTT-off", AinaDeviceInfo.ButtonProtocol.SPP, available = false)
+        val puckOff = info("Pryme-off", AinaDeviceInfo.ButtonProtocol.BLE_HID, available = false)
+        val ranked = AinaDeviceClassifier.rankForPicker(listOf(ainaOff, puckOff))
+        assertEquals(null, AinaDeviceClassifier.pickPrimary(ranked))
+    }
+
+    @Test
+    fun `pickPrimary accepts an available AUDIO_ONLY device`() {
+        // Speakermic with an unrecognized button protocol still routes
+        // its audio; XV falls back to on-screen PTT. Not our happy path
+        // but it's a legitimate primary — must not be filtered out.
+        val audioOnly = info("Generic-HFP", AinaDeviceInfo.ButtonProtocol.AUDIO_ONLY, available = true)
+        val ranked = AinaDeviceClassifier.rankForPicker(listOf(audioOnly))
+        assertEquals("Generic-HFP", AinaDeviceClassifier.pickPrimary(ranked)?.name)
+    }
+
     @Test
     fun `device that throws on name access is treated as nameless`() {
         // Some OEM stacks throw SecurityException on getName() if


### PR DESCRIPTION
## Summary

Field report 2026-07-10: on plugin load with the operator's AINA
speakermic powered off but a bonded Pryme BLE PTT puck present, XV
auto-picked the puck as the **primary** device. The puck is button-
only (no mic / no speaker), so audio still routed to the phone
speaker while the puck's button drove PTT — the operator's mental
model of \"primary is the speakermic\" was broken.

Root cause: \`listBondedAinaDevices\` hard-codes \`available=true\` for
BLE_HID pucks (\`XvMapComponent.kt:2536\`) because HID-over-GATT
buttons don't appear in \`AudioManager.getAvailableCommunicationDevices\`
and there's no other reachability signal. That's the correct policy
for the picker (better to render the puck in normal color than dim
every BLE PTT the operator has ever paired). But \`autoConnectAina\`
was consuming that same \`available\` field via \`firstOrNull { it.available }\` —
so an off-but-\"available\" puck won primary whenever the speakermic
was down.

## Fix

- Add \`AinaDeviceClassifier.pickPrimary(ranked)\` that filters to
  \`available && buttonProtocol != BLE_HID\`. Pure function; unit-
  testable.
- Wire \`autoConnectAina\` to call it in place of the inline
  \`firstOrNull { available }\`.
- Returns \`null\` when no eligible speakermic is available. Caller
  deliberately does NOT fall back to picking a puck as primary —
  the operator explicitly does not want that.
- \`autoConnectAinaSecondary\` (the button-only slot) is unchanged
  and continues to pick BLE_HID pucks.

Operator can still manually persist a BLE_HID as primary via the
picker if they insist. The savedMac restore path is untouched.

## Tests

5 new unit tests in \`AinaDeviceClassifierTest\`:
- BLE_HID puck skipped when only unavailable speakermic present
- Speakermic wins when both puck and AINA are live
- SPP > BLE preference preserved within the eligible tier
- All-unavailable returns null
- AUDIO_ONLY remains eligible for primary

## Test plan
- [x] \`ktlintCheck\` — green
- [x] \`assembleCivDebug\` — green
- [x] \`testCivDebugUnitTest\` — full suite green (5 new tests included)
- [ ] On-device: AINA off + Pryme on at launch → no primary auto-pick,
      log shows \"no available speakermic ... waiting for one to come up\"
- [ ] On-device: AINA on + Pryme on at launch → AINA gets primary,
      Pryme gets external button
- [ ] On-device: only Pryme bonded (no AINA) → primary stays empty;
      on-screen PTT still functional