### PR TITLE
refactor(ui): rename Secondary → External button

### DIFF
--- a/app/src/main/aidl/com/atakmap/android/xv/service/IXvVoice.aidl
+++ b/app/src/main/aidl/com/atakmap/android/xv/service/IXvVoice.aidl
@@ -80,17 +80,18 @@ interface IXvVoice {
     void disconnectAina();
     boolean isAinaConnected();
 
-    // SECONDARY PTT input — an additional bonded BT speakermic or
-    // BLE PTT button that drives slot 0 in parallel with the primary.
+    // EXTERNAL BUTTON PTT input — an optional BLE PTT puck (Pryme
+    // BT-PTT-Z, PTT-Z01, generic BLE-HID) whose button drives slot 0
+    // in parallel with the primary speakermic. Button-only role.
     // PttDispatcher's OR-gate keeps concurrent presses from cutting
     // each other off so a motorcyclist with an AINA helmet
     // speakermic + a handlebar Pryme puck can hold either button
-    // without one tearing the other's TX down. Secondary is hard-
-    // locked to slot 0; PTTS / PTTE / MFB on the secondary device
-    // are ignored.
-    void connectAinaSecondary(String mac, String name, String kind);
-    void disconnectAinaSecondary();
-    boolean isAinaSecondaryConnected();
+    // without one tearing the other's TX down. The external button
+    // is hard-locked to slot 0; PTTS / PTTE / MFB on the external
+    // device are ignored.
+    void connectExternalButton(String mac, String name, String kind);
+    void disconnectExternalButton();
+    boolean isExternalButtonConnected();
 
     // Mumble session signal. The plugin still owns the Mumble TCP
     // socket (because cert lookup needs ATAK runtime), but tells the

--- a/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
+++ b/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
@@ -114,16 +114,16 @@ class XvMapComponent : AbstractMapComponent() {
     @Volatile
     private var lastAinaMac: String? = null
 
-    // Last secondary AINA / Pryme / BLE PTT MAC the plugin asked the
-    // service to bind, and a best-effort cached connect state for the
-    // UI. The service is the source of truth; we just need a snapshot
-    // for the picker status row so it doesn't have to round-trip AIDL
-    // on every refresh.
+    // Last external-button (AINA / Pryme / BLE PTT) MAC the plugin
+    // asked the service to bind, and a best-effort cached connect
+    // state for the UI. The service is the source of truth; we just
+    // need a snapshot for the picker status row so it doesn't have to
+    // round-trip AIDL on every refresh.
     @Volatile
-    private var lastSecondaryAinaMac: String? = null
+    private var lastExternalButtonMac: String? = null
 
     @Volatile
-    private var lastSecondaryAinaConnected: Boolean = false
+    private var lastExternalButtonConnected: Boolean = false
 
     // Resolved BluetoothDevice for the currently-connected AINA, set in
     // connectAinaInternal and cleared in disconnectAinaInternal.
@@ -1041,10 +1041,10 @@ class XvMapComponent : AbstractMapComponent() {
         // the speakermic's PTT / PTTE buttons produce events — that's
         // wrong for hardware the user has explicitly bonded.
         autoConnectAina()
-        // Restore the operator's secondary PTT input (e.g. handlebar
+        // Restore the operator's external button (e.g. handlebar
         // Pryme puck for a motorcyclist whose helmet AINA is the
-        // primary). No-op when no secondary is persisted.
-        autoConnectAinaSecondary()
+        // primary). No-op when no external button is persisted.
+        autoConnectExternalButton()
 
         // Trigger runtime permission prompts for our own UID. The
         // MapComponent runs in ATAK's process; checkSelfPermission here
@@ -1990,21 +1990,22 @@ class XvMapComponent : AbstractMapComponent() {
                 setSelectedAinaInternal(mac)
             }
 
-            override fun availableSecondaryAinaDevices(): List<com.atakmap.android.xv.aina.AinaDeviceInfo> {
-                // Secondary PTT is a BUTTON slot — a handlebar puck,
-                // hand-held BLE PTT, or similar hardware whose sole
-                // job is to key the primary channel when the operator
-                // can't easily reach the speakermic (motorcyclist
-                // scenario: AINA on the vest + BLE puck on the bar).
-                // Speakermics (AINA V1 SPP + AINA V2 BLE, both audio-
-                // carrying) are deliberately hidden — the operator
-                // wears at most one speakermic at a time, so a
-                // "second speakermic" pick is confusing UX with no
-                // real use case. Field-observed 2026-07-07: operator
-                // saw AINA entries in the secondary picker and asked
-                // why speakermics were listed there when the label
-                // already promised "Optional second button (e.g. a
-                // Pryme handlebar puck)".
+            override fun availableExternalButtonDevices(): List<com.atakmap.android.xv.aina.AinaDeviceInfo> {
+                // The external button is a BUTTON-ONLY slot — a
+                // handlebar puck, hand-held BLE PTT, or similar
+                // hardware whose sole job is to key the primary
+                // channel when the operator can't easily reach the
+                // speakermic (motorcyclist scenario: AINA on the vest
+                // + BLE puck on the bar). Speakermics (AINA V1 SPP +
+                // AINA V2 BLE, both audio-carrying) are deliberately
+                // hidden — the operator wears at most one speakermic
+                // at a time, so a "second speakermic" pick is
+                // confusing UX with no real use case. Field-observed
+                // 2026-07-07: operator saw AINA entries in the
+                // external-button picker and asked why speakermics
+                // were listed there when the label already promised
+                // "Optional second button (e.g. a Pryme handlebar
+                // puck)".
                 //
                 // Also hides the device the operator picked as PRIMARY
                 // so they can't accidentally double-connect to the
@@ -2017,9 +2018,9 @@ class XvMapComponent : AbstractMapComponent() {
                 }
             }
 
-            override fun selectedSecondaryAinaMac(): String? = settings.persistedSecondaryAinaMac()
+            override fun selectedExternalButtonMac(): String? = settings.persistedExternalButtonMac()
 
-            override fun secondaryAinaConnectionUp(): Boolean = lastSecondaryAinaConnected
+            override fun externalButtonConnectionUp(): Boolean = lastExternalButtonConnected
 
             override fun addBlePttDevice(
                 mac: String,
@@ -2031,11 +2032,11 @@ class XvMapComponent : AbstractMapComponent() {
                     "addBlePttDevice: mac=${com.atakmap.android.xv.aina.redactMac(normalized)} name=$name",
                 )
                 // Record in the known-BLE-PTT store so both the primary
-                // and secondary pickers surface this device. Which slot
-                // it goes into is the operator's call from the picker.
-                // Existing "primary MAC != secondary MAC" enforcement in
-                // setSelectedSecondaryAinaInternal continues to guard
-                // against collisions.
+                // and external-button pickers surface this device. Which
+                // slot it goes into is the operator's call from the
+                // picker. Existing "primary MAC != external-button MAC"
+                // enforcement in setSelectedExternalButtonInternal
+                // continues to guard against collisions.
                 settings.addKnownBlePttDevice(normalized, name)
                 return null
             }
@@ -2061,17 +2062,17 @@ class XvMapComponent : AbstractMapComponent() {
                 if (primary != null && primary.equals(normalized, ignoreCase = true)) {
                     setSelectedAinaInternal(null)
                 }
-                val secondary = settings.persistedSecondaryAinaMac()
-                if (secondary != null && secondary.equals(normalized, ignoreCase = true)) {
-                    setSelectedSecondaryAinaInternal(null)
+                val externalButton = settings.persistedExternalButtonMac()
+                if (externalButton != null && externalButton.equals(normalized, ignoreCase = true)) {
+                    setSelectedExternalButtonInternal(null)
                 }
                 settings.removeKnownBlePttDevice(normalized)
                 return null
             }
 
-            override fun setSelectedSecondaryAina(mac: String?) {
-                Log.i(TAG, "Controller.setSelectedSecondaryAina('$mac')")
-                setSelectedSecondaryAinaInternal(mac)
+            override fun setSelectedExternalButton(mac: String?) {
+                Log.i(TAG, "Controller.setSelectedExternalButton('$mac')")
+                setSelectedExternalButtonInternal(mac)
             }
 
             override fun autoConnectBtEnabled(): Boolean = settings.persistedAutoConnectBtEnabled()
@@ -2592,41 +2593,42 @@ class XvMapComponent : AbstractMapComponent() {
         ainaProbe ?: com.atakmap.android.xv.aina.AinaProtocolProbe(ctx).also { ainaProbe = it }
 
     @SuppressWarnings("MissingPermission")
-    private fun setSelectedSecondaryAinaInternal(mac: String?) {
-        settings.persistSecondaryAinaMac(mac)
+    private fun setSelectedExternalButtonInternal(mac: String?) {
+        settings.persistExternalButtonMac(mac)
         if (mac.isNullOrBlank()) {
-            voiceClient?.ifBound { it.disconnectAinaSecondary() }
-            lastSecondaryAinaMac = null
-            lastSecondaryAinaConnected = false
-            settings.persistSecondaryAinaKind(null)
+            voiceClient?.ifBound { it.disconnectExternalButton() }
+            lastExternalButtonMac = null
+            lastExternalButtonConnected = false
+            settings.persistExternalButtonKind(null)
             return
         }
         // Refuse silently if it collides with the primary — picker
         // already filters it out, but defend in depth.
         val primary = settings.persistedAinaMac()
         if (primary != null && primary.equals(mac, ignoreCase = true)) {
-            Log.w(TAG, "setSelectedSecondaryAinaInternal: $mac collides with primary — ignored")
-            settings.persistSecondaryAinaMac(null)
+            Log.w(TAG, "setSelectedExternalButtonInternal: $mac collides with primary — ignored")
+            settings.persistExternalButtonMac(null)
             return
         }
         val kind = resolveConnectKind(mac)
-        Log.i(TAG, "setSelectedSecondaryAinaInternal: connecting $mac as kind=$kind")
-        settings.persistSecondaryAinaKind(kind)
-        lastSecondaryAinaMac = mac
-        voiceClient?.ifBound { it.connectAinaSecondary(mac, null, kind) }
-        // No service-side state-edge callback for the secondary yet —
-        // optimistically cache "connected" so the UI shows progress.
-        // A future commit could thread an onAinaSecondaryConnectionChanged
-        // through the AIDL listener; for now the operator sees the picker
-        // status flip green on successful connect.
-        lastSecondaryAinaConnected = true
+        Log.i(TAG, "setSelectedExternalButtonInternal: connecting $mac as kind=$kind")
+        settings.persistExternalButtonKind(kind)
+        lastExternalButtonMac = mac
+        voiceClient?.ifBound { it.connectExternalButton(mac, null, kind) }
+        // No service-side state-edge callback for the external button
+        // yet — optimistically cache "connected" so the UI shows
+        // progress. A future commit could thread an
+        // onExternalButtonConnectionChanged through the AIDL listener;
+        // for now the operator sees the picker status flip green on
+        // successful connect.
+        lastExternalButtonConnected = true
     }
 
     // Shared MAC-format check for the scan-and-pick flow's primary /
-    // secondary Controller methods. Uppercases, normalizes dashes to
-    // colons, verifies the standard EUI-48 shape. Returns the
-    // canonical form on success or null on invalid input so callers
-    // can surface a specific error message.
+    // external-button Controller methods. Uppercases, normalizes
+    // dashes to colons, verifies the standard EUI-48 shape. Returns
+    // the canonical form on success or null on invalid input so
+    // callers can surface a specific error message.
     private fun normalizeAndValidateMac(mac: String): String? {
         val normalized = mac.trim().uppercase().replace('-', ':')
         val macRegex = Regex("^([0-9A-F]{2}:){5}[0-9A-F]{2}$")
@@ -2634,25 +2636,25 @@ class XvMapComponent : AbstractMapComponent() {
     }
 
     @SuppressWarnings("MissingPermission")
-    private fun autoConnectAinaSecondary() {
+    private fun autoConnectExternalButton() {
         // Slight delay to match autoConnectAina + give the BT adapter
         // time to settle.
         android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
-            val savedMac = settings.persistedSecondaryAinaMac()
+            val savedMac = settings.persistedExternalButtonMac()
             if (savedMac != null) {
-                connectSavedAinaSecondary(savedMac)
+                connectSavedExternalButton(savedMac)
                 return@postDelayed
             }
             if (!settings.persistedAutoConnectBtEnabled()) {
-                Log.i(TAG, "autoConnectAinaSecondary: no saved selection and auto-connect disabled — skipping")
+                Log.i(TAG, "autoConnectExternalButton: no saved selection and auto-connect disabled — skipping")
                 return@postDelayed
             }
-            // Auto-pick a SECONDARY: prefer a BLE_HID puck (typical
-            // motorcyclist handlebar button) over an additional
-            // speakermic, since the operator's primary is the audio
-            // path and a second audio device on slot 0 would compete
-            // for SCO. Filter out the primary's MAC so we don't pick
-            // the same device twice.
+            // Auto-pick an EXTERNAL BUTTON: prefer a BLE_HID puck
+            // (typical motorcyclist handlebar button) over an
+            // additional speakermic, since the operator's primary is
+            // the audio path and a second audio device on slot 0 would
+            // compete for SCO. Filter out the primary's MAC so we
+            // don't pick the same device twice.
             val primaryMac = settings.persistedAinaMac()
             val candidates =
                 listBondedAinaDevices()
@@ -2660,7 +2662,7 @@ class XvMapComponent : AbstractMapComponent() {
                         primaryMac != null && it.mac.equals(primaryMac, ignoreCase = true)
                     }
             if (candidates.isEmpty()) {
-                Log.i(TAG, "autoConnectAinaSecondary: no compatible secondary candidate — skipping")
+                Log.i(TAG, "autoConnectExternalButton: no compatible external-button candidate — skipping")
                 return@postDelayed
             }
             val picked =
@@ -2673,7 +2675,7 @@ class XvMapComponent : AbstractMapComponent() {
                     // create operator-surprise side effects. Operator
                     // can still manually pick a second AINA in the
                     // Settings → Preferences picker if they want it.
-                    Log.i(TAG, "autoConnectAinaSecondary: no BLE PTT button bonded — leaving secondary empty")
+                    Log.i(TAG, "autoConnectExternalButton: no BLE PTT button bonded — leaving external-button slot empty")
                     return@postDelayed
                 }
             val kind =
@@ -2683,41 +2685,41 @@ class XvMapComponent : AbstractMapComponent() {
                     com.atakmap.android.xv.aina.AinaDeviceInfo.ButtonProtocol.BLE -> "v2"
                     else -> "auto"
                 }
-            Log.i(TAG, "autoConnectAinaSecondary: auto-picked → ${picked.name} ${picked.mac} kind=$kind")
-            settings.persistSecondaryAinaMac(picked.mac)
-            settings.persistSecondaryAinaKind(kind)
-            lastSecondaryAinaMac = picked.mac
-            voiceClient?.ifBound { it.connectAinaSecondary(picked.mac, null, kind) }
-            lastSecondaryAinaConnected = true
+            Log.i(TAG, "autoConnectExternalButton: auto-picked → ${picked.name} ${picked.mac} kind=$kind")
+            settings.persistExternalButtonMac(picked.mac)
+            settings.persistExternalButtonKind(kind)
+            lastExternalButtonMac = picked.mac
+            voiceClient?.ifBound { it.connectExternalButton(picked.mac, null, kind) }
+            lastExternalButtonConnected = true
         }, 1400)
     }
 
     @SuppressWarnings("MissingPermission")
-    private fun connectSavedAinaSecondary(savedMac: String) {
+    private fun connectSavedExternalButton(savedMac: String) {
         val adapter = BluetoothAdapter.getDefaultAdapter() ?: return
         val bonded =
             try {
                 adapter.bondedDevices ?: emptySet()
             } catch (t: Throwable) {
-                Log.w(TAG, "connectSavedAinaSecondary: bondedDevices threw", t)
+                Log.w(TAG, "connectSavedExternalButton: bondedDevices threw", t)
                 return
             }
         val device =
             bonded.firstOrNull { it.address.equals(savedMac, ignoreCase = true) }
                 ?: run {
-                    Log.w(TAG, "connectSavedAinaSecondary: saved MAC $savedMac no longer bonded")
+                    Log.w(TAG, "connectSavedExternalButton: saved MAC $savedMac no longer bonded")
                     return
                 }
         val primary = settings.persistedAinaMac()
         if (primary != null && primary.equals(savedMac, ignoreCase = true)) {
-            Log.w(TAG, "connectSavedAinaSecondary: collides with primary — skipping")
+            Log.w(TAG, "connectSavedExternalButton: collides with primary — skipping")
             return
         }
-        val kind = settings.persistedSecondaryAinaKind() ?: "auto"
-        Log.i(TAG, "connectSavedAinaSecondary: ${device.name} ${device.address} kind=$kind")
-        lastSecondaryAinaMac = device.address
-        voiceClient?.ifBound { it.connectAinaSecondary(device.address, null, kind) }
-        lastSecondaryAinaConnected = true
+        val kind = settings.persistedExternalButtonKind() ?: "auto"
+        Log.i(TAG, "connectSavedExternalButton: ${device.name} ${device.address} kind=$kind")
+        lastExternalButtonMac = device.address
+        voiceClient?.ifBound { it.connectExternalButton(device.address, null, kind) }
+        lastExternalButtonConnected = true
     }
 
     private fun setSelectedAinaInternal(mac: String?) {

--- a/app/src/main/java/com/atakmap/android/xv/plugin/XvSettings.kt
+++ b/app/src/main/java/com/atakmap/android/xv/plugin/XvSettings.kt
@@ -43,28 +43,29 @@ class XvSettings(
         }
     }
 
-    // Secondary PTT input — an OPTIONAL second bonded BT device whose
-    // PTT button drives slot 0 in parallel with the primary. Motorcyclist
-    // use case: AINA helmet speakermic + Pryme handlebar puck both
-    // keying VS1. Independent of the primary so the operator can swap
-    // either side without affecting the other. Null/blank = no secondary
-    // selected (single-input behaviour).
-    fun persistedSecondaryAinaMac(): String? =
-        prefs()?.getString(PREF_AINA_MAC_SECONDARY, null)?.takeIf { it.isNotBlank() }
+    // External button — an OPTIONAL second bonded BT PTT input whose
+    // button drives slot 0 in parallel with the primary speakermic.
+    // Button-only role: a BLE PTT puck (Pryme BT-PTT-Z, PTT-Z01, generic
+    // BLE-HID). Motorcyclist use case: AINA helmet speakermic + Pryme
+    // handlebar puck both keying VS1. Independent of the primary so the
+    // operator can swap either side without affecting the other.
+    // Null/blank = no external button selected (single-input behaviour).
+    fun persistedExternalButtonMac(): String? =
+        prefs()?.getString(PREF_EXTERNAL_BUTTON_MAC, null)?.takeIf { it.isNotBlank() }
 
-    fun persistSecondaryAinaMac(mac: String?) {
+    fun persistExternalButtonMac(mac: String?) {
         prefs()?.edit()?.apply {
-            if (mac.isNullOrBlank()) remove(PREF_AINA_MAC_SECONDARY) else putString(PREF_AINA_MAC_SECONDARY, mac)
+            if (mac.isNullOrBlank()) remove(PREF_EXTERNAL_BUTTON_MAC) else putString(PREF_EXTERNAL_BUTTON_MAC, mac)
             apply()
         }
     }
 
-    fun persistedSecondaryAinaKind(): String? =
-        prefs()?.getString(PREF_AINA_KIND_SECONDARY, null)?.takeIf { it.isNotBlank() }
+    fun persistedExternalButtonKind(): String? =
+        prefs()?.getString(PREF_EXTERNAL_BUTTON_KIND, null)?.takeIf { it.isNotBlank() }
 
-    fun persistSecondaryAinaKind(kind: String?) {
+    fun persistExternalButtonKind(kind: String?) {
         prefs()?.edit()?.apply {
-            if (kind.isNullOrBlank()) remove(PREF_AINA_KIND_SECONDARY) else putString(PREF_AINA_KIND_SECONDARY, kind)
+            if (kind.isNullOrBlank()) remove(PREF_EXTERNAL_BUTTON_KIND) else putString(PREF_EXTERNAL_BUTTON_KIND, kind)
             apply()
         }
     }
@@ -259,9 +260,17 @@ class XvSettings(
         // Persistent keys.
         private const val PREF_AINA_MAC = "aina_mac"
 
-        // Secondary PTT input pair — see persistedSecondaryAinaMac.
-        private const val PREF_AINA_MAC_SECONDARY = "aina_mac_secondary"
-        private const val PREF_AINA_KIND_SECONDARY = "aina_kind_secondary"
+        // External-button input pair — see persistedExternalButtonMac.
+        //
+        // On-disk key names retain the historical `_secondary` suffix
+        // intentionally: this constant was renamed from
+        // PREF_AINA_MAC_SECONDARY / PREF_AINA_KIND_SECONDARY as part
+        // of the "Secondary → External button" concept rename, but the
+        // stored String value is preserved so existing installs keep
+        // auto-connecting the persisted MAC without a prefs migration.
+        // Do NOT change the string values.
+        private const val PREF_EXTERNAL_BUTTON_MAC = "aina_mac_secondary"
+        private const val PREF_EXTERNAL_BUTTON_KIND = "aina_kind_secondary"
 
         // Manually-added BLE PTT devices — see knownBlePttDevices.
         // Set<String> with "MAC|Name" entries.

--- a/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
@@ -336,21 +336,21 @@ class VoicePlant(
 
     @Volatile private var prymeBle: PrymeBleReader? = null
 
-    // Secondary PTT slot (e.g. a Pryme handlebar puck for motorcyclists
-    // who already wear an AINA speakermic). Independent connect /
-    // disconnect surface so the operator can pair both a speakermic
-    // AND a secondary button without one tearing the other down.
-    // PttDispatcher's OR-gate keeps concurrent presses from cutting
-    // each other off — see [PttDispatcher.down]. Secondary input is
-    // hard-locked to slot 0 (primary channel) and ignores PTTS/PTTE
-    // because the typical motorcyclist use case is "talk on the main
-    // channel without taking a hand off the bar" — not a full second
-    // input device with its own emergency button.
-    @Volatile private var ainaSecondarySpp: AinaSppReader? = null
+    // External-button PTT slot (e.g. a Pryme handlebar puck for
+    // motorcyclists who already wear an AINA speakermic). Independent
+    // connect / disconnect surface so the operator can pair both a
+    // speakermic AND an external button without one tearing the other
+    // down. PttDispatcher's OR-gate keeps concurrent presses from
+    // cutting each other off — see [PttDispatcher.down]. The external
+    // button is hard-locked to slot 0 (primary channel) and ignores
+    // PTTS/PTTE because the typical motorcyclist use case is "talk on
+    // the main channel without taking a hand off the bar" — not a full
+    // second input device with its own emergency button.
+    @Volatile private var externalButtonSpp: AinaSppReader? = null
 
-    @Volatile private var ainaSecondaryBle: AinaBleReader? = null
+    @Volatile private var externalButtonBle: AinaBleReader? = null
 
-    @Volatile private var prymeSecondaryBle: PrymeBleReader? = null
+    @Volatile private var externalButtonPrymeBle: PrymeBleReader? = null
 
     // MAC of the currently-connected AINA (or null when none). Used by
     // the BOND_STATE_CHANGED receiver to detect "the operator just
@@ -1223,30 +1223,30 @@ class VoicePlant(
     }
 
     /**
-     * Connect a SECONDARY AINA / Pryme / BLE PTT input. Use case:
-     * motorcyclist with an AINA V2 helmet speakermic AND a Pryme
-     * BLE PTT puck mounted on the handlebar — they need both to be
-     * able to key VS1 without one tearing the other down. Hard-
-     * locked to slot 0 (primary channel) and ignores PTTS/PTTE
-     * because the typical handlebar-button use case is "talk on
-     * the main channel"; a real second-channel split / emergency
-     * input would be its own redesign. Independent disconnect via
-     * [disconnectAinaSecondary] so the operator can swap the
-     * secondary independently of the primary.
+     * Connect an EXTERNAL BUTTON PTT input. Use case: motorcyclist
+     * with an AINA V2 helmet speakermic AND a Pryme BLE PTT puck
+     * mounted on the handlebar — they need both to be able to key
+     * VS1 without one tearing the other down. Hard-locked to slot 0
+     * (primary channel) and ignores PTTS/PTTE because the typical
+     * handlebar-button use case is "talk on the main channel"; a
+     * real second-channel split / emergency input would be its own
+     * redesign. Independent disconnect via [disconnectExternalButton]
+     * so the operator can swap the external button independently of
+     * the primary.
      */
-    fun connectAinaSecondary(
+    fun connectExternalButton(
         mac: String?,
         name: String?,
         kind: String?,
     ) {
         Log.i(
             TAG,
-            "connectAinaSecondary kind=$kind mac=${com.atakmap.android.xv.aina.redactMac(mac)}",
+            "connectExternalButton kind=$kind mac=${com.atakmap.android.xv.aina.redactMac(mac)}",
         )
-        disconnectAinaSecondary()
+        disconnectExternalButton()
         val adapter = android.bluetooth.BluetoothAdapter.getDefaultAdapter()
         if (adapter == null) {
-            Log.w(TAG, "connectAinaSecondary: no Bluetooth adapter")
+            Log.w(TAG, "connectExternalButton: no Bluetooth adapter")
             return
         }
         val device =
@@ -1262,11 +1262,11 @@ class VoicePlant(
                     null
                 }
             } catch (t: Throwable) {
-                Log.w(TAG, "connectAinaSecondary: resolve threw", t)
+                Log.w(TAG, "connectExternalButton: resolve threw", t)
                 null
             }
         if (device == null) {
-            Log.w(TAG, "connectAinaSecondary: no device for mac=$mac name=$name")
+            Log.w(TAG, "connectExternalButton: no device for mac=$mac name=$name")
             return
         }
         val resolvedKind =
@@ -1281,14 +1281,15 @@ class VoicePlant(
                 kind
             }
         // Mirror the primary path's per-source disconnect handling —
-        // when the secondary transport drops mid-TX, forget the held
-        // button so the burst can terminate. See the field-bug note in
-        // [connectAina] above; the same failure mode applies to a
-        // handlebar Pryme puck as to a helmet AINA.
+        // when the external-button transport drops mid-TX, forget the
+        // held button so the burst can terminate. See the field-bug
+        // note in [connectAina] above; the same failure mode applies
+        // to a handlebar Pryme puck as to a helmet AINA.
         val onConn: (source: PttSource, up: Boolean) -> Unit = { source, up ->
-            Log.i(TAG, "Secondary AINA connection up=$up source=$source")
-            // Secondary doesn't drive the AINA-connected dot in the UI
-            // (that's the primary's indicator). Logged only.
+            Log.i(TAG, "External button connection up=$up source=$source")
+            // External button doesn't drive the AINA-connected dot in
+            // the UI (that's the primary speakermic's indicator).
+            // Logged only.
             if (!up) {
                 releaseStuckPttOnTransportDrop(source)
             }
@@ -1298,59 +1299,59 @@ class VoicePlant(
                 val r =
                     AinaSppReader(
                         context,
-                        secondaryAinaEvent(PttSource.AINA_V1),
+                        externalButtonEvent(PttSource.AINA_V1),
                         { up -> onConn(PttSource.AINA_V1, up) },
                     )
-                ainaSecondarySpp = r
+                externalButtonSpp = r
                 r.connect(device)
             }
             "v2", "ble" -> {
                 val r =
                     AinaBleReader(
                         context,
-                        secondaryAinaEvent(PttSource.AINA_V2),
+                        externalButtonEvent(PttSource.AINA_V2),
                         { up -> onConn(PttSource.AINA_V2, up) },
                     )
-                ainaSecondaryBle = r
+                externalButtonBle = r
                 r.connect(device)
             }
             "ble-hid", "hid" -> {
                 val r =
                     PrymeBleReader(
                         context,
-                        secondaryAinaEvent(PttSource.PRYME_BLE),
+                        externalButtonEvent(PttSource.PRYME_BLE),
                         { up -> onConn(PttSource.PRYME_BLE, up) },
                     )
-                prymeSecondaryBle = r
+                externalButtonPrymeBle = r
                 r.connect(device)
             }
-            else -> Log.w(TAG, "connectAinaSecondary: unknown kind '$resolvedKind'")
+            else -> Log.w(TAG, "connectExternalButton: unknown kind '$resolvedKind'")
         }
     }
 
-    fun disconnectAinaSecondary() {
-        ainaSecondaryBle?.disconnect()
-        ainaSecondaryBle = null
-        ainaSecondarySpp?.disconnect()
-        ainaSecondarySpp = null
-        prymeSecondaryBle?.disconnect()
-        prymeSecondaryBle = null
-        // Clear any held-source bookkeeping the secondary left behind
-        // mid-burst — otherwise the OR-gate would think a press is
-        // still in flight on a now-disconnected source.
+    fun disconnectExternalButton() {
+        externalButtonBle?.disconnect()
+        externalButtonBle = null
+        externalButtonSpp?.disconnect()
+        externalButtonSpp = null
+        externalButtonPrymeBle?.disconnect()
+        externalButtonPrymeBle = null
+        // Clear any held-source bookkeeping the external button left
+        // behind mid-burst — otherwise the OR-gate would think a press
+        // is still in flight on a now-disconnected source.
         try {
-            // Multiple sources might match; clear all the secondary
-            // ones to be safe. Idempotent inside PttDispatcher.
+            // Multiple sources might match; clear all the external-
+            // button ones to be safe. Idempotent inside PttDispatcher.
             pttDispatcher.forgetSource(PttSource.AINA_V1)
             pttDispatcher.forgetSource(PttSource.AINA_V2)
             pttDispatcher.forgetSource(PttSource.PRYME_BLE)
         } catch (t: Throwable) {
-            Log.w(TAG, "forgetSource on secondary disconnect threw", t)
+            Log.w(TAG, "forgetSource on external-button disconnect threw", t)
         }
     }
 
-    fun isAinaSecondaryConnected(): Boolean =
-        ainaSecondaryBle != null || ainaSecondarySpp != null || prymeSecondaryBle != null
+    fun isExternalButtonConnected(): Boolean =
+        externalButtonBle != null || externalButtonSpp != null || externalButtonPrymeBle != null
 
     fun disconnectAina() {
         ainaBle?.disconnect()
@@ -1363,7 +1364,7 @@ class VoicePlant(
         // BT preference. Operator's explicit override (if any) still wins.
         router.preferredBtMacHint = null
         connectedAinaMac = null
-        // Mirror [disconnectAinaSecondary]: if the operator (or a wholesale
+        // Mirror [disconnectExternalButton]: if the operator (or a wholesale
         // BT-adapter-off cascade) is tearing us down mid-burst, drop any
         // held button state from the primary source so the OR-gate can
         // see an empty set and TxController.stop() runs. Idempotent
@@ -1450,7 +1451,7 @@ class VoicePlant(
     // Per-source button-handler factory for the primary input. Captures
     // [source] so PttDispatcher's OR-gate can distinguish concurrent
     // presses from different physical buttons (primary AINA + screen
-    // PTT, primary AINA + secondary handlebar puck, etc.). MFB
+    // PTT, primary AINA + external handlebar puck, etc.). MFB
     // (Voice Responder's multifunction call button) fires on RELEASE
     // only — single tap toggles the call state: answer if currently
     // ringing, hang up if currently active. Press-down is ignored so
@@ -1467,20 +1468,20 @@ class VoicePlant(
             }
         }
 
-    // Secondary input handler factory. Hard-locked to slot 0 (primary
-    // channel) and ignores PTTS / PTTE / MFB because the typical
-    // secondary-button use case is a motorcyclist's handlebar puck:
-    // "let me key the main channel from a second physical button I
-    // already have on the bike." Anything more nuanced (a real second
-    // input with full per-channel/emergency capability) is a separate
-    // redesign — out of scope for the "low-risk multi-PTT" the user
-    // asked for.
-    private fun secondaryAinaEvent(source: PttSource): (AinaButton, Boolean) -> Unit =
+    // External-button input handler factory. Hard-locked to slot 0
+    // (primary channel) and ignores PTTS / PTTE / MFB because the
+    // typical external-button use case is a motorcyclist's handlebar
+    // puck: "let me key the main channel from a second physical button
+    // I already have on the bike." Anything more nuanced (a real
+    // second input with full per-channel/emergency capability) is a
+    // separate redesign — out of scope for the "low-risk multi-PTT"
+    // the user asked for.
+    private fun externalButtonEvent(source: PttSource): (AinaButton, Boolean) -> Unit =
         { btn, down ->
-            Log.i(TAG, "secondary AINA button $btn down=$down source=$source")
+            Log.i(TAG, "external button $btn down=$down source=$source")
             when (btn) {
                 AinaButton.PTT -> if (down) pttDown(0, source) else pttUp(0, source)
-                else -> { /* secondary input does not drive PTTS/PTTE/MFB */ }
+                else -> { /* external button does not drive PTTS/PTTE/MFB */ }
             }
         }
 
@@ -1547,7 +1548,7 @@ class VoicePlant(
         } catch (_: Throwable) {
         }
         try {
-            disconnectAinaSecondary()
+            disconnectExternalButton()
         } catch (_: Throwable) {
         }
         try {

--- a/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
@@ -1641,23 +1641,23 @@ class XvVoiceService : Service() {
                 return plant().isAinaConnected()
             }
 
-            override fun connectAinaSecondary(
+            override fun connectExternalButton(
                 mac: String?,
                 name: String?,
                 kind: String?,
             ) {
                 assertAuthorizedCaller()
-                plant().connectAinaSecondary(mac, name, kind)
+                plant().connectExternalButton(mac, name, kind)
             }
 
-            override fun disconnectAinaSecondary() {
+            override fun disconnectExternalButton() {
                 assertAuthorizedCaller()
-                plant().disconnectAinaSecondary()
+                plant().disconnectExternalButton()
             }
 
-            override fun isAinaSecondaryConnected(): Boolean {
+            override fun isExternalButtonConnected(): Boolean {
                 assertAuthorizedCaller()
-                return plant().isAinaSecondaryConnected()
+                return plant().isExternalButtonConnected()
             }
 
             override fun setMumbleSessionState(connectedAndInChannel: Boolean) {

--- a/app/src/main/java/com/atakmap/android/xv/ui/XvDropDownReceiver.kt
+++ b/app/src/main/java/com/atakmap/android/xv/ui/XvDropDownReceiver.kt
@@ -186,24 +186,25 @@ class XvDropDownReceiver(
         // launches; auto-connect on plugin load uses this MAC if set.
         fun setSelectedAina(mac: String?)
 
-        // ---- Secondary PTT (Settings → Preferences) ----
-        // Optional second AINA / Pryme / BLE PTT input that keys
-        // slot 0 in parallel with the primary. Motorcyclist use case:
+        // ---- External button (Settings → Preferences) ----
+        // Optional BLE PTT puck (Pryme BT-PTT-Z, PTT-Z01, generic
+        // BLE-HID) whose button keys slot 0 in parallel with the
+        // primary speakermic. Button-only role. Motorcyclist use case:
         // helmet speakermic + handlebar puck both keying VS1 without
         // one cutting the other off. Independent of the primary so
         // either can be swapped without affecting the other.
-        fun availableSecondaryAinaDevices(): List<AinaDeviceInfo> = emptyList()
+        fun availableExternalButtonDevices(): List<AinaDeviceInfo> = emptyList()
 
-        fun selectedSecondaryAinaMac(): String? = null
+        fun selectedExternalButtonMac(): String? = null
 
-        fun secondaryAinaConnectionUp(): Boolean = false
+        fun externalButtonConnectionUp(): Boolean = false
 
-        fun setSelectedSecondaryAina(mac: String?) {}
+        fun setSelectedExternalButton(mac: String?) {}
 
         // Assign a scan-discovered BLE PTT button to the primary or
-        // secondary PTT slot. Both persist the MAC + kind="ble-hid" and
-        // hand off to the existing service-side connect path
-        // (IXvVoice.connectAina / connectAinaSecondary), which uses
+        // external-button PTT slot. Both persist the MAC + kind="ble-hid"
+        // and hand off to the existing service-side connect path
+        // (IXvVoice.connectAina / connectExternalButton), which uses
         // PrymeBleReader on top of the HM-10 transparent-UART service.
         // The device does NOT need to be bonded — BluetoothAdapter's
         // getRemoteDevice(mac) constructs a BluetoothDevice from the
@@ -212,9 +213,10 @@ class XvDropDownReceiver(
         // operator-actionable error string on failure.
         // Add a scan-discovered BLE PTT button to the known-devices
         // library. Does NOT assign it to a slot — the operator picks
-        // it from the primary or secondary picker afterwards, subject
-        // to the existing "primary MAC != secondary MAC" rule. Returns
-        // null on success or a short operator-actionable error.
+        // it from the primary or external-button picker afterwards,
+        // subject to the existing "primary MAC != external-button MAC"
+        // rule. Returns null on success or a short operator-actionable
+        // error.
         fun addBlePttDevice(
             mac: String,
             name: String?,
@@ -227,10 +229,10 @@ class XvDropDownReceiver(
         fun knownBlePttDevices(): List<AinaDeviceInfo> = emptyList()
 
         // Clear a persisted BLE PTT device by MAC. Also clears it from
-        // the primary / secondary slot if the operator had assigned it
-        // there. Returns null on success or an operator-actionable
-        // error string. No-op if the MAC isn't in the known-devices
-        // store.
+        // the primary / external-button slot if the operator had
+        // assigned it there. Returns null on success or an
+        // operator-actionable error string. No-op if the MAC isn't in
+        // the known-devices store.
         fun removeBlePttDevice(mac: String): String? = "not implemented"
 
         // ---- BT auto-connect toggle ----
@@ -1240,11 +1242,11 @@ class XvDropDownReceiver(
                 ) {
                     if (intent?.action != BluetoothAdapter.ACTION_STATE_CHANGED) return
                     refresh()
-                    // Repopulate the AINA + secondary AINA pickers so
+                    // Repopulate the AINA + external-button pickers so
                     // newly-visible (or newly-hidden) bonded devices
                     // show up without the operator having to close
                     // and reopen the Settings panel. wireAinaPicker /
-                    // wireSecondaryAinaPicker are idempotent — each
+                    // wireExternalButtonPicker are idempotent — each
                     // just resets adapter + selection + listener on
                     // the same spinner view. Field-observed 2026-07-07:
                     // after re-enabling Bluetooth from the banner tap,
@@ -1267,9 +1269,9 @@ class XvDropDownReceiver(
                             android.util.Log.w("XvSettings", "wireAinaPicker refresh after BT state change threw", t)
                         }
                         try {
-                            wireSecondaryAinaPicker(v)
+                            wireExternalButtonPicker(v)
                         } catch (t: Throwable) {
-                            android.util.Log.w("XvSettings", "wireSecondaryAinaPicker refresh after BT state change threw", t)
+                            android.util.Log.w("XvSettings", "wireExternalButtonPicker refresh after BT state change threw", t)
                         }
                     }
                 }
@@ -1314,7 +1316,7 @@ class XvDropDownReceiver(
         // List order MUST match the tab strip's visual order so
         // select(0) puts the first tab up. Operator-visible ordering
         // is Devices (prefs) | TX/RX | Server (calls) — Devices leads
-        // because it carries the AINA / secondary PTT / audio-device
+        // because it carries the AINA / external-button / audio-device
         // pickers operators touch every session. The XML id names
         // still say "prefs" for backward compatibility with the
         // findViewById calls above.
@@ -1440,7 +1442,7 @@ class XvDropDownReceiver(
         }
 
         wireAinaPicker(v)
-        wireSecondaryAinaPicker(v)
+        wireExternalButtonPicker(v)
         wireBlePttScanButton(v)
         wireAutoConnectBtSwitch(v)
         wireBtAudioOverridePicker(v)
@@ -1513,7 +1515,7 @@ class XvDropDownReceiver(
         spinner.setSelection(pos)
     }
 
-    // Builds an ArrayAdapter shared by the primary + secondary AINA
+    // Builds an ArrayAdapter shared by the primary + external-button
     // pickers. Row 0 is the "no external button" sentinel; subsequent
     // rows correspond 1:1 with `devices` (so callers convert
     // spinner-pos to a device via pos-1). Unavailable rows carry a
@@ -1650,16 +1652,16 @@ class XvDropDownReceiver(
             }
     }
 
-    // Secondary PTT picker. Same shape as wireAinaPicker but routes
-    // through setSelectedSecondaryAina. The Controller's
-    // availableSecondaryAinaDevices already filters out the primary
+    // External-button picker. Same shape as wireAinaPicker but routes
+    // through setSelectedExternalButton. The Controller's
+    // availableExternalButtonDevices already filters out the primary
     // so the operator can't double-pick.
-    private fun wireSecondaryAinaPicker(v: View) {
+    private fun wireExternalButtonPicker(v: View) {
         val spinner = v.findViewById<Spinner>(R.id.xv_spinner_aina_secondary) ?: return
         val statusLabel = v.findViewById<TextView>(R.id.xv_label_aina_secondary_status)
-        val devices = controller.availableSecondaryAinaDevices()
+        val devices = controller.availableExternalButtonDevices()
         spinner.adapter = buildAinaPickerAdapter(devices)
-        val selectedMac = controller.selectedSecondaryAinaMac()
+        val selectedMac = controller.selectedExternalButtonMac()
         val selectedIdx =
             if (selectedMac == null) {
                 0
@@ -1669,10 +1671,10 @@ class XvDropDownReceiver(
             }
         spinner.setSelection(selectedIdx)
         statusLabel?.text =
-            formatAinaStatus(devices, selectedMac, controller.secondaryAinaConnectionUp())
+            formatAinaStatus(devices, selectedMac, controller.externalButtonConnectionUp())
         // See wireAinaPicker for the same first-fire suppression rationale.
         // A spurious pos=0 fire from setAdapter/setSelection would write
-        // null back to persisted-secondary and disconnect the reader.
+        // null back to persisted-external-button and disconnect the reader.
         var suppressFirstFire = true
         spinner.onItemSelectedListener =
             object : android.widget.AdapterView.OnItemSelectedListener {
@@ -1692,11 +1694,11 @@ class XvDropDownReceiver(
                         } else {
                             devices.getOrNull(pos - 1)?.mac
                         }
-                    val current = controller.selectedSecondaryAinaMac()
+                    val current = controller.selectedExternalButtonMac()
                     if (pickedMac != current) {
-                        controller.setSelectedSecondaryAina(pickedMac)
+                        controller.setSelectedExternalButton(pickedMac)
                         statusLabel?.text =
-                            formatAinaStatus(devices, pickedMac, controller.secondaryAinaConnectionUp())
+                            formatAinaStatus(devices, pickedMac, controller.externalButtonConnectionUp())
                     }
                 }
 
@@ -1708,8 +1710,8 @@ class XvDropDownReceiver(
     // buttons (Pryme BT-PTT-Z, PTT-Z01, similar HM-10-based hardware
     // that won't pair via the phone's system Bluetooth settings),
     // shows results in a live-updating dialog, then asks the operator
-    // whether to assign the picked device to the primary or secondary
-    // PTT slot. Delegates the actual connect to the Controller.
+    // whether to assign the picked device to the primary or external-
+    // button PTT slot. Delegates the actual connect to the Controller.
     private fun wireBlePttScanButton(v: View) {
         val btn = v.findViewById<Button>(R.id.xv_btn_scan_ble_ptt) ?: return
         btn.setOnClickListener { showBlePttScanDialog(v) }
@@ -1748,11 +1750,11 @@ class XvDropDownReceiver(
                                 err ?: "Removed ${picked.name}",
                                 if (err == null) android.widget.Toast.LENGTH_SHORT else android.widget.Toast.LENGTH_LONG,
                             ).show()
-                        // Rebuild the primary + secondary pickers so
-                        // the removed device disappears immediately
+                        // Rebuild the primary + external-button pickers
+                        // so the removed device disappears immediately
                         // without waiting for a settings re-open.
                         wireAinaPicker(rootView)
-                        wireSecondaryAinaPicker(rootView)
+                        wireExternalButtonPicker(rootView)
                     }.setNegativeButton("Cancel", null)
                     .show()
             }.setNegativeButton("Cancel", null)
@@ -1830,7 +1832,7 @@ class XvDropDownReceiver(
         val displayName = picked.name?.takeIf { it.isNotBlank() } ?: picked.mac
         val err = controller.addBlePttDevice(picked.mac, picked.name)
         val msg =
-            err ?: "Added $displayName — now pick it from the Primary PTT or Secondary PTT dropdown."
+            err ?: "Added $displayName — now pick it from the Primary PTT or External button dropdown."
         android.widget.Toast
             .makeText(
                 pluginContext,
@@ -1841,7 +1843,7 @@ class XvDropDownReceiver(
             // Rebuild both pickers so the new device appears in the
             // dropdowns immediately without a settings re-open.
             wireAinaPicker(rootView)
-            wireSecondaryAinaPicker(rootView)
+            wireExternalButtonPicker(rootView)
         }
     }
 

--- a/app/src/main/res/layout/xv_settings.xml
+++ b/app/src/main/res/layout/xv_settings.xml
@@ -36,7 +36,7 @@
 
     <!-- Tab strip: Devices | TX/RX | Server.
          Devices sits leftmost + is the default because the AINA
-         speakermic / secondary PTT / audio-device pickers are the
+         speakermic / external-button / audio-device pickers are the
          controls operators touch every session; TX/RX (hot-mic,
          timeouts, tone) is tuning; Server (TAK server picker, Mumble
          connect/disconnect) is one-time enrollment. Tab IDs were
@@ -415,11 +415,11 @@
                     android:fontFamily="monospace"
                     android:layout_marginTop="4dp"/>
 
-                <!-- Section header: Secondary PTT input -->
+                <!-- Section header: External button input -->
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="SECONDARY PTT"
+                    android:text="EXTERNAL BUTTON"
                     android:textColor="@color/xv_text_dim"
                     android:textSize="11sp"
                     android:letterSpacing="0.15"
@@ -428,7 +428,7 @@
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="Optional second button (e.g. a Pryme handlebar puck for motorcyclists, or any compatible BLE PTT). Either button can key the primary channel without one cutting off the other."
+                    android:text="Optional BLE PTT puck (e.g. Pryme BT-PTT). Provides an extra push-to-talk button; must be button-only — speakermics belong in the Primary slot. Either button can key the primary channel without one cutting off the other."
                     android:textColor="@color/xv_text_dim"
                     android:textSize="11sp"
                     android:layout_marginTop="2dp"/>
@@ -458,9 +458,9 @@
                      transparent-UART service UUID (Pryme BT-PTT-Z,
                      PTT-Z01, similar HM-10 buttons) plus a name filter
                      for anything advertising "PTT". On tap, operator
-                     picks the device + which slot (primary or secondary)
-                     to assign it to; XV connects via unbonded GATT
-                     through PrymeBleReader. -->
+                     picks the device + which slot (primary or external
+                     button) to assign it to; XV connects via unbonded
+                     GATT through PrymeBleReader. -->
                 <Button
                     android:id="@+id/xv_btn_scan_ble_ptt"
                     android:layout_width="match_parent"

--- a/app/src/test/java/com/atakmap/android/xv/audio/PttDispatcherTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/audio/PttDispatcherTest.kt
@@ -285,9 +285,9 @@ class PttDispatcherTest {
 
     @Test
     fun `OR-gate — forgetSource on one of multiple held sources keeps TX engaged`() {
-        // Concurrent burst: the secondary AINA disconnects mid-press
-        // while the operator's on-screen PTT is still held. TX must
-        // stay engaged on the surviving source.
+        // Concurrent burst: the external-button AINA disconnects
+        // mid-press while the operator's on-screen PTT is still held.
+        // TX must stay engaged on the surviving source.
         val d = buildDispatcher()
         d.down(slot = 0, source = PttSource.AINA_V1)
         d.down(slot = 0, source = PttSource.ON_SCREEN)


### PR DESCRIPTION
## Motivation

The optional second BT PTT input slot has been called "Secondary" in
the UI and Kotlin code since it landed, which carried the wrong
mental model. "Secondary" implied a full second speakermic — a role
XV has never supported and never will (see the audio-plant Rule 2
constraint: only one BT speakermic can sensibly own SCO at a time).
An operator recently flagged the confusion in the field: they saw
AINA speakermics listed in the "Secondary PTT" picker and asked why,
when the description already promised "a Pryme handlebar puck".

The correct mental model is:

- **Primary speakermic** — an HFP device that provides audio in/out
  AND its own PTT button. Always one device.
- **External button** — an optional BLE PTT puck (Pryme BT-PTT-Z,
  PTT-Z01, generic BLE-HID) that keys the primary channel in parallel
  with the primary speakermic via PttDispatcher's OR-gate. Button-only.

This PR is the trivial-diff foundation for the follow-up work that
will restructure the Devices tab and add main-page icons (both
tracked separately).

## What changed

Pure rename — zero behavior change, zero pref-key migration on disk.

- **XvSettings.kt** — Kotlin constants
  `PREF_AINA_MAC_SECONDARY` / `PREF_AINA_KIND_SECONDARY` renamed to
  `PREF_EXTERNAL_BUTTON_MAC` / `PREF_EXTERNAL_BUTTON_KIND`.
  Getters/setters `persistedSecondaryAinaMac()` / `persistSecondaryAinaMac()`
  / `persistedSecondaryAinaKind()` / `persistSecondaryAinaKind()`
  renamed to their external-button equivalents. A Kdoc block
  documents the intentional preservation of the on-disk string
  values `"aina_mac_secondary"` and `"aina_kind_secondary"` — this
  is load-bearing (see "What stayed" below).
- **XvMapComponent.kt** — private methods
  `setSelectedSecondaryAinaInternal` / `autoConnectAinaSecondary` /
  `connectSavedAinaSecondary`, volatile fields
  `lastSecondaryAinaMac` / `lastSecondaryAinaConnected`, and the
  Controller-facing methods `availableSecondaryAinaDevices` /
  `selectedSecondaryAinaMac` / `secondaryAinaConnectionUp` /
  `setSelectedSecondaryAina` all renamed. Log strings that mean
  "the button-only second slot" updated; log strings that mean
  "VS2 / Mumble secondary channel" are untouched (different concept).
- **XvDropDownReceiver.kt** — Controller-interface method renames
  matching XvMapComponent, plus `wireSecondaryAinaPicker` →
  `wireExternalButtonPicker`. The scan-and-add flow toast now
  reads "External button dropdown".
- **VoicePlant.kt** + **XvVoiceService.kt** — reader fields
  `ainaSecondarySpp` / `ainaSecondaryBle` / `prymeSecondaryBle`
  renamed to `externalButtonSpp` / `externalButtonBle` /
  `externalButtonPrymeBle`; handler-factory `secondaryAinaEvent` →
  `externalButtonEvent`; service methods `connectAinaSecondary` /
  `disconnectAinaSecondary` / `isAinaSecondaryConnected` renamed to
  their external-button equivalents.
- **IXvVoice.aidl** — matching AIDL method rename. Only internal
  consumers (plugin process + service process in the same APK); no
  external AIDL client to break.
- **xv_settings.xml** — section header "SECONDARY PTT" → "EXTERNAL
  BUTTON", description text rewritten to make the button-only
  contract explicit.
- **PttDispatcherTest.kt** — updated one test-comment scenario
  description to use "external-button AINA" instead of "secondary
  AINA".

## What stayed (deliberately)

- **On-disk pref keys**. The SharedPreferences string values
  `"aina_mac_secondary"` and `"aina_kind_secondary"` are preserved
  verbatim. Existing installs must keep auto-connecting the
  persisted external-button MAC on plugin start without any
  migration step. Only the Kotlin constant *names* changed.
- **XML view IDs** on the spinner + status label
  (`xv_spinner_aina_secondary`, `xv_label_aina_secondary_status`).
  Only the visible `android:text` values changed. This avoids
  breaking any layout-inflation references that key on the id.
- **Every other "secondary" reference in the codebase**. VS2 /
  Mumble secondary channels, `setSecondaryChannel`,
  `secondarySlotSuffix`, `PttSource` per-device-type roles, and
  the AINA wire-protocol `PTTS` bit are unrelated concepts and are
  untouched.
- **All behavior**. Auto-connect on plugin load, picker filtering
  (BLE_HID-only, primary-MAC exclusion), OR-gate handling of
  concurrent presses, audio routing, and PttDispatcher slot 0
  hard-lock all work exactly as before.

## Test plan

Verified locally on branch:

- [x] `./gradlew ktlintCheck` — green
- [x] `./gradlew assembleCivDebug` — green
- [x] `./gradlew testCivDebugUnitTest` — green

On-device smoke (please run before merge):

- [ ] Open Settings → Devices — the section that used to read
      "SECONDARY PTT" now reads "EXTERNAL BUTTON" with the updated
      description text.
- [ ] An install that had a Secondary MAC persisted before this PR
      still auto-connects that MAC on the next plugin start
      (proves the on-disk-key preservation works).
- [ ] Picker still lists only BLE_HID-classified devices in the
      External Button dropdown; speakermic entries stay hidden.
- [ ] Simultaneous hold of the primary speakermic PTT + the
      external-button puck still routes to slot 0 without either
      release cutting the burst short.