### PR TITLE
fix(audio): audio-device override actually pins comm device

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/audio/ScoLink.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/ScoLink.kt
@@ -25,6 +25,18 @@ import java.util.concurrent.CopyOnWriteArraySet
 // 26 so the legacy path still has to compile.
 class ScoLink(
     private val context: Context,
+    // BT MAC of the operator's "Audio device" override — the explicit
+    // pick from the Settings audio-device dropdown. When non-null AND
+    // that device appears in [AudioManager.availableCommunicationDevices]
+    // (i.e. it exposes HFP as a comm device), it wins absolutely over
+    // [preferredBtMac]. Design intent: "if I set an Audio device, that's
+    // where audio should go — regardless of which speakermic has the
+    // button." When the override MAC is present but the device isn't a
+    // valid comm device (A2DP-only headphones, out-of-range, etc.),
+    // ScoLink logs a warning and falls back to [preferredBtMac].
+    // Resolved on each acquire so the picker takes effect without
+    // re-creating the link.
+    private val outputOverrideMac: () -> String? = { null },
     // BT MAC of the operator's preferred speakermic (typically AINA),
     // resolved on each acquire so changing the AINA picker takes effect
     // without re-creating the link. Returns null if no preference is
@@ -103,18 +115,27 @@ class ScoLink(
                 // XV's voice on whichever BT device connected last —
                 // typically the car stereo when the operator gets in
                 // the car with both paired.
+                //
+                // Watch BOTH candidates: the audio-device override MAC
+                // (wins when set + HFP-capable) and the AINA hint MAC.
+                // Either reappearing is a reason to re-pin so we land
+                // on whichever wins the current-precedence.
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return
                 if (state != State.CONNECTED) return
-                val wantedMac = preferredBtMac() ?: return
+                val override = outputOverrideMac()
+                val hint = preferredBtMac()
+                if (override == null && hint == null) return
                 val matched =
-                    addedDevices.any {
-                        it.type == AudioDeviceInfo.TYPE_BLUETOOTH_SCO &&
-                            macOf(it).equals(wantedMac, ignoreCase = true)
+                    addedDevices.any { dev ->
+                        if (dev.type != AudioDeviceInfo.TYPE_BLUETOOTH_SCO) return@any false
+                        val mac = macOf(dev)
+                        (override != null && mac.equals(override, ignoreCase = true)) ||
+                            (hint != null && mac.equals(hint, ignoreCase = true))
                     }
                 if (matched) {
                     Log.i(
                         TAG,
-                        "AudioDeviceCallback: preferred BT $wantedMac just appeared — re-pinning comm device",
+                        "AudioDeviceCallback: preferred BT (override or hint) just appeared — re-pinning comm device",
                     )
                     reassertCommDeviceIfNeeded()
                 }
@@ -122,17 +143,40 @@ class ScoLink(
         }
 
     /**
-     * Pick the best available BT comm-device candidate, preferring the
-     * operator's pinned MAC over the OS's most-recently-connected
-     * default. Used by [startCommDevice] and
-     * [reassertCommDeviceIfNeeded] so both cold-start and warm-path
-     * routing honor the AINA pin. Production wrapper around the pure
-     * companion [pickBtCommDeviceFromCandidates] — see that for the
-     * full selection contract.
+     * Pick the best available BT comm-device candidate, honoring the
+     * "Audio device" override first and the AINA hint second. Used by
+     * [startCommDevice] and [reassertCommDeviceIfNeeded] so both
+     * cold-start and warm-path routing route to the operator's chosen
+     * device. Production wrapper around the pure companion
+     * [pickBtCommDeviceFromCandidates] — see that for the full
+     * selection contract.
+     *
+     * When the override MAC is set but the device isn't a valid comm
+     * device in the current candidate list (typical for A2DP-only
+     * headphones — they don't advertise HFP and never appear in
+     * [AudioManager.availableCommunicationDevices]), we log a warning
+     * with the redacted MAC and fall through to the AINA hint / speaker,
+     * per the "override is best-effort" design.
      */
     private fun pickBtCommDevice(candidates: List<AudioDeviceInfo>): AudioDeviceInfo? {
         val mapped = candidates.map { Candidate(it.type, macOf(it), it) }
-        return pickBtCommDeviceFromCandidates(mapped, preferredBtMac())?.audioDevice as AudioDeviceInfo?
+        val override = outputOverrideMac()
+        val hint = preferredBtMac()
+        val result = pickBtCommDeviceWithOverride(mapped, override, hint)
+        if (result.overrideMissed && override != null) {
+            // Override MAC was set but the device isn't a valid comm
+            // device (typical for A2DP-only headphones — they don't
+            // advertise HFP and never appear in
+            // [AudioManager.availableCommunicationDevices]). Log a
+            // warning with the REDACTED MAC per the sensitive-content
+            // rules and let the fallback (hint / speaker) stand.
+            Log.w(
+                TAG,
+                "outputBtOverrideMac ${com.atakmap.android.xv.aina.redactMac(override)} not available " +
+                    "as comm device — falling back to preferredBtMacHint / speaker",
+            )
+        }
+        return result.pick?.audioDevice as AudioDeviceInfo?
     }
 
     /**
@@ -237,9 +281,27 @@ class ScoLink(
             } catch (_: Throwable) {
                 null
             }
-        val wantedMac = preferredBtMac()
+        // Compute the effective desired MAC using the same precedence
+        // pickBtCommDevice() applies at cold-start: override wins when
+        // it's set AND currently a comm device, otherwise fall back to
+        // the hint. Reading availableCommunicationDevices here — even
+        // when we might skip the re-assert below — is cheap and avoids
+        // divergence between the "should we re-assert" check and the
+        // actual pick.
+        val overrideMac = outputOverrideMac()
+        val hintMac = preferredBtMac()
+        val candidatesForDesired =
+            try {
+                audioManager.availableCommunicationDevices
+            } catch (_: Throwable) {
+                emptyList()
+            }
+        val overrideIsValidCommDev =
+            overrideMac != null &&
+                candidatesForDesired.any { macOf(it).equals(overrideMac, ignoreCase = true) }
+        val wantedMac = if (overrideIsValidCommDev) overrideMac else hintMac
         // Re-assert if EITHER the current comm device isn't BT, OR it
-        // IS BT but doesn't match our pinned MAC. The second case is
+        // IS BT but doesn't match our effective MAC. The second case is
         // the in-car bug: AINA was active, then car stereo connected
         // and Android switched the comm device to the car. Without
         // the MAC check we'd see "current is BT_SCO" and skip the
@@ -406,8 +468,13 @@ class ScoLink(
                 Log.w(TAG, "availableCommunicationDevices failed", t)
                 emptyList()
             }
-        val wantedMac = preferredBtMac()
-        Log.i(TAG, "available comm devices: ${candidates.size} (preferredMac=${wantedMac ?: "<none>"})")
+        val overrideMac = outputOverrideMac()
+        val hintMac = preferredBtMac()
+        Log.i(
+            TAG,
+            "available comm devices: ${candidates.size} " +
+                "(override=${overrideMac ?: "<none>"} hint=${hintMac ?: "<none>"})",
+        )
         for (d in candidates) {
             Log.i(TAG, "  candidate type=${d.type} name='${d.productName}' mac='${macOf(d)}'")
         }
@@ -525,6 +592,73 @@ class ScoLink(
 
     companion object {
         private const val TAG = "XvSco"
+
+        /**
+         * Outcome of the two-input selector [pickBtCommDeviceWithOverride].
+         * [overrideMissed] is true when the caller passed an [overrideMac]
+         * that didn't match any BT candidate — the production wrapper
+         * uses this signal to emit the fall-back warning log.
+         */
+        internal data class Selection(
+            val pick: Candidate?,
+            val overrideMissed: Boolean,
+        )
+
+        /**
+         * Two-input pure selector layered over
+         * [pickBtCommDeviceFromCandidates]. Precedence:
+         *
+         *   1. [overrideMac] wins absolutely when set AND matches a BT
+         *      candidate (SCO preferred over A2DP for the same MAC).
+         *   2. [overrideMac] set but not matched → fall through to the
+         *      single-arg selector on [hintMac], and flag the miss so
+         *      the caller can log a warning.
+         *   3. [overrideMac] null/blank → single-arg selector on
+         *      [hintMac] (legacy behavior).
+         *
+         * Split out from [pickBtCommDevice] so tests can pin every
+         * precedence branch without standing up AudioManager. See the
+         * class-level docstring for the "Audio device" precedence
+         * design intent.
+         */
+        @androidx.annotation.VisibleForTesting
+        internal fun pickBtCommDeviceWithOverride(
+            candidates: List<Candidate>,
+            overrideMac: String?,
+            hintMac: String?,
+        ): Selection {
+            if (overrideMac.isNullOrBlank()) {
+                return Selection(
+                    pick = pickBtCommDeviceFromCandidates(candidates, hintMac),
+                    overrideMissed = false,
+                )
+            }
+            // Override set — try to match it first. Use the same
+            // SCO-over-A2DP-for-same-MAC ordering as the single-arg
+            // selector so an override that happens to match a device
+            // exposing both profiles picks the SCO variant.
+            val overrideScoMatch =
+                candidates.firstOrNull {
+                    it.type == android.media.AudioDeviceInfo.TYPE_BLUETOOTH_SCO &&
+                        it.mac.equals(overrideMac, ignoreCase = true)
+                }
+            if (overrideScoMatch != null) {
+                return Selection(pick = overrideScoMatch, overrideMissed = false)
+            }
+            val overrideA2dpMatch =
+                candidates.firstOrNull {
+                    it.type == android.media.AudioDeviceInfo.TYPE_BLUETOOTH_A2DP &&
+                        it.mac.equals(overrideMac, ignoreCase = true)
+                }
+            if (overrideA2dpMatch != null) {
+                return Selection(pick = overrideA2dpMatch, overrideMissed = false)
+            }
+            // Override missed — fall back to the hint and flag it.
+            return Selection(
+                pick = pickBtCommDeviceFromCandidates(candidates, hintMac),
+                overrideMissed = true,
+            )
+        }
 
         /**
          * Pure-function selector — picks the best comm-device candidate

--- a/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
@@ -139,18 +139,20 @@ class VoicePlant(
     private val scoLink: ScoLink =
         ScoLink(
             context = context,
-            preferredBtMac = {
-                // ScoLink controls MIC INPUT via SCO/HFP — and the mic
-                // lives on whichever device the operator picked as
-                // their speakermic (the AINA picker = preferredBtMacHint).
-                // The AUDIO DEVICE override (outputBtOverrideMac) is
-                // for output routing only — splitting it across, e.g.,
-                // a car-stereo A2DP sink while the AINA still carries
-                // the mic. So the hint wins here; the override is a
-                // fallback for the no-speakermic-picked case so a
-                // single-BT operator's override still drives SCO.
-                router.preferredBtMacHint ?: router.outputBtOverrideMac
-            },
+            // "Audio device" override — the explicit Settings pick.
+            // Wins absolutely when set AND the device exposes HFP
+            // (i.e. shows up in availableCommunicationDevices). When
+            // the operator picks a specific BT output, their mental
+            // model is "audio goes there, regardless of which puck
+            // owns the button" — ScoLink honors that here.
+            outputOverrideMac = { router.outputBtOverrideMac },
+            // AINA-hint fallback. Used when either (a) no override
+            // is set or (b) the override MAC isn't a valid comm
+            // device — A2DP-only headphones, out-of-range puck,
+            // etc. ScoLink logs a warning at the fall-back and
+            // pins comm to the hint (which is typically the AINA
+            // that owns the PTT button).
+            preferredBtMac = { router.preferredBtMacHint },
         ).also { link ->
             // Wire ScoLink into AudioControllerImpl so focus-loss
             // teardown publishes SUSPENDED instead of the controller

--- a/app/src/test/java/com/atakmap/android/xv/audio/ScoLinkPickerTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/audio/ScoLinkPickerTest.kt
@@ -131,4 +131,158 @@ class ScoLinkPickerTest {
         assertEquals("XX:11", pick!!.mac)
         assertEquals(AudioDeviceInfo.TYPE_BLUETOOTH_A2DP, pick.type)
     }
+
+    // ============================================================
+    // Two-input selector — "Audio device" override precedence
+    // ============================================================
+    //
+    // Regression coverage for the bug where a persisted primary AINA
+    // (preferredBtMacHint) silently swallowed the operator's explicit
+    // "Audio device" pick (outputBtOverrideMac). Design intent: the
+    // override wins absolutely when set + HFP-capable; the hint is the
+    // fallback (either no override at all, or an A2DP-only override).
+
+    @Test
+    fun `override wins over hint when both are set and override is HFP-capable`() {
+        // AINA on AA:BB… (has SCO), headphones on 11:22… (has SCO too —
+        // simulating an HFP-capable BT headset). The override must win.
+        val list =
+            listOf(
+                sco("AA:BB:CC:DD:EE:FF"), // hint (AINA)
+                sco("11:22:33:44:55:66"), // override (headphones)
+            )
+        val result =
+            ScoLink.pickBtCommDeviceWithOverride(
+                candidates = list,
+                overrideMac = "11:22:33:44:55:66",
+                hintMac = "AA:BB:CC:DD:EE:FF",
+            )
+        assertEquals("11:22:33:44:55:66", result.pick!!.mac)
+        assertEquals(AudioDeviceInfo.TYPE_BLUETOOTH_SCO, result.pick.type)
+        assertEquals(false, result.overrideMissed)
+    }
+
+    @Test
+    fun `override match is case-insensitive`() {
+        val list = listOf(sco("11:22:33:44:55:66"))
+        val result =
+            ScoLink.pickBtCommDeviceWithOverride(
+                candidates = list,
+                overrideMac = "11:22:33:44:55:66".lowercase(),
+                hintMac = null,
+            )
+        assertEquals("11:22:33:44:55:66", result.pick!!.mac)
+        assertEquals(false, result.overrideMissed)
+    }
+
+    @Test
+    fun `only hint set — behaves like legacy single-arg selector (regression)`() {
+        // Regression coverage: an operator with a primary AINA and NO
+        // Audio-device override picked must still route to the AINA.
+        val list =
+            listOf(
+                sco("AA:BB:CC:DD:EE:FF"), // hint (AINA)
+                sco("99:99:99:99:99:99"), // some other BT
+            )
+        val result =
+            ScoLink.pickBtCommDeviceWithOverride(
+                candidates = list,
+                overrideMac = null,
+                hintMac = "AA:BB:CC:DD:EE:FF",
+            )
+        assertEquals("AA:BB:CC:DD:EE:FF", result.pick!!.mac)
+        assertEquals(false, result.overrideMissed)
+    }
+
+    @Test
+    fun `blank override treated like null — hint drives selection`() {
+        val list = listOf(sco("AA:BB:CC:DD:EE:FF"))
+        val result =
+            ScoLink.pickBtCommDeviceWithOverride(
+                candidates = list,
+                overrideMac = "   ",
+                hintMac = "AA:BB:CC:DD:EE:FF",
+            )
+        assertEquals("AA:BB:CC:DD:EE:FF", result.pick!!.mac)
+        assertEquals(false, result.overrideMissed)
+    }
+
+    @Test
+    fun `override MAC absent from candidates — falls back to hint and flags miss`() {
+        // A2DP-only headphones don't advertise HFP → they don't appear
+        // in availableCommunicationDevices at all. Override MAC won't
+        // match any candidate. Fall back to the hint AINA and flag the
+        // miss so the production wrapper can log a warning.
+        val list =
+            listOf(
+                sco("AA:BB:CC:DD:EE:FF"), // hint (AINA)
+            )
+        val result =
+            ScoLink.pickBtCommDeviceWithOverride(
+                candidates = list,
+                overrideMac = "11:22:33:44:55:66", // A2DP-only headphones
+                hintMac = "AA:BB:CC:DD:EE:FF",
+            )
+        assertEquals("AA:BB:CC:DD:EE:FF", result.pick!!.mac)
+        assertEquals(true, result.overrideMissed)
+    }
+
+    @Test
+    fun `override missed and no hint — falls through to first-SCO with miss flag`() {
+        // Operator set an Audio-device override, no primary AINA. The
+        // override isn't currently present. Fall through to whatever
+        // the single-arg selector picks with null hint (first SCO) so
+        // audio at least routes somewhere sane, and flag the miss.
+        val list =
+            listOf(
+                sco("77:77:77:77:77:77"),
+                sco("88:88:88:88:88:88"),
+            )
+        val result =
+            ScoLink.pickBtCommDeviceWithOverride(
+                candidates = list,
+                overrideMac = "11:22:33:44:55:66",
+                hintMac = null,
+            )
+        assertEquals("77:77:77:77:77:77", result.pick!!.mac)
+        assertEquals(true, result.overrideMissed)
+    }
+
+    @Test
+    fun `override with A2DP-only match (both profiles absent) still returns A2DP`() {
+        // Some BT devices expose only A2DP as a comm device on certain
+        // handsets — the override should still match. Not the primary
+        // field case (A2DP normally isn't in availableCommunicationDevices)
+        // but keep behavior consistent with the single-arg selector.
+        val list = listOf(a2dp("11:22:33:44:55:66"))
+        val result =
+            ScoLink.pickBtCommDeviceWithOverride(
+                candidates = list,
+                overrideMac = "11:22:33:44:55:66",
+                hintMac = null,
+            )
+        assertEquals("11:22:33:44:55:66", result.pick!!.mac)
+        assertEquals(AudioDeviceInfo.TYPE_BLUETOOTH_A2DP, result.pick.type)
+        assertEquals(false, result.overrideMissed)
+    }
+
+    @Test
+    fun `override prefers SCO over A2DP for the same MAC`() {
+        // Device advertises both profiles under the same MAC. Override
+        // must land on the SCO endpoint — TX needs SCO, and the single-
+        // arg selector applies the same rule.
+        val list =
+            listOf(
+                a2dp("11:22:33:44:55:66"),
+                sco("11:22:33:44:55:66"),
+            )
+        val result =
+            ScoLink.pickBtCommDeviceWithOverride(
+                candidates = list,
+                overrideMac = "11:22:33:44:55:66",
+                hintMac = null,
+            )
+        assertEquals(AudioDeviceInfo.TYPE_BLUETOOTH_SCO, result.pick!!.type)
+        assertEquals(false, result.overrideMissed)
+    }
 }


### PR DESCRIPTION
## Summary

The Settings "Audio device" picker (routes XV RX/TX to a specific BT
device — e.g. BT headphones — regardless of which puck owns the PTT
button) was silently ignored whenever a primary AINA speakermic was
also persisted. This PR restores the operator's stated precedence:
"if I set an Audio device, that's where audio should go."

## Reproducer

1. Operator has a primary AINA speakermic set (MAC persisted in
   `XvSettings` under `PREF_AINA_MAC`).
2. Operator pairs a separate BT device (BT headphones) to the phone.
3. Operator opens XV Settings and selects the headphones from the
   "Audio device" picker.
4. RX audio still comes out of the AINA (or the phone speaker on the
   A2DP-only case). The override is silently swallowed.

## Root cause

`ScoLink` resolved its preferred BT MAC via a single closure at
`VoicePlant.kt:140-153`:

```kotlin
preferredBtMac = { router.preferredBtMacHint ?: router.outputBtOverrideMac }
```

`preferredBtMacHint` is written by `connectAinaInternal` on every AINA
connect. Once set, the Elvis fallback never evaluated
`outputBtOverrideMac`, so the override MAC never reached
`pickBtCommDeviceFromCandidates` and `setCommunicationDevice` was
called with the AINA's SCO endpoint. `AudioRouter.preferredDevice()`
(the output chain for `AudioTrack.setPreferredDevice`) already handled
override-over-hint correctly at `AudioRouter.kt:427-435` — the bug
was strictly in the SCO comm-device selection path that owns voice
routing in `MODE_IN_COMMUNICATION`.

## Fix

- `ScoLink` now takes two closures: `outputOverrideMac` (the explicit
  Audio-device pick) and `preferredBtMac` (the AINA hint). Override
  wins absolutely when set AND the device exposes HFP (appears in
  `AudioManager.availableCommunicationDevices`).
- When the override MAC is present but not a valid comm device
  (A2DP-only headphones, out-of-range puck), `ScoLink` logs a warning
  with the redacted MAC and falls back to the hint / speaker per the
  "override is best-effort" design discussed with the operator.
- `reassertCommDeviceIfNeeded` and `onAudioDevicesAdded` (warm-path
  re-pin) both use the same effective-MAC precedence so a mid-session
  re-add of the AINA or car BT doesn't clobber a legitimate override
  pin.
- Precedence is layered as a new pure companion selector,
  `pickBtCommDeviceWithOverride`, returning both the pick and an
  `overrideMissed` flag. The single-arg
  `pickBtCommDeviceFromCandidates` is preserved so the original
  `ScoLinkPickerTest` coverage still pins.
- No preference, UI, write-path, or symbol-renaming changes — this
  PR strictly re-orders how `ScoLink` reads two values that already
  exist.

## Test plan

- [x] `./gradlew ktlintCheck` — green
- [x] `./gradlew assembleCivDebug` — green
- [x] `./gradlew testCivDebugUnitTest` — green (19 total in
      `ScoLinkPickerTest`, incl. 9 new precedence tests)
- [ ] On-device: primary AINA persisted + Audio-device set to a
      non-primary HFP BT headset → verify RX audio arrives at the
      override device, not the AINA
- [ ] On-device: Audio-device set to an A2DP-only device
      (headphones without HFP) → verify the fall-back warning fires in
      logcat (`XvSco`: `outputBtOverrideMac … not available as comm
      device — falling back to preferredBtMacHint / speaker`) and
      audio lands on the AINA (or phone speaker if no AINA set)
- [ ] Regression: no Audio-device override set, primary AINA only →
      verify RX still routes to the AINA (unit test
      `only hint set — behaves like legacy single-arg selector`
      covers this at the selector level)