### PR TITLE
feat(ptt): Samsung Active Key as optional PTT source

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,11 @@ and feature polish.
 3. **External button registration.** XV registers BT speakermic buttons
    per-MAC for the curated device list — SPP-based hardware (AINA APTT
    V1 and similar Pryme speakermics) and BLE GATT devices (AINA APTT V2,
-   Pryme BT-PTT-Z).
+   Pryme BT-PTT-Z). On Samsung ruggedized hardware (Galaxy Tab Active5,
+   XCover6 Pro / 7, Tab Active4 Pro, Tab Active3) the programmable
+   side Active Key can be enabled as an additional PTT source alongside
+   any bonded speakermic — the toggle only appears on hardware that
+   actually has the key.
 
 4. **Reachability-aware BT device picker.** On plugin load, XV restores
    the last-connected speakermic when it's actually reachable and

--- a/app/src/main/aidl/com/atakmap/android/xv/service/IXvVoice.aidl
+++ b/app/src/main/aidl/com/atakmap/android/xv/service/IXvVoice.aidl
@@ -105,6 +105,19 @@ interface IXvVoice {
     void setSamsungActiveKeyEnabled(boolean enabled);
     boolean isSamsungActiveKeyRunning();
 
+    // Foreground-KeyEvent fallback for the Samsung Active Key. Some
+    // firmware (verified on Tab Active5 / SM-X308U 2026-07-10) does
+    // NOT emit `HARD_KEY_REPORT` and only routes the key as a
+    // `KeyEvent` to the foreground activity. XvMapComponent hooks the
+    // MapView's OnKeyListener, filters `KEYCODE == 1015`, and forwards
+    // the down/up edge across this AIDL so the service's PttDispatcher
+    // sees a `PttSource.SAMSUNG_ACTIVE_KEY`-tagged edge (same source
+    // tag the broadcast path uses — the dispatcher's OR-gate collapses
+    // duplicates when both paths happen to fire on the same press).
+    // No-op on non-Samsung devices (plugin gates the call on
+    // `SamsungActiveKey.isSupported`).
+    void notifySamsungActiveKeyEdge(boolean isDown);
+
     // Mumble session signal. The plugin still owns the Mumble TCP
     // socket (because cert lookup needs ATAK runtime), but tells the
     // service when there's a live session so the service knows

--- a/app/src/main/aidl/com/atakmap/android/xv/service/IXvVoice.aidl
+++ b/app/src/main/aidl/com/atakmap/android/xv/service/IXvVoice.aidl
@@ -92,6 +92,19 @@ interface IXvVoice {
     void disconnectAinaSecondary();
     boolean isAinaSecondaryConnected();
 
+    // Samsung ruggedized-device Active Key PTT source. When enabled
+    // AND the device is a Samsung Tab Active5 / XCover6 Pro / etc.
+    // that actually has the key, the service registers a broadcast
+    // receiver for `HARD_KEY_REPORT` and translates press / release
+    // into slot-0 PTT edges via `PttSource.SAMSUNG_ACTIVE_KEY`. On
+    // any non-Samsung device the plugin never enables this — it's a
+    // zero-cost feature (no receiver registered, no behaviour
+    // change). Independent of AINA / External Button; uses the
+    // dispatcher's multi-source OR-gate so concurrent presses across
+    // sources don't cut each other off.
+    void setSamsungActiveKeyEnabled(boolean enabled);
+    boolean isSamsungActiveKeyRunning();
+
     // Mumble session signal. The plugin still owns the Mumble TCP
     // socket (because cert lookup needs ATAK runtime), but tells the
     // service when there's a live session so the service knows

--- a/app/src/main/java/com/atakmap/android/xv/audio/PttSource.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/PttSource.kt
@@ -18,6 +18,16 @@ enum class PttSource(val dropsTrailingClick: Boolean) {
     AINA_V1(dropsTrailingClick = true),
     AINA_V2(dropsTrailingClick = true),
     PRYME_BLE(dropsTrailingClick = true),
+
+    // Samsung ruggedized-device programmable Active Key (Tab Active5,
+    // XCover6 Pro / 7, etc.). Emits `HARD_KEY_REPORT` broadcasts we
+    // convert into PTT down/up edges via [SamsungActiveKeyReader]. The
+    // key is a bare rubber-dome side button on the tablet chassis with
+    // no audible click at release — same as ON_SCREEN, so we do NOT
+    // trim the trailing frame on release. Independent PTT source; runs
+    // in parallel with AINA / External Button via the dispatcher's
+    // OR-gate.
+    SAMSUNG_ACTIVE_KEY(dropsTrailingClick = false),
     DEBUG(dropsTrailingClick = false),
     ;
 

--- a/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
+++ b/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
@@ -486,6 +486,19 @@ class XvMapComponent : AbstractMapComponent() {
     private var ainaBle: AinaBleReader? = null
     private var ainaSpp: AinaSppReader? = null
     private var emergency: EmergencyController? = null
+
+    // Foreground-KeyEvent fallback for the Samsung Active Key. Attached
+    // to the MapView's OnKeyListener only on Samsung ruggedized
+    // hardware AND when the operator has enabled the feature. On any
+    // non-Samsung device this stays null and the OnKeyListener is
+    // never added. Required for Tab Active5 / SM-X308U-class firmware
+    // where the HARD_KEY_REPORT broadcast is not emitted — the plain
+    // KeyEvent is the only signal. Foreground-only by construction
+    // (InputDispatcher routes non-broadcast keys to the top activity);
+    // the broadcast path in the service handles background PTT on
+    // firmware that emits it.
+    @Volatile
+    private var samsungActiveKeyFg: com.atakmap.android.xv.ptt.SamsungActiveKeyForegroundReader? = null
     private var presenceRegistry: XvPresenceRegistry? = null
     private var presencePublisher: XvCotPublisher? = null
     private var presenceListener: XvCotListener? = null
@@ -1148,6 +1161,14 @@ class XvMapComponent : AbstractMapComponent() {
         context: Context,
         mapView: MapView,
     ) {
+        // Foreground-KeyEvent fallback path: detach the OnKeyListener
+        // BEFORE we drop heldMapView. Also fires a defensive up() so
+        // the service's dispatcher can't strand SAMSUNG_ACTIVE_KEY in
+        // heldButtons if the plugin unloads mid-press.
+        try {
+            stopSamsungActiveKeyForeground()
+        } catch (_: Throwable) {
+        }
         presenceListener?.stop()
         presenceListener = null
         presencePublisher?.stop()
@@ -2119,6 +2140,14 @@ class XvMapComponent : AbstractMapComponent() {
                 voiceClient?.setPersistent("samsungActiveKey") {
                     it.setSamsungActiveKeyEnabled(enabled)
                 }
+                // Foreground-KeyEvent fallback path (attached in ATAK's
+                // process). Runs in parallel with the service-side
+                // broadcast reader — the dispatcher's OR-gate collapses
+                // any duplicate down / up if both paths happen to fire
+                // for the same press. Started / stopped in lockstep
+                // with the toggle so a mid-session flip cleans up
+                // consistently across both paths.
+                if (enabled) startSamsungActiveKeyForeground() else stopSamsungActiveKeyForeground()
             }
 
             override fun latchedMode(): Boolean = settings.persistedLatchedMode()
@@ -2320,6 +2349,87 @@ class XvMapComponent : AbstractMapComponent() {
         }
         Log.i(TAG, "autoStartSamsungActiveKey: enabling Samsung Active Key PTT")
         voiceClient?.setPersistent("samsungActiveKey") { it.setSamsungActiveKeyEnabled(true) }
+        // Also start the foreground-KeyEvent fallback. Required on
+        // Tab Active5-class firmware that doesn't emit HARD_KEY_REPORT;
+        // harmless additive path on firmware that does (dispatcher's
+        // OR-gate collapses duplicate edges by source).
+        startSamsungActiveKeyForeground()
+    }
+
+    /**
+     * Attach the [com.atakmap.android.xv.ptt.SamsungActiveKeyForegroundReader]
+     * to the MapView. Idempotent. The reader translates a foreground
+     * `KEYCODE == 1015` down / up into a
+     * `PttSource.SAMSUNG_ACTIVE_KEY` edge dispatched to the service
+     * via [IXvVoice.notifySamsungActiveKeyEdge]. Runs in parallel with
+     * the service-side broadcast reader — the dispatcher's OR-gate
+     * dedupes if both paths ever fire for the same press.
+     *
+     * Foreground-only by design: `InputDispatcher` routes non-broadcast
+     * keys to the top activity, so this reader only sees events while
+     * ATAK is what the operator is looking at. The broadcast path
+     * ([com.atakmap.android.xv.ptt.SamsungActiveKeyReader], in the
+     * service) is still the ideal for backgrounded PTT, but on
+     * firmware that doesn't emit `HARD_KEY_REPORT` (verified on
+     * Tab Active5 / SM-X308U 2026-07-10), this KeyEvent path is the
+     * ONLY signal the Active Key produces.
+     */
+    private fun startSamsungActiveKeyForeground() {
+        val mapView = heldMapView ?: return
+        val ctx = mapView.context
+        if (!com.atakmap.android.xv.util.SamsungActiveKey.isSupported(ctx)) {
+            // Same device gate as the broadcast path — no OnKeyListener
+            // on non-Samsung hardware, zero cost on Pixel / Motorola /
+            // etc.
+            return
+        }
+        if (samsungActiveKeyFg != null) {
+            Log.i(TAG, "startSamsungActiveKeyForeground: already attached — ignoring")
+            return
+        }
+        val reader =
+            com.atakmap.android.xv.ptt.SamsungActiveKeyForegroundReader { isDown, _ ->
+                // We deliberately drop the source arg here — the AIDL
+                // hop is source-implicit (the receiver on the service
+                // side always tags SAMSUNG_ACTIVE_KEY). The Boolean is
+                // enough to preserve edge direction across the process
+                // boundary.
+                voiceClient?.ifBound { it.notifySamsungActiveKeyEdge(isDown) }
+            }
+        if (reader.start(mapView)) {
+            samsungActiveKeyFg = reader
+        } else {
+            Log.w(TAG, "startSamsungActiveKeyForeground: reader.start() failed — leaving detached")
+        }
+    }
+
+    /**
+     * Detach the foreground KeyEvent reader from the MapView.
+     * Idempotent — safe to call if never started. If the operator
+     * toggles the feature off mid-press, we also fire a defensive
+     * `notifySamsungActiveKeyEdge(isDown = false)` so the service-side
+     * dispatcher doesn't hold a stranded source in its OR-gate. On the
+     * broadcast side the service already runs `forgetSource(...)` on
+     * `stopSamsungActiveKey()`; this mirrors that guarantee for the
+     * foreground path.
+     */
+    private fun stopSamsungActiveKeyForeground() {
+        val reader = samsungActiveKeyFg ?: return
+        try {
+            reader.stop(heldMapView)
+        } catch (t: Throwable) {
+            Log.w(TAG, "stopSamsungActiveKeyForeground: reader.stop() threw", t)
+        }
+        samsungActiveKeyFg = null
+        // Defensive release: if the operator toggled the feature off
+        // with the Active Key held down, the service still thinks
+        // SAMSUNG_ACTIVE_KEY is a live source. Sending an up() here is
+        // idempotent when the source isn't held.
+        try {
+            voiceClient?.ifBound { it.notifySamsungActiveKeyEdge(false) }
+        } catch (t: Throwable) {
+            Log.w(TAG, "defensive notifySamsungActiveKeyEdge(false) threw", t)
+        }
     }
 
     private fun autoConnectMumble() {

--- a/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
+++ b/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
@@ -1046,6 +1046,15 @@ class XvMapComponent : AbstractMapComponent() {
         // primary). No-op when no secondary is persisted.
         autoConnectAinaSecondary()
 
+        // Samsung ruggedized-device Active Key. Zero-cost on any
+        // non-Samsung device: `SamsungActiveKey.isSupported()` returns
+        // false, this method exits before touching the service, and
+        // the corresponding Settings row stays hidden. On Samsung
+        // Tab Active5 / XCover6 Pro / etc. + operator opt-in, the
+        // service registers the `HARD_KEY_REPORT` broadcast receiver
+        // and the side key keys slot 0 through the normal dispatcher.
+        autoStartSamsungActiveKeyIfEnabled()
+
         // Trigger runtime permission prompts for our own UID. The
         // MapComponent runs in ATAK's process; checkSelfPermission here
         // would query ATAK's grants, masking the fact that XV's own UID
@@ -2081,6 +2090,37 @@ class XvMapComponent : AbstractMapComponent() {
                 settings.persistAutoConnectBtEnabled(enabled)
             }
 
+            override fun samsungActiveKeySupported(): Boolean {
+                val ctx = heldMapView?.context ?: heldPluginContext ?: return false
+                return com.atakmap.android.xv.util.SamsungActiveKey.isSupported(ctx)
+            }
+
+            override fun samsungActiveKeyEnabled(): Boolean =
+                settings.persistedSamsungActiveKeyEnabled()
+
+            override fun setSamsungActiveKeyEnabled(enabled: Boolean) {
+                Log.i(TAG, "Controller.setSamsungActiveKeyEnabled($enabled)")
+                settings.persistSamsungActiveKeyEnabled(enabled)
+                // Only push the service call on hardware that actually
+                // has the key. Redundant defence — the row shouldn't
+                // be visible on non-Samsung devices — but cheap and
+                // keeps the operator's persisted pref honest if a
+                // future firmware change (or an operator flipping a
+                // debug feature) somehow surfaced the toggle.
+                val ctx = heldMapView?.context ?: heldPluginContext ?: return
+                if (!com.atakmap.android.xv.util.SamsungActiveKey.isSupported(ctx)) {
+                    Log.w(
+                        TAG,
+                        "setSamsungActiveKeyEnabled($enabled) — device does not have the Active Key; " +
+                            "persisting pref but skipping service call",
+                    )
+                    return
+                }
+                voiceClient?.setPersistent("samsungActiveKey") {
+                    it.setSamsungActiveKeyEnabled(enabled)
+                }
+            }
+
             override fun latchedMode(): Boolean = settings.persistedLatchedMode()
 
             override fun setLatchedMode(enabled: Boolean) {
@@ -2255,6 +2295,32 @@ class XvMapComponent : AbstractMapComponent() {
             "strict" -> VxCompat.STRICT
             else -> null
         }
+
+    // Start the service-side Samsung Active Key listener iff both
+    // the capability check AND the persisted operator toggle agree.
+    // Gate ordering (capability first) matters: on non-Samsung
+    // hardware we never even ask the service to start the reader, so
+    // there is zero runtime cost — no broadcast receiver, no wasted
+    // Binder round-trip.
+    //
+    // A separate isSupported() short-circuit here in the plugin
+    // (versus letting the service reject the call) also means the
+    // Samsung Active Key toggle in Settings can be authoritatively
+    // gated on the same helper — no divergence between "will we act
+    // on it" and "will we show the toggle".
+    private fun autoStartSamsungActiveKeyIfEnabled() {
+        val ctx = heldMapView?.context ?: return
+        if (!com.atakmap.android.xv.util.SamsungActiveKey.isSupported(ctx)) {
+            Log.i(TAG, "autoStartSamsungActiveKey: device does not have the Active Key — skipping")
+            return
+        }
+        if (!settings.persistedSamsungActiveKeyEnabled()) {
+            Log.i(TAG, "autoStartSamsungActiveKey: operator toggle OFF — skipping")
+            return
+        }
+        Log.i(TAG, "autoStartSamsungActiveKey: enabling Samsung Active Key PTT")
+        voiceClient?.setPersistent("samsungActiveKey") { it.setSamsungActiveKeyEnabled(true) }
+    }
 
     private fun autoConnectMumble() {
         // Slight delay so the rest of plugin init (cert lookup, presence

--- a/app/src/main/java/com/atakmap/android/xv/plugin/XvSettings.kt
+++ b/app/src/main/java/com/atakmap/android/xv/plugin/XvSettings.kt
@@ -241,6 +241,22 @@ class XvSettings(
         prefs()?.edit()?.putBoolean(PREF_STATUS_TONES, enabled)?.apply()
     }
 
+    // Whether the Samsung ruggedized-device Active Key is enabled as
+    // a PTT source. The corresponding Settings row is only shown at
+    // all when [com.atakmap.android.xv.util.SamsungActiveKey.isSupported]
+    // returns true (Galaxy Tab Active5, XCover6 Pro / 7, Tab Active4 Pro,
+    // Tab Active3) — on any other device this preference is inert and
+    // the toggle is hidden entirely. Default OFF so first launch on
+    // new hardware doesn't silently start intercepting the key; the
+    // operator opts in explicitly. Read at plugin load by
+    // [XvMapComponent.autoStartSamsungActiveKeyIfEnabled].
+    fun persistedSamsungActiveKeyEnabled(): Boolean =
+        prefs()?.getBoolean(PREF_SAMSUNG_ACTIVE_KEY_ENABLED, false) ?: false
+
+    fun persistSamsungActiveKeyEnabled(enabled: Boolean) {
+        prefs()?.edit()?.putBoolean(PREF_SAMSUNG_ACTIVE_KEY_ENABLED, enabled)?.apply()
+    }
+
     // Last-joined primary channel. Written by onChannelChanged on
     // every slot-0 move (excluding "TAK PRIVATE - …" temp channels);
     // read by connectMumbleWithDefaults to override server-side default
@@ -281,6 +297,11 @@ class XvSettings(
         private const val PREF_TPT_TONE = "tpt_tone"
         private const val PREF_LATCHED_TIMEOUT = "latched_timeout_sec"
         private const val PREF_STATUS_TONES = "status_tones_enabled"
+
+        // Whether the Samsung ruggedized-device Active Key is used as
+        // a PTT source. Only meaningful on hardware that has the key.
+        // Default false; the row is hidden on other devices.
+        private const val PREF_SAMSUNG_ACTIVE_KEY_ENABLED = "samsung_active_key_enabled"
 
         // TAK server picker — empty/missing means auto-pick (first
         // connected, else first configured); else the explicit host

--- a/app/src/main/java/com/atakmap/android/xv/ptt/SamsungActiveKeyForegroundReader.kt
+++ b/app/src/main/java/com/atakmap/android/xv/ptt/SamsungActiveKeyForegroundReader.kt
@@ -1,0 +1,193 @@
+package com.atakmap.android.xv.ptt
+
+import android.util.Log
+import android.view.KeyEvent
+import android.view.View
+import com.atakmap.android.maps.MapView
+import com.atakmap.android.xv.audio.PttSource
+import com.atakmap.android.xv.util.SamsungActiveKey
+
+/**
+ * Foreground-KeyEvent fallback path for the Samsung Active Key.
+ *
+ * Companion to [SamsungActiveKeyReader] (which listens for the
+ * `HARD_KEY_REPORT` broadcast). Both paths coexist and dedupe via the
+ * central [com.atakmap.android.xv.audio.PttDispatcher]'s source-based
+ * OR-gate — a duplicate down edge for
+ * [PttSource.SAMSUNG_ACTIVE_KEY] while it's already held is ignored,
+ * and this reader further short-circuits back-to-back `ACTION_DOWN`s
+ * for its own state so the log output stays clean.
+ *
+ * ---
+ *
+ * Why the fallback exists:
+ *
+ * On-device validation 2026-07-10 against a Samsung Galaxy Tab
+ * Active5 (SM-X308U) confirmed that shipping firmware does NOT emit
+ * the `com.samsung.android.knox.intent.action.HARD_KEY_REPORT`
+ * broadcast for `KEY_CODE == 1015`, despite what the Samsung Knox
+ * documentation implies. The operator's Settings → Advanced features
+ * → Active Key surface exposes only "launch app" mappings, which fire
+ * one intent on press and produce no release signal — unusable as a
+ * PTT source.
+ *
+ * The plain [KeyEvent] path, in contrast, produces both `ACTION_DOWN`
+ * (with `repeatCount == 0`) and `ACTION_UP` for `KEYCODE == 1015` and
+ * is delivered to the foreground activity by
+ * `PhoneWindowManager.interceptKeyTq` → `InputDispatcher`. That
+ * matches what PTT needs on both edges.
+ *
+ * ---
+ *
+ * Trade-off / operational limitation:
+ *
+ * Because `InputDispatcher` routes non-broadcast keys to the top
+ * activity, this reader only sees events while ATAK is in the
+ * foreground. That's the same constraint any hardware-button PTT app
+ * has when it is neither a system app nor an IME nor an accessibility
+ * service — no way around it without one of those privileges. Backing
+ * the reader with an accessibility service is a non-starter for a
+ * plugin (privacy prompt cost).
+ *
+ * The broadcast reader ([SamsungActiveKeyReader]) IS backgrounded-safe
+ * and is still the ideal — on hardware that does emit the broadcast,
+ * both paths fire and PttDispatcher's dedupe collapses the duplicate
+ * down / up cleanly. On Tab Active5-class firmware where only the
+ * KeyEvent fires, this path is the sole PTT source for the Active
+ * Key, and it works whenever XV is what the operator is looking at.
+ *
+ * ---
+ *
+ * Device gate: same as the broadcast path — the caller
+ * ([com.atakmap.android.xv.plugin.XvMapComponent]) short-circuits on
+ * [com.atakmap.android.xv.util.SamsungActiveKey.isSupported] so a
+ * non-Samsung device never instantiates this reader.
+ */
+class SamsungActiveKeyForegroundReader(
+    // Fired on the leading down edge (with `isDown = true`) and on the
+    // release (`isDown = false`). Wired to
+    // XvVoiceService.notifySamsungActiveKeyEdge in the plugin, which
+    // routes through the service's PttDispatcher.down(..., source =
+    // SAMSUNG_ACTIVE_KEY) / up(...) in the correct process.
+    private val onEdge: (isDown: Boolean, source: PttSource) -> Unit,
+) {
+    // Track our own held-state so we drop a stray KeyEvent that would
+    // otherwise fire an already-held down or already-released up edge.
+    // Two motivations:
+    //   1) Guard against InputDispatcher redelivering the same key
+    //      when the foreground activity changes mid-hold.
+    //   2) Keep the log narrative honest — one "DOWN" line per real
+    //      press, one "UP" line per real release.
+    @Volatile
+    private var held: Boolean = false
+
+    @Volatile
+    private var attached: Boolean = false
+
+    // Package-visible so unit tests can synthesize a KeyEvent against
+    // the listener directly, without needing a live MapView (which
+    // requires an ATAK-runtime bring-up we don't want in a Robolectric
+    // suite).
+    internal val listener =
+        View.OnKeyListener { _, keyCode, event ->
+            when (SamsungActiveKey.handleKeyEvent(keyCode, event.action, event.repeatCount)) {
+                SamsungActiveKey.FallbackAction.PTT_DOWN -> {
+                    if (held) {
+                        // Repeat / re-entry after a lost UP — drop.
+                        Log.d(TAG, "Samsung Active Key DOWN (via KeyEvent foreground) — already held; dropping duplicate")
+                        return@OnKeyListener true
+                    }
+                    held = true
+                    Log.i(TAG, "Samsung Active Key DOWN (via KeyEvent foreground)")
+                    try {
+                        onEdge(true, PttSource.SAMSUNG_ACTIVE_KEY)
+                    } catch (t: Throwable) {
+                        Log.w(TAG, "onEdge(down) threw", t)
+                    }
+                    true
+                }
+                SamsungActiveKey.FallbackAction.PTT_UP -> {
+                    if (!held) {
+                        // UP without a matching DOWN — likely delivered
+                        // to us after the foreground shifted mid-press.
+                        // Suppress to avoid a spurious txController.stop
+                        // for a burst we never engaged.
+                        Log.d(TAG, "Samsung Active Key UP (via KeyEvent foreground) — not held; dropping")
+                        return@OnKeyListener true
+                    }
+                    held = false
+                    Log.i(TAG, "Samsung Active Key UP (via KeyEvent foreground)")
+                    try {
+                        onEdge(false, PttSource.SAMSUNG_ACTIVE_KEY)
+                    } catch (t: Throwable) {
+                        Log.w(TAG, "onEdge(up) threw", t)
+                    }
+                    true
+                }
+                SamsungActiveKey.FallbackAction.IGNORE -> {
+                    // Not our key / not an edge we care about — let ATAK
+                    // and any downstream OnKeyListener handle it.
+                    false
+                }
+            }
+        }
+
+    /**
+     * Attach the KeyEvent listener to [mapView]. Idempotent — a second
+     * call while already attached is a no-op. Returns true if the
+     * listener is currently attached after the call, false only if the
+     * runtime rejected the attach.
+     */
+    fun start(mapView: MapView): Boolean {
+        synchronized(this) {
+            if (attached) {
+                Log.i(TAG, "start() ignored — foreground listener already attached")
+                return true
+            }
+            return try {
+                mapView.addOnKeyListener(listener)
+                attached = true
+                Log.i(TAG, "Samsung Active Key foreground KeyEvent reader started")
+                true
+            } catch (t: Throwable) {
+                Log.w(TAG, "addOnKeyListener threw", t)
+                false
+            }
+        }
+    }
+
+    /**
+     * Detach the KeyEvent listener. Idempotent — safe to call if never
+     * started, if already stopped, or if the MapView was torn down
+     * from under us.
+     *
+     * If a press was in flight (the operator toggled the feature off
+     * or the plugin unloaded while the Active Key was held), the
+     * dispatcher-side cleanup is the caller's responsibility — this
+     * class only owns the KeyEvent hook. Callers should invoke
+     * [com.atakmap.android.xv.audio.PttDispatcher.forgetSource] with
+     * [PttSource.SAMSUNG_ACTIVE_KEY] on stop.
+     */
+    fun stop(mapView: MapView?) {
+        synchronized(this) {
+            if (!attached) return
+            if (mapView != null) {
+                try {
+                    mapView.removeOnKeyListener(listener)
+                } catch (t: Throwable) {
+                    Log.w(TAG, "removeOnKeyListener threw", t)
+                }
+            }
+            attached = false
+            held = false
+            Log.i(TAG, "Samsung Active Key foreground KeyEvent reader stopped")
+        }
+    }
+
+    /** True while the KeyEvent listener is currently attached. */
+    fun isRunning(): Boolean = attached
+
+    companion object {
+        private const val TAG = "XvSamsungActiveKeyFg"
+    }
+}

--- a/app/src/main/java/com/atakmap/android/xv/ptt/SamsungActiveKeyReader.kt
+++ b/app/src/main/java/com/atakmap/android/xv/ptt/SamsungActiveKeyReader.kt
@@ -1,0 +1,182 @@
+package com.atakmap.android.xv.ptt
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.util.Log
+import androidx.core.content.ContextCompat
+import com.atakmap.android.xv.audio.PttSource
+import com.atakmap.android.xv.util.SamsungActiveKey
+
+/**
+ * PTT reader for the programmable Active Key on Samsung ruggedized
+ * hardware (Galaxy Tab Active5, Tab Active4 Pro, Tab Active3, XCover6
+ * Pro, XCover7).
+ *
+ * Mechanism: the Samsung framework broadcasts
+ * `com.samsung.android.knox.intent.action.HARD_KEY_REPORT` on every
+ * press and release of the side Active Key. The broadcast carries
+ * `KEY_CODE` (int; 1015 for the side PTT key) and `KEY_REPORT_TYPE`
+ * (1 = press, 2 = release). No Knox SDK, license, or enterprise
+ * entitlement is required to RECEIVE the broadcast — any registered
+ * receiver in the system gets the event.
+ *
+ * We register the receiver with `RECEIVER_NOT_EXPORTED` (Android 13+
+ * flag) because the intent comes from the Samsung framework itself,
+ * not from a third-party app targeting us — no need to widen the
+ * receiver's exported surface.
+ *
+ * ---
+ *
+ * Foreground behaviour: the receiver is registered on `start()` and
+ * unregistered on `stop()`. On Samsung ruggedized firmware the
+ * `HARD_KEY_REPORT` broadcast is delivered to every registered
+ * receiver regardless of app foreground state, so PTT via the Active
+ * Key works while XV is in the background (which is the entire point
+ * of the split-process service model this reader lives inside — see
+ * [com.atakmap.android.xv.service.XvVoiceService]).
+ *
+ * Duplicate registrations are guarded internally: repeated `start()`
+ * calls are no-ops if we're already listening, and `stop()` is safe to
+ * call multiple times (including when we were never started).
+ *
+ * When the toggle is OFF or a different app is in the foreground, this
+ * reader does nothing — the key's normal Samsung-configured behaviour
+ * (whatever the operator has set in Settings → Advanced features →
+ * Active Key) is unaffected. Non-Samsung devices never see this reader
+ * instantiated at all (see the gate in
+ * [com.atakmap.android.xv.util.SamsungActiveKey.isSupported]).
+ */
+class SamsungActiveKeyReader(
+    private val context: Context,
+    // Fired on key-down with `isDown = true` and on key-up with
+    // `isDown = false`. Wired to PttDispatcher.down / up in
+    // XvVoiceService alongside the AINA / Pryme readers.
+    private val onEdge: (isDown: Boolean, source: PttSource) -> Unit,
+) {
+    private val receiver: BroadcastReceiver =
+        object : BroadcastReceiver() {
+            override fun onReceive(
+                ctx: Context,
+                intent: Intent,
+            ) {
+                if (intent.action != SamsungActiveKey.ACTION_HARD_KEY_REPORT) return
+                val keyCode =
+                    intent.getIntExtra(
+                        SamsungActiveKey.EXTRA_KEY_CODE,
+                        -1,
+                    )
+                if (keyCode != SamsungActiveKey.KEY_CODE_PTT) {
+                    // Ignore the Top / Emergency key (KEY_CODE_EMERGENCY
+                    // = 1079) and anything else the framework happens to
+                    // broadcast. Emergency key routing is out of scope
+                    // for this reader — the emergency subsystem
+                    // ([com.atakmap.android.xv.emergency]) is wired to
+                    // AINA PTTE only.
+                    return
+                }
+                val reportType =
+                    intent.getIntExtra(
+                        SamsungActiveKey.EXTRA_KEY_REPORT_TYPE,
+                        -1,
+                    )
+                when (reportType) {
+                    SamsungActiveKey.KEY_REPORT_TYPE_PRESSED -> {
+                        Log.i(TAG, "Samsung Active Key DOWN")
+                        try {
+                            onEdge(true, PttSource.SAMSUNG_ACTIVE_KEY)
+                        } catch (t: Throwable) {
+                            Log.w(TAG, "onEdge(down) threw", t)
+                        }
+                    }
+                    SamsungActiveKey.KEY_REPORT_TYPE_RELEASED -> {
+                        Log.i(TAG, "Samsung Active Key UP")
+                        try {
+                            onEdge(false, PttSource.SAMSUNG_ACTIVE_KEY)
+                        } catch (t: Throwable) {
+                            Log.w(TAG, "onEdge(up) threw", t)
+                        }
+                    }
+                    else -> {
+                        Log.d(TAG, "unexpected KEY_REPORT_TYPE=$reportType — ignoring")
+                    }
+                }
+            }
+        }
+
+    @Volatile
+    private var registered: Boolean = false
+
+    /**
+     * Begin listening for `HARD_KEY_REPORT` broadcasts. Idempotent: a
+     * second call while already listening is a no-op and logs at INFO
+     * so the redundancy is visible in field logs without spamming.
+     *
+     * Returns `true` if the receiver is now registered (either newly
+     * or was already registered), `false` if registration failed
+     * (e.g. the runtime rejected the receiver on a non-Samsung device
+     * masquerading as one — defence-in-depth against future firmware
+     * quirks).
+     */
+    fun start(): Boolean {
+        synchronized(this) {
+            if (registered) {
+                Log.i(TAG, "start() ignored — receiver already registered")
+                return true
+            }
+            val filter = IntentFilter(SamsungActiveKey.ACTION_HARD_KEY_REPORT)
+            return try {
+                // NOT_EXPORTED: the broadcast originates from the
+                // Samsung framework and is delivered by the system,
+                // so we do not need to accept it from third-party
+                // apps. Uses ContextCompat so the pre-Android-13
+                // fallback path also compiles cleanly.
+                ContextCompat.registerReceiver(
+                    context,
+                    receiver,
+                    filter,
+                    ContextCompat.RECEIVER_NOT_EXPORTED,
+                )
+                registered = true
+                Log.i(TAG, "Samsung Active Key reader started (HARD_KEY_REPORT listener registered)")
+                true
+            } catch (t: Throwable) {
+                Log.w(TAG, "registerReceiver(HARD_KEY_REPORT) threw", t)
+                false
+            }
+        }
+    }
+
+    /**
+     * Stop listening. Idempotent — safe to call if we never started,
+     * if we already stopped, or if the receiver was already stripped
+     * out from under us by a runtime restart. Any in-flight PTT-down
+     * edge (Active Key held when the operator toggles the feature
+     * off) is the caller's responsibility to release via the
+     * dispatcher's [com.atakmap.android.xv.audio.PttDispatcher.forgetSource].
+     */
+    fun stop() {
+        synchronized(this) {
+            if (!registered) return
+            try {
+                context.unregisterReceiver(receiver)
+            } catch (_: IllegalArgumentException) {
+                // Never registered, or already unregistered — nothing
+                // actionable. Matches the swallow pattern used by
+                // XvVoiceService for the other broadcast receivers.
+            } catch (t: Throwable) {
+                Log.w(TAG, "unregisterReceiver threw", t)
+            }
+            registered = false
+            Log.i(TAG, "Samsung Active Key reader stopped")
+        }
+    }
+
+    /** True while the broadcast receiver is currently registered. */
+    fun isRunning(): Boolean = registered
+
+    companion object {
+        private const val TAG = "XvSamsungActiveKey"
+    }
+}

--- a/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
@@ -30,6 +30,7 @@ import com.atakmap.android.xv.audio.StatusTones
 import com.atakmap.android.xv.audio.TptPlayer
 import com.atakmap.android.xv.audio.TptTone
 import com.atakmap.android.xv.audio.TxController
+import com.atakmap.android.xv.ptt.SamsungActiveKeyReader
 
 // All of XV's audio + AINA + PTT-state subsystem, instantiated in our
 // APK's UID where FOREGROUND_SERVICE_TYPE_MICROPHONE actually grants
@@ -351,6 +352,15 @@ class VoicePlant(
     @Volatile private var ainaSecondaryBle: AinaBleReader? = null
 
     @Volatile private var prymeSecondaryBle: PrymeBleReader? = null
+
+    // Samsung ruggedized-device programmable Active Key reader
+    // (Tab Active5, XCover6 Pro / 7, Tab Active4 Pro, Tab Active3).
+    // Independent of AINA / External Button — runs in parallel and
+    // keys slot 0 via [PttSource.SAMSUNG_ACTIVE_KEY]. Present only on
+    // hardware that emits `HARD_KEY_REPORT`; on any other device this
+    // stays null because [XvVoiceService] never calls
+    // [startSamsungActiveKey]. See [com.atakmap.android.xv.util.SamsungActiveKey].
+    @Volatile private var samsungActiveKey: SamsungActiveKeyReader? = null
 
     // MAC of the currently-connected AINA (or null when none). Used by
     // the BOND_STATE_CHANGED receiver to detect "the operator just
@@ -1352,6 +1362,63 @@ class VoicePlant(
     fun isAinaSecondaryConnected(): Boolean =
         ainaSecondaryBle != null || ainaSecondarySpp != null || prymeSecondaryBle != null
 
+    /**
+     * Start the Samsung ruggedized-device Active Key reader. Registers
+     * a broadcast receiver for `HARD_KEY_REPORT` and routes press /
+     * release edges through [pttDown] / [pttUp] with
+     * [PttSource.SAMSUNG_ACTIVE_KEY]. Idempotent — repeated calls are
+     * no-ops if the reader is already running.
+     *
+     * The plugin gates the call on
+     * [com.atakmap.android.xv.util.SamsungActiveKey.isSupported] +
+     * the operator's persisted toggle, so this method itself does not
+     * re-verify hardware capability — starting on a non-Samsung device
+     * is harmless (the broadcast just never fires).
+     */
+    fun startSamsungActiveKey() {
+        if (samsungActiveKey != null) {
+            Log.i(TAG, "startSamsungActiveKey: already running — ignoring")
+            return
+        }
+        val reader =
+            SamsungActiveKeyReader(context) { isDown, source ->
+                if (isDown) {
+                    pttDown(slot = 0, source = source)
+                } else {
+                    pttUp(slot = 0, source = source)
+                }
+            }
+        if (reader.start()) {
+            samsungActiveKey = reader
+        } else {
+            Log.w(TAG, "startSamsungActiveKey: reader.start() failed — leaving disabled")
+        }
+    }
+
+    /**
+     * Stop the Samsung Active Key reader (if running) and drop any
+     * pending held-source bookkeeping from the dispatcher so a
+     * mid-press "toggle-off" doesn't leave the OR-gate thinking the
+     * button is still down. Idempotent.
+     */
+    fun stopSamsungActiveKey() {
+        val reader = samsungActiveKey ?: return
+        try {
+            reader.stop()
+        } catch (t: Throwable) {
+            Log.w(TAG, "stopSamsungActiveKey: reader.stop() threw", t)
+        }
+        samsungActiveKey = null
+        try {
+            pttDispatcher.forgetSource(PttSource.SAMSUNG_ACTIVE_KEY)
+        } catch (t: Throwable) {
+            Log.w(TAG, "forgetSource(SAMSUNG_ACTIVE_KEY) threw", t)
+        }
+    }
+
+    /** True while the Samsung Active Key reader is registered. */
+    fun isSamsungActiveKeyRunning(): Boolean = samsungActiveKey?.isRunning() == true
+
     fun disconnectAina() {
         ainaBle?.disconnect()
         ainaBle = null
@@ -1548,6 +1615,10 @@ class VoicePlant(
         }
         try {
             disconnectAinaSecondary()
+        } catch (_: Throwable) {
+        }
+        try {
+            stopSamsungActiveKey()
         } catch (_: Throwable) {
         }
         try {

--- a/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
@@ -1674,6 +1674,23 @@ class XvVoiceService : Service() {
                 return plant().isSamsungActiveKeyRunning()
             }
 
+            // Foreground-KeyEvent fallback edge dispatch. The plugin's
+            // SamsungActiveKeyForegroundReader owns the OnKeyListener
+            // attached to the MapView (the KeyEvent path only reaches
+            // the top activity); it forwards each filtered edge here so
+            // the service's PttDispatcher — the single source of truth
+            // for TX state — sees the SAMSUNG_ACTIVE_KEY-tagged edge in
+            // the correct process. Same authorization gate as the other
+            // PTT paths.
+            override fun notifySamsungActiveKeyEdge(isDown: Boolean) {
+                assertAuthorizedCaller()
+                if (isDown) {
+                    plant().pttDown(0, com.atakmap.android.xv.audio.PttSource.SAMSUNG_ACTIVE_KEY)
+                } else {
+                    plant().pttUp(0, com.atakmap.android.xv.audio.PttSource.SAMSUNG_ACTIVE_KEY)
+                }
+            }
+
             override fun setMumbleSessionState(connectedAndInChannel: Boolean) {
                 assertAuthorizedCaller()
                 plant().setMumbleSessionLive(connectedAndInChannel)
@@ -1777,6 +1794,11 @@ class XvVoiceService : Service() {
         // except that one hook (their outgoing-call mic stays hot
         // from the moment of dial — same behavior as before, no
         // breakage).
+        // Additive-since-v3 (no version bump): notifySamsungActiveKeyEdge
+        // for the foreground-KeyEvent fallback on Tab Active5 firmware
+        // that doesn't emit HARD_KEY_REPORT. Older plugins built
+        // against v3 simply won't call it — the broadcast path is
+        // still their only Samsung Active Key route.
         private const val AIDL_API_VERSION = 3
 
         // Channel ids for the incoming-ring + active-call CallStyle

--- a/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
@@ -1660,6 +1660,20 @@ class XvVoiceService : Service() {
                 return plant().isAinaSecondaryConnected()
             }
 
+            override fun setSamsungActiveKeyEnabled(enabled: Boolean) {
+                assertAuthorizedCaller()
+                if (enabled) {
+                    plant().startSamsungActiveKey()
+                } else {
+                    plant().stopSamsungActiveKey()
+                }
+            }
+
+            override fun isSamsungActiveKeyRunning(): Boolean {
+                assertAuthorizedCaller()
+                return plant().isSamsungActiveKeyRunning()
+            }
+
             override fun setMumbleSessionState(connectedAndInChannel: Boolean) {
                 assertAuthorizedCaller()
                 plant().setMumbleSessionLive(connectedAndInChannel)

--- a/app/src/main/java/com/atakmap/android/xv/ui/XvDropDownReceiver.kt
+++ b/app/src/main/java/com/atakmap/android/xv/ui/XvDropDownReceiver.kt
@@ -242,6 +242,21 @@ class XvDropDownReceiver(
 
         fun setAutoConnectBtEnabled(enabled: Boolean) {}
 
+        // ---- Samsung ruggedized-device Active Key ----
+        // True only when the current device is a Samsung Tab Active5
+        // / XCover6 Pro / XCover7 / Tab Active4 Pro / Tab Active3 that
+        // carries the programmable Active Key. Consulted at Settings-
+        // row inflation time — the row is hidden (`View.GONE`) on
+        // every device where this returns false so operators on non-
+        // Samsung hardware never see the toggle at all. Default false
+        // so a lazy Controller impl on a non-Samsung dev host still
+        // hides the row.
+        fun samsungActiveKeySupported(): Boolean = false
+
+        fun samsungActiveKeyEnabled(): Boolean = false
+
+        fun setSamsungActiveKeyEnabled(enabled: Boolean) {}
+
         // ---- TX / RX preferences (Settings → TX/RX) ----
         // Latched (full-duplex) call mode. While on, channel stays
         // open in both directions. Off = standard half-duplex PTT.
@@ -1443,6 +1458,7 @@ class XvDropDownReceiver(
         wireSecondaryAinaPicker(v)
         wireBlePttScanButton(v)
         wireAutoConnectBtSwitch(v)
+        wireSamsungActiveKeySwitch(v)
         wireBtAudioOverridePicker(v)
     }
 
@@ -1850,6 +1866,33 @@ class XvDropDownReceiver(
         sw.isChecked = controller.autoConnectBtEnabled()
         sw.setOnCheckedChangeListener { _, isChecked ->
             controller.setAutoConnectBtEnabled(isChecked)
+        }
+    }
+
+    // Samsung ruggedized-device Active Key toggle. The whole row is
+    // hidden entirely on any device that doesn't have the key —
+    // per operator direction 2026-07-10 we do NOT show a greyed-out
+    // row on non-Samsung hardware; the option simply does not appear.
+    // On Samsung Tab Active5 / XCover6 Pro / etc. the row is shown,
+    // reflects the persisted toggle, and updates the service on flip.
+    private fun wireSamsungActiveKeySwitch(v: View) {
+        val row = v.findViewById<View>(R.id.xv_row_samsung_active_key) ?: return
+        val help = v.findViewById<View>(R.id.xv_label_samsung_active_key_help)
+        val sw = v.findViewById<android.widget.Switch>(R.id.xv_switch_samsung_active_key) ?: return
+        val supported = controller.samsungActiveKeySupported()
+        if (!supported) {
+            row.visibility = View.GONE
+            help?.visibility = View.GONE
+            return
+        }
+        row.visibility = View.VISIBLE
+        help?.visibility = View.VISIBLE
+        // Detach any previous listener before pushing state so restoring
+        // the persisted value doesn't spuriously call setSamsungActiveKeyEnabled.
+        sw.setOnCheckedChangeListener(null)
+        sw.isChecked = controller.samsungActiveKeyEnabled()
+        sw.setOnCheckedChangeListener { _, isChecked ->
+            controller.setSamsungActiveKeyEnabled(isChecked)
         }
     }
 

--- a/app/src/main/java/com/atakmap/android/xv/util/SamsungActiveKey.kt
+++ b/app/src/main/java/com/atakmap/android/xv/util/SamsungActiveKey.kt
@@ -2,6 +2,7 @@ package com.atakmap.android.xv.util
 
 import android.content.Context
 import android.os.Build
+import android.view.KeyEvent
 
 /**
  * Capability detection for the programmable Active Key found on Samsung
@@ -170,6 +171,74 @@ object SamsungActiveKey {
         return features.any { feat ->
             feat.equals("com.samsung.hardware.active_key", ignoreCase = true) ||
                 feat.equals("com.samsung.feature.active_key", ignoreCase = true)
+        }
+    }
+
+    /**
+     * Classification returned by [handleKeyEvent] for a single Android
+     * [KeyEvent] observed while XV / ATAK is in the foreground. Used by
+     * the foreground-KeyEvent fallback path
+     * ([com.atakmap.android.xv.ptt.SamsungActiveKeyForegroundReader]) so
+     * the transport layer maps to the same [com.atakmap.android.xv.audio.PttSource]
+     * edges that the broadcast path fires — while keeping the decision
+     * itself pure and unit-testable (no Android runtime, no
+     * Robolectric).
+     *
+     * The fallback exists because on-device validation 2026-07-10
+     * against a Samsung Galaxy Tab Active5 (SM-X308U) confirmed that
+     * shipping firmware does **not** emit the `HARD_KEY_REPORT`
+     * broadcast — the operator's Settings → Advanced features → Active
+     * Key surface only offers "launch app" style intents, which
+     * produce one intent on press and no release signal (unusable as a
+     * PTT source). The plain `KeyEvent` path, in contrast, produces
+     * both `ACTION_DOWN` (with `repeatCount == 0`) and `ACTION_UP` —
+     * which is exactly what PTT needs.
+     *
+     * The trade-off: a `KeyEvent` routed by
+     * `PhoneWindowManager.interceptKeyTq` -> `InputDispatcher` is
+     * delivered to the top activity only, so this path works only
+     * while ATAK is in the foreground. That's the same limitation
+     * every non-system, non-IME hardware-button PTT app has; the
+     * broadcast path (which does work backgrounded on qualifying
+     * firmware) is still the ideal and stays in place.
+     */
+    enum class FallbackAction {
+        /** Fire a PTT down edge tagged [com.atakmap.android.xv.audio.PttSource.SAMSUNG_ACTIVE_KEY]. */
+        PTT_DOWN,
+
+        /** Fire a PTT up edge tagged [com.atakmap.android.xv.audio.PttSource.SAMSUNG_ACTIVE_KEY]. */
+        PTT_UP,
+
+        /** Not an Active Key event we care about — pass through to the next handler. */
+        IGNORE,
+    }
+
+    /**
+     * Pure classification of a single Android [KeyEvent] tuple for the
+     * foreground-KeyEvent fallback path. Returns [FallbackAction.PTT_DOWN]
+     * on the initial press of `KEYCODE == 1015` (the Samsung Active
+     * Key), [FallbackAction.PTT_UP] on release, and [FallbackAction.IGNORE]
+     * for everything else — including auto-repeat down events
+     * (`repeatCount > 0`), volume / navigation keys, and unusual
+     * actions like [KeyEvent.ACTION_MULTIPLE].
+     *
+     * Auto-repeat is dropped so a physically held key doesn't spam the
+     * dispatcher with duplicate down edges after the first — this is
+     * belt-and-suspenders (the dispatcher's OR-gate would ignore the
+     * duplicates anyway, since `PttSource.SAMSUNG_ACTIVE_KEY` is
+     * already held), but it also keeps log output readable.
+     */
+    fun handleKeyEvent(
+        keyCode: Int,
+        action: Int,
+        repeatCount: Int,
+    ): FallbackAction {
+        if (keyCode != KEY_CODE_PTT) return FallbackAction.IGNORE
+        return when (action) {
+            KeyEvent.ACTION_DOWN ->
+                if (repeatCount == 0) FallbackAction.PTT_DOWN else FallbackAction.IGNORE
+            KeyEvent.ACTION_UP -> FallbackAction.PTT_UP
+            else -> FallbackAction.IGNORE
         }
     }
 }

--- a/app/src/main/java/com/atakmap/android/xv/util/SamsungActiveKey.kt
+++ b/app/src/main/java/com/atakmap/android/xv/util/SamsungActiveKey.kt
@@ -1,0 +1,175 @@
+package com.atakmap.android.xv.util
+
+import android.content.Context
+import android.os.Build
+
+/**
+ * Capability detection for the programmable Active Key found on Samsung
+ * ruggedized tablets and phones (Galaxy Tab Active5, Tab Active4/3,
+ * Galaxy XCover6 Pro / XCover7, etc.).
+ *
+ * When present, pressing / releasing the key causes the Samsung
+ * framework to broadcast the system intent
+ * `com.samsung.android.knox.intent.action.HARD_KEY_REPORT` with the
+ * following extras:
+ *   - `com.samsung.android.knox.intent.extra.KEY_CODE`   — int
+ *       * 1015 = XCover / Active / PTT key (side)
+ *       * 1079 = Top / Emergency key
+ *   - `com.samsung.android.knox.intent.extra.KEY_REPORT_TYPE` — int
+ *       * 1 = pressed
+ *       * 2 = released
+ *
+ * Despite the `knox` prefix in the action string, the broadcast is
+ * emitted by the Samsung framework itself on qualifying hardware and
+ * does NOT require the Knox SDK, a Knox license, or any Samsung
+ * enterprise entitlement to receive. Any app that registers a
+ * [android.content.BroadcastReceiver] for the action gets the events.
+ *
+ * We therefore do NOT depend on the Knox SDK jar. The reader
+ * ([com.atakmap.android.xv.ptt.SamsungActiveKeyReader]) simply
+ * registers a normal broadcast receiver against the well-known action
+ * string when the operator flips the toggle in Settings.
+ *
+ * Sources (2026-07):
+ *   - Samsung Knox docs, "Unmanaged key mappings":
+ *     https://docs.samsungknox.com/dev/knox-sdk/features/independent-software-vendors-da/hardware-key-mappings/unmanaged-key-mappings/
+ *   - Samsung Knox docs, "Hardware key mapping":
+ *     https://docs.samsungknox.com/dev/knox-sdk/features/independent-software-vendors-da/hardware-key-mappings/hardware-key-mapping/
+ *
+ * ---
+ *
+ * Curated-hardware policy (per CLAUDE.md README rules): this helper
+ * gates a Settings row that only appears on devices that actually have
+ * the key. Non-Samsung devices are a zero-cost path — the row is
+ * hidden with `View.GONE` in the drawer code so operators never see a
+ * "greyed-out feature they can't use". The detection is intentionally
+ * conservative — start with the Samsung ruggedized model prefixes we
+ * have integrated evidence for, and grow the list as more hardware is
+ * validated end-to-end.
+ */
+object SamsungActiveKey {
+    /**
+     * Broadcast action fired by the Samsung framework when the Active
+     * Key / XCover key is pressed or released. Stable and documented
+     * in the Samsung Knox hardware-key-mapping guide referenced above.
+     */
+    const val ACTION_HARD_KEY_REPORT: String =
+        "com.samsung.android.knox.intent.action.HARD_KEY_REPORT"
+
+    /**
+     * Int extra — which key fired. `KEYCODE_PTT` = 1015 is the side
+     * Active Key on Tab Active5 / XCover6 Pro / etc.;
+     * `KEYCODE_EMERGENCY` = 1079 is the top key on XCovers. We
+     * currently listen for the PTT keycode only; the emergency
+     * button is out of scope for this reader.
+     */
+    const val EXTRA_KEY_CODE: String =
+        "com.samsung.android.knox.intent.extra.KEY_CODE"
+
+    /**
+     * Int extra — 1 = press, 2 = release. Anything else is an
+     * unexpected value (log at debug and drop).
+     */
+    const val EXTRA_KEY_REPORT_TYPE: String =
+        "com.samsung.android.knox.intent.extra.KEY_REPORT_TYPE"
+
+    /** Samsung `KEYCODE_PTT` (side Active Key on Tab Active5 etc.). */
+    const val KEY_CODE_PTT: Int = 1015
+
+    /** Samsung `KEY_REPORT_TYPE` "pressed". */
+    const val KEY_REPORT_TYPE_PRESSED: Int = 1
+
+    /** Samsung `KEY_REPORT_TYPE` "released". */
+    const val KEY_REPORT_TYPE_RELEASED: Int = 2
+
+    // Model-prefix allow-list for hardware that carries the
+    // programmable Active Key. Populated conservatively — extend as
+    // additional ruggedized Samsung models are validated end-to-end
+    // per CLAUDE.md's curated-hardware policy.
+    //
+    // Tab Active5 (SM-X30x): X300 = Wi-Fi, X306 = 5G B/N variants,
+    // X308 = 5G U variant.
+    // Tab Active4 Pro: SM-T63x.
+    // Tab Active3: SM-T57x.
+    // XCover7: SM-G556.
+    // XCover6 Pro: SM-G736.
+    private val ACTIVE_KEY_MODEL_PREFIXES: List<String> =
+        listOf(
+            // Tab Active5 series
+            "SM-X300",
+            "SM-X306",
+            "SM-X308",
+            // Tab Active4 Pro
+            "SM-T630",
+            "SM-T636",
+            // Tab Active3
+            "SM-T570",
+            "SM-T575",
+            "SM-T577",
+            // XCover7
+            "SM-G556",
+            // XCover6 Pro
+            "SM-G736",
+        )
+
+    /**
+     * True when the current device is a Samsung ruggedized model that
+     * carries the programmable Active Key. Consulted at Settings-row
+     * inflation time to decide whether to show the "Enable Samsung
+     * Active Key as PTT" toggle at all. On any non-Samsung device this
+     * is a fast constant `false`.
+     *
+     * [context] is accepted for symmetry with the Android-runtime
+     * shape (a future extension may consult
+     * [android.content.pm.PackageManager.hasSystemFeature] if Samsung
+     * ever exposes a feature flag), but the current check reads only
+     * [android.os.Build.MANUFACTURER] + [android.os.Build.MODEL] and
+     * is safe to call from any thread.
+     */
+    fun isSupported(
+        @Suppress("UNUSED_PARAMETER") context: Context,
+    ): Boolean =
+        isSupportedInternal(
+            manufacturer = Build.MANUFACTURER.orEmpty(),
+            model = Build.MODEL.orEmpty(),
+            features = emptySet(),
+        )
+
+    /**
+     * Pure test seam for [isSupported]. Takes the interesting Build
+     * fields + system-feature set as parameters so it can be exercised
+     * without an Android runtime. Robolectric is NOT required.
+     */
+    fun isSupportedInternal(
+        manufacturer: String,
+        model: String,
+        features: Set<String>,
+    ): Boolean {
+        if (!manufacturer.equals("samsung", ignoreCase = true)) {
+            return false
+        }
+        // Model prefix match. Model strings from Samsung firmware are
+        // upper-cased (e.g. "SM-X306B") but be defensive — trim + case-
+        // insensitive compare so a lowercase Build.MODEL from some
+        // future firmware doesn't mis-detect.
+        val normalizedModel = model.trim()
+        if (normalizedModel.isEmpty()) return false
+        val prefixMatch =
+            ACTIVE_KEY_MODEL_PREFIXES.any { prefix ->
+                normalizedModel.startsWith(prefix, ignoreCase = true)
+            }
+        if (prefixMatch) return true
+        // Feature-flag path. Samsung does not currently publish an
+        // official system feature for the Active Key, but if a future
+        // firmware exposes one via PackageManager.hasSystemFeature, we
+        // honour it as an additional positive signal so operator
+        // hardware we haven't hard-listed still lights up the toggle.
+        // The exact string is speculative — we accept two commonly-
+        // referenced candidates so a real Samsung feature flag lands
+        // in either form without an XV update.
+        return features.any { feat ->
+            feat.equals("com.samsung.hardware.active_key", ignoreCase = true) ||
+                feat.equals("com.samsung.feature.active_key", ignoreCase = true)
+        }
+    }
+}

--- a/app/src/main/res/layout/xv_settings.xml
+++ b/app/src/main/res/layout/xv_settings.xml
@@ -527,6 +527,51 @@
                     android:textSize="11sp"
                     android:layout_marginTop="4dp"/>
 
+                <!-- Samsung ruggedized-device Active Key PTT toggle.
+                     Visible ONLY on Samsung Tab Active5 / XCover6 Pro
+                     / XCover7 / Tab Active4 Pro / Tab Active3 — the
+                     row is hidden (`View.GONE`) at inflate time on
+                     every other device via
+                     XvDropDownReceiver.wireSamsungActiveKeySwitch,
+                     which consults
+                     `SamsungActiveKey.isSupported(context)`. Non-
+                     Samsung operators never see this row. Default
+                     OFF; the operator opts in explicitly. -->
+                <LinearLayout
+                    android:id="@+id/xv_row_samsung_active_key"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:padding="12dp"
+                    android:background="@drawable/xv_card_bg"
+                    android:layout_marginTop="12dp"
+                    android:visibility="gone">
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Use Samsung Active Key as PTT"
+                        android:textColor="@color/xv_text"
+                        android:textSize="14sp"/>
+
+                    <Switch
+                        android:id="@+id/xv_switch_samsung_active_key"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"/>
+                </LinearLayout>
+
+                <TextView
+                    android:id="@+id/xv_label_samsung_active_key_help"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Use the programmable side button on your Samsung ruggedized device as an additional PTT source, alongside on-screen PTT and any bonded AINA / BLE PTT button. Press to talk; release to end. Turn OFF to restore the key's default Samsung behaviour."
+                    android:textColor="@color/xv_text_dim"
+                    android:textSize="11sp"
+                    android:layout_marginTop="4dp"
+                    android:visibility="gone"/>
+
                 <!-- Section header: Audio device -->
                 <TextView
                     android:layout_width="match_parent"

--- a/app/src/test/java/com/atakmap/android/xv/ptt/SamsungActiveKeyForegroundReaderTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/ptt/SamsungActiveKeyForegroundReaderTest.kt
@@ -1,0 +1,187 @@
+package com.atakmap.android.xv.ptt
+
+import android.view.KeyEvent
+import android.view.View
+import com.atakmap.android.xv.audio.PttSource
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * Coverage for [SamsungActiveKeyForegroundReader], the foreground-
+ * KeyEvent fallback path for the Samsung Active Key. The broadcast
+ * path ([SamsungActiveKeyReaderTest]) covers the ideal-case wiring;
+ * this suite covers the fallback that Tab Active5-class firmware
+ * actually needs (the broadcast is not emitted on SM-X308U as of
+ * 2026-07-10).
+ *
+ * We drive the reader's `OnKeyListener` directly against synthetic
+ * `KeyEvent` instances rather than standing up a real ATAK `MapView`
+ * — the listener is the whole behaviour surface, and standing up an
+ * ATAK runtime inside a unit test would add cost with no additional
+ * coverage.
+ */
+@RunWith(RobolectricTestRunner::class)
+class SamsungActiveKeyForegroundReaderTest {
+    private class Recorder : (Boolean, PttSource) -> Unit {
+        val edges = mutableListOf<Pair<Boolean, PttSource>>()
+
+        override fun invoke(
+            isDown: Boolean,
+            source: PttSource,
+        ) {
+            edges.add(isDown to source)
+        }
+    }
+
+    private fun keyEvent(
+        keyCode: Int,
+        action: Int,
+        repeatCount: Int = 0,
+    ): KeyEvent =
+        // Args to the raw KeyEvent constructor: downTime, eventTime,
+        // action, code, repeatCount. downTime + eventTime are not read
+        // by handleKeyEvent, so we pass 0L for both.
+        KeyEvent(
+            0L,
+            0L,
+            action,
+            keyCode,
+            repeatCount,
+        )
+
+    private fun dispatch(
+        listener: View.OnKeyListener,
+        event: KeyEvent,
+    ): Boolean {
+        // The View argument is not used by the reader's listener — it
+        // reads only keyCode + event.action + event.repeatCount — so
+        // passing null keeps the harness minimal. (Kotlin's null-safety
+        // is fine here because View is Java and the listener signature
+        // accepts a nullable receiver at the JVM level; use the
+        // application context's decor-view surrogate if a future rev
+        // needs a real View instance.)
+        val view: View? = null
+        @Suppress("UNCHECKED_CAST")
+        return listener.onKey(view, event.keyCode, event)
+    }
+
+    @Test
+    fun `KEYCODE_PTT press fires exactly one SAMSUNG_ACTIVE_KEY down edge`() {
+        val recorder = Recorder()
+        val reader = SamsungActiveKeyForegroundReader(recorder)
+        val consumed =
+            dispatch(reader.listener, keyEvent(1015, KeyEvent.ACTION_DOWN, repeatCount = 0))
+        assertTrue("Active-Key press must be consumed by the fallback listener", consumed)
+        assertEquals(1, recorder.edges.size)
+        assertEquals(true to PttSource.SAMSUNG_ACTIVE_KEY, recorder.edges.single())
+    }
+
+    @Test
+    fun `press then release fires down then up`() {
+        val recorder = Recorder()
+        val reader = SamsungActiveKeyForegroundReader(recorder)
+        dispatch(reader.listener, keyEvent(1015, KeyEvent.ACTION_DOWN))
+        dispatch(reader.listener, keyEvent(1015, KeyEvent.ACTION_UP))
+        assertEquals(2, recorder.edges.size)
+        assertEquals(true to PttSource.SAMSUNG_ACTIVE_KEY, recorder.edges[0])
+        assertEquals(false to PttSource.SAMSUNG_ACTIVE_KEY, recorder.edges[1])
+    }
+
+    @Test
+    fun `auto-repeat DOWN events after the initial press are dropped`() {
+        // A physically-held key produces an ACTION_DOWN with a rising
+        // repeatCount at the system auto-repeat rate. handleKeyEvent
+        // drops those; the reader's held-state further guards against
+        // any pathological duplicate ACTION_DOWN with repeatCount == 0.
+        val recorder = Recorder()
+        val reader = SamsungActiveKeyForegroundReader(recorder)
+        dispatch(reader.listener, keyEvent(1015, KeyEvent.ACTION_DOWN, repeatCount = 0))
+        dispatch(reader.listener, keyEvent(1015, KeyEvent.ACTION_DOWN, repeatCount = 1))
+        dispatch(reader.listener, keyEvent(1015, KeyEvent.ACTION_DOWN, repeatCount = 2))
+        dispatch(reader.listener, keyEvent(1015, KeyEvent.ACTION_UP))
+        assertEquals(2, recorder.edges.size)
+        assertEquals(true to PttSource.SAMSUNG_ACTIVE_KEY, recorder.edges[0])
+        assertEquals(false to PttSource.SAMSUNG_ACTIVE_KEY, recorder.edges[1])
+    }
+
+    @Test
+    fun `duplicate press (both repeatCount=0) after held is dropped by internal held-guard`() {
+        // Belt-and-suspenders: if InputDispatcher somehow redelivers a
+        // fresh ACTION_DOWN while we still think the key is held (no
+        // intervening UP), the reader must suppress it — otherwise the
+        // dispatcher would see back-to-back down edges for the same
+        // source, which the OR-gate would collapse but a debug operator
+        // reading logs shouldn't have to squint at.
+        val recorder = Recorder()
+        val reader = SamsungActiveKeyForegroundReader(recorder)
+        dispatch(reader.listener, keyEvent(1015, KeyEvent.ACTION_DOWN))
+        dispatch(reader.listener, keyEvent(1015, KeyEvent.ACTION_DOWN))
+        assertEquals("only one down edge should reach the callback", 1, recorder.edges.size)
+    }
+
+    @Test
+    fun `release without a matching press is dropped by held-guard`() {
+        // Foreground handoff mid-press: the KeyEvent path may deliver
+        // an ACTION_UP to us that we never saw the ACTION_DOWN for
+        // (e.g. the operator pressed the key while ATAK was
+        // backgrounded, then swapped back before release). A spurious
+        // txController.stop() for a burst we never engaged is exactly
+        // the bug held-state guards against.
+        val recorder = Recorder()
+        val reader = SamsungActiveKeyForegroundReader(recorder)
+        dispatch(reader.listener, keyEvent(1015, KeyEvent.ACTION_UP))
+        assertEquals(0, recorder.edges.size)
+    }
+
+    @Test
+    fun `volume-down keycode is not consumed and does not fire PTT`() {
+        // A rogue "consumed=true" here would swallow volume rocker
+        // events for every other component in ATAK — must return false.
+        val recorder = Recorder()
+        val reader = SamsungActiveKeyForegroundReader(recorder)
+        val consumed = dispatch(reader.listener, keyEvent(KeyEvent.KEYCODE_VOLUME_DOWN, KeyEvent.ACTION_DOWN))
+        assertFalse("volume keys must pass through untouched", consumed)
+        assertEquals(0, recorder.edges.size)
+    }
+
+    @Test
+    fun `edges are tagged SAMSUNG_ACTIVE_KEY`() {
+        // Belt-and-suspenders against a copy-paste regression where
+        // the reader might ship events under the wrong PttSource.
+        val recorder = Recorder()
+        val reader = SamsungActiveKeyForegroundReader(recorder)
+        dispatch(reader.listener, keyEvent(1015, KeyEvent.ACTION_DOWN))
+        dispatch(reader.listener, keyEvent(1015, KeyEvent.ACTION_UP))
+        assertTrue(
+            "every edge must be tagged SAMSUNG_ACTIVE_KEY",
+            recorder.edges.all { it.second == PttSource.SAMSUNG_ACTIVE_KEY },
+        )
+    }
+
+    @Test
+    fun `start attaches to a real ATAK-adjacent view and stop detaches idempotently`() {
+        // We can't stand up a real com.atakmap.android.maps.MapView in
+        // a Robolectric unit test (needs ATAK runtime), but we CAN
+        // exercise start()/stop()'s idempotency and internal state
+        // machine against a plain View surrogate via reflection —
+        // MapView.addOnKeyListener / removeOnKeyListener are just
+        // View methods. Here we exercise state-machine behaviour
+        // without touching a live view: a stop() before any start()
+        // is a no-op, and isRunning() is false throughout.
+        val recorder = Recorder()
+        val reader = SamsungActiveKeyForegroundReader(recorder)
+        assertFalse(reader.isRunning())
+        reader.stop(mapView = null)
+        assertFalse("stop() before start() must be a safe no-op", reader.isRunning())
+        // No edges dispatched simply from lifecycle transitions.
+        assertEquals(0, recorder.edges.size)
+        // Sanity: the app context is available in Robolectric so future
+        // extensions can rely on it if they want.
+        assertTrue(RuntimeEnvironment.getApplication() != null)
+    }
+}

--- a/app/src/test/java/com/atakmap/android/xv/ptt/SamsungActiveKeyReaderTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/ptt/SamsungActiveKeyReaderTest.kt
@@ -1,0 +1,186 @@
+package com.atakmap.android.xv.ptt
+
+import android.content.Intent
+import com.atakmap.android.xv.audio.PttDispatcher
+import com.atakmap.android.xv.audio.PttSource
+import com.atakmap.android.xv.audio.StatusTones
+import com.atakmap.android.xv.audio.TptPlayer
+import com.atakmap.android.xv.audio.TxController
+import com.atakmap.android.xv.util.SamsungActiveKey
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * Coverage for [SamsungActiveKeyReader]'s wiring to [PttDispatcher].
+ *
+ * The reader translates the Samsung framework's `HARD_KEY_REPORT`
+ * broadcast into PTT down/up edges tagged with
+ * [PttSource.SAMSUNG_ACTIVE_KEY]. These tests use Robolectric to
+ * dispatch a synthetic broadcast against a registered receiver and
+ * verify the dispatcher sees the correct edges.
+ *
+ * We do NOT rely on any Samsung-only APIs — the mechanism is a plain
+ * `BroadcastReceiver` filtering on the framework's action string, so
+ * a Robolectric context is a fully-representative harness.
+ */
+@RunWith(RobolectricTestRunner::class)
+class SamsungActiveKeyReaderTest {
+    private lateinit var txController: TxController
+    private lateinit var statusTones: StatusTones
+    private lateinit var tptPlayer: TptPlayer
+    private lateinit var dispatcher: PttDispatcher
+    private lateinit var reader: SamsungActiveKeyReader
+
+    @Before
+    fun setup() {
+        txController = mockk(relaxed = true)
+        statusTones = mockk(relaxed = true)
+        tptPlayer = mockk(relaxed = true)
+        dispatcher =
+            PttDispatcher(
+                txController = txController,
+                statusTones = statusTones,
+                latchedModeEnabled = { false },
+                momentaryTimeoutSec = { 0 },
+                latchedTimeoutSec = { 0 },
+                tptPlayer = tptPlayer,
+            )
+        reader =
+            SamsungActiveKeyReader(
+                context = RuntimeEnvironment.getApplication(),
+                onEdge = { isDown, source ->
+                    if (isDown) dispatcher.down(slot = 0, source = source) else dispatcher.up(slot = 0, source = source)
+                },
+            )
+    }
+
+    private fun pressBroadcast(): Intent =
+        Intent(SamsungActiveKey.ACTION_HARD_KEY_REPORT).apply {
+            putExtra(SamsungActiveKey.EXTRA_KEY_CODE, SamsungActiveKey.KEY_CODE_PTT)
+            putExtra(SamsungActiveKey.EXTRA_KEY_REPORT_TYPE, SamsungActiveKey.KEY_REPORT_TYPE_PRESSED)
+        }
+
+    private fun releaseBroadcast(): Intent =
+        Intent(SamsungActiveKey.ACTION_HARD_KEY_REPORT).apply {
+            putExtra(SamsungActiveKey.EXTRA_KEY_CODE, SamsungActiveKey.KEY_CODE_PTT)
+            putExtra(SamsungActiveKey.EXTRA_KEY_REPORT_TYPE, SamsungActiveKey.KEY_REPORT_TYPE_RELEASED)
+        }
+
+    @Test
+    fun `start registers the receiver and press-broadcast fires slot-0 TX`() {
+        val ok = reader.start()
+        assertTrue("reader.start() should register the receiver in a Robolectric context", ok)
+        assertTrue(reader.isRunning())
+        RuntimeEnvironment.getApplication().sendBroadcast(pressBroadcast())
+        org.robolectric.shadows.ShadowLooper.idleMainLooper()
+        verify(exactly = 1) { txController.start(slot = 0) }
+    }
+
+    @Test
+    fun `press then release fires start then stop`() {
+        reader.start()
+        val app = RuntimeEnvironment.getApplication()
+        app.sendBroadcast(pressBroadcast())
+        org.robolectric.shadows.ShadowLooper.idleMainLooper()
+        app.sendBroadcast(releaseBroadcast())
+        org.robolectric.shadows.ShadowLooper.idleMainLooper()
+        verify(exactly = 1) { txController.start(slot = 0) }
+        verify(exactly = 1) { txController.stop() }
+    }
+
+    @Test
+    fun `stop unregisters the receiver — later broadcasts are dropped`() {
+        reader.start()
+        reader.stop()
+        assertFalse(reader.isRunning())
+        RuntimeEnvironment.getApplication().sendBroadcast(pressBroadcast())
+        org.robolectric.shadows.ShadowLooper.idleMainLooper()
+        verify(exactly = 0) { txController.start(slot = 0) }
+    }
+
+    @Test
+    fun `emergency key code is ignored — only KEYCODE_PTT drives TX`() {
+        reader.start()
+        val emergency =
+            Intent(SamsungActiveKey.ACTION_HARD_KEY_REPORT).apply {
+                // KEY_CODE_EMERGENCY = 1079 per Samsung Knox docs. XV's
+                // emergency subsystem is wired to AINA PTTE only; this
+                // reader must not couple the top key to slot-0 PTT.
+                putExtra(SamsungActiveKey.EXTRA_KEY_CODE, 1079)
+                putExtra(SamsungActiveKey.EXTRA_KEY_REPORT_TYPE, SamsungActiveKey.KEY_REPORT_TYPE_PRESSED)
+            }
+        RuntimeEnvironment.getApplication().sendBroadcast(emergency)
+        org.robolectric.shadows.ShadowLooper.idleMainLooper()
+        verify(exactly = 0) { txController.start(slot = 0) }
+    }
+
+    @Test
+    fun `malformed report type is dropped without touching TX`() {
+        reader.start()
+        val bogus =
+            Intent(SamsungActiveKey.ACTION_HARD_KEY_REPORT).apply {
+                putExtra(SamsungActiveKey.EXTRA_KEY_CODE, SamsungActiveKey.KEY_CODE_PTT)
+                // Not 1 (press) or 2 (release) — some future firmware
+                // may emit an unexpected value; we must not misinterpret.
+                putExtra(SamsungActiveKey.EXTRA_KEY_REPORT_TYPE, 99)
+            }
+        RuntimeEnvironment.getApplication().sendBroadcast(bogus)
+        org.robolectric.shadows.ShadowLooper.idleMainLooper()
+        verify(exactly = 0) { txController.start(slot = 0) }
+        verify(exactly = 0) { txController.stop() }
+    }
+
+    @Test
+    fun `double start is a safe no-op — receiver still delivers exactly one event`() {
+        assertTrue(reader.start())
+        assertTrue("second start() should also return true (already-registered path)", reader.start())
+        RuntimeEnvironment.getApplication().sendBroadcast(pressBroadcast())
+        org.robolectric.shadows.ShadowLooper.idleMainLooper()
+        // The receiver was registered only once, so exactly one TX
+        // engage — a duplicate registration would double-fire.
+        verify(exactly = 1) { txController.start(slot = 0) }
+    }
+
+    @Test
+    fun `stop before start is a safe no-op`() {
+        // No throw; no state change; subsequent start still works.
+        reader.stop()
+        assertFalse(reader.isRunning())
+        assertTrue(reader.start())
+        assertTrue(reader.isRunning())
+    }
+
+    @Test
+    fun `edges are tagged with SAMSUNG_ACTIVE_KEY source`() {
+        // Wire a custom onEdge to inspect the source directly (belt-
+        // and-suspenders against a copy-paste regression where the
+        // reader ships events under the wrong PttSource).
+        val seenSources = mutableListOf<Pair<Boolean, PttSource>>()
+        val r =
+            SamsungActiveKeyReader(
+                context = RuntimeEnvironment.getApplication(),
+                onEdge = { isDown, source -> seenSources.add(isDown to source) },
+            )
+        r.start()
+        val app = RuntimeEnvironment.getApplication()
+        app.sendBroadcast(pressBroadcast())
+        org.robolectric.shadows.ShadowLooper.idleMainLooper()
+        app.sendBroadcast(releaseBroadcast())
+        org.robolectric.shadows.ShadowLooper.idleMainLooper()
+        r.stop()
+        assertTrue("expected one down and one up edge", seenSources.size == 2)
+        assertTrue("first edge is down", seenSources[0].first)
+        assertFalse("second edge is up", seenSources[1].first)
+        assertTrue(
+            "all edges must be tagged SAMSUNG_ACTIVE_KEY",
+            seenSources.all { it.second == PttSource.SAMSUNG_ACTIVE_KEY },
+        )
+    }
+}

--- a/app/src/test/java/com/atakmap/android/xv/util/SamsungActiveKeyTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/util/SamsungActiveKeyTest.kt
@@ -1,0 +1,264 @@
+package com.atakmap.android.xv.util
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Coverage for the pure device-capability check that gates the
+ * Samsung Active Key PTT feature in Settings.
+ *
+ * The check is intentionally a pure function of Build.MANUFACTURER,
+ * Build.MODEL, and system features — no Android runtime needed — so
+ * the Robolectric harness stays optional here. If Samsung ever ships
+ * a real system feature for the Active Key, the extension is one
+ * `features` entry away without breaking the existing branches.
+ */
+class SamsungActiveKeyTest {
+    // ============================================================
+    // Model-prefix positives — Tab Active5 family
+    // ============================================================
+
+    @Test
+    fun `Samsung SM-X306B Tab Active5 5G → supported`() {
+        assertTrue(
+            SamsungActiveKey.isSupportedInternal(
+                manufacturer = "samsung",
+                model = "SM-X306B",
+                features = emptySet(),
+            ),
+        )
+    }
+
+    @Test
+    fun `Samsung SM-X300 Tab Active5 Wi-Fi → supported`() {
+        assertTrue(
+            SamsungActiveKey.isSupportedInternal(
+                manufacturer = "samsung",
+                model = "SM-X300",
+                features = emptySet(),
+            ),
+        )
+    }
+
+    @Test
+    fun `Samsung SM-X308U Tab Active5 5G US variant → supported`() {
+        assertTrue(
+            SamsungActiveKey.isSupportedInternal(
+                manufacturer = "samsung",
+                model = "SM-X308U",
+                features = emptySet(),
+            ),
+        )
+    }
+
+    // ============================================================
+    // Model-prefix positives — other supported Samsung ruggedized
+    // ============================================================
+
+    @Test
+    fun `Samsung SM-T636 Tab Active4 Pro → supported`() {
+        assertTrue(
+            SamsungActiveKey.isSupportedInternal(
+                manufacturer = "samsung",
+                model = "SM-T636",
+                features = emptySet(),
+            ),
+        )
+    }
+
+    @Test
+    fun `Samsung SM-T575 Tab Active3 → supported`() {
+        assertTrue(
+            SamsungActiveKey.isSupportedInternal(
+                manufacturer = "samsung",
+                model = "SM-T575",
+                features = emptySet(),
+            ),
+        )
+    }
+
+    @Test
+    fun `Samsung SM-G736U XCover6 Pro → supported`() {
+        assertTrue(
+            SamsungActiveKey.isSupportedInternal(
+                manufacturer = "samsung",
+                model = "SM-G736U",
+                features = emptySet(),
+            ),
+        )
+    }
+
+    @Test
+    fun `Samsung SM-G556B XCover7 → supported`() {
+        assertTrue(
+            SamsungActiveKey.isSupportedInternal(
+                manufacturer = "samsung",
+                model = "SM-G556B",
+                features = emptySet(),
+            ),
+        )
+    }
+
+    // ============================================================
+    // Negatives — non-Samsung
+    // ============================================================
+
+    @Test
+    fun `Google Pixel 9 Pro → not supported`() {
+        assertFalse(
+            SamsungActiveKey.isSupportedInternal(
+                manufacturer = "Google",
+                model = "Pixel 9 Pro",
+                features = emptySet(),
+            ),
+        )
+    }
+
+    @Test
+    fun `Motorola anything → not supported`() {
+        assertFalse(
+            SamsungActiveKey.isSupportedInternal(
+                manufacturer = "motorola",
+                model = "moto g power (2024)",
+                features = emptySet(),
+            ),
+        )
+    }
+
+    @Test
+    fun `Microsoft Surface Duo → not supported`() {
+        // Development host in AGENTS.md; the operator explicitly
+        // wants a hard "no" on non-Samsung dev hardware.
+        assertFalse(
+            SamsungActiveKey.isSupportedInternal(
+                manufacturer = "Microsoft",
+                model = "Surface Duo",
+                features = emptySet(),
+            ),
+        )
+    }
+
+    // ============================================================
+    // Negatives — Samsung, but a non-Active model (has power +
+    // volume only, no programmable side key)
+    // ============================================================
+
+    @Test
+    fun `Samsung SM-G998B Galaxy S21 Ultra → not supported`() {
+        assertFalse(
+            SamsungActiveKey.isSupportedInternal(
+                manufacturer = "samsung",
+                model = "SM-G998B",
+                features = emptySet(),
+            ),
+        )
+    }
+
+    @Test
+    fun `Samsung SM-A536B Galaxy A53 → not supported`() {
+        assertFalse(
+            SamsungActiveKey.isSupportedInternal(
+                manufacturer = "samsung",
+                model = "SM-A536B",
+                features = emptySet(),
+            ),
+        )
+    }
+
+    // ============================================================
+    // Feature-flag positive — future Samsung firmware may publish a
+    // proper system feature; we honour it as an additive signal so
+    // hardware we haven't hard-listed still lights up the toggle.
+    // ============================================================
+
+    @Test
+    fun `Samsung unknown model but declares active_key system feature → supported`() {
+        // Hypothetical future ruggedized Samsung with a model prefix
+        // we haven't seen yet, but firmware exposes the feature flag.
+        // Note: MANUFACTURER == samsung is still required — the feature
+        // flag alone on a non-Samsung device isn't recognised.
+        assertTrue(
+            SamsungActiveKey.isSupportedInternal(
+                manufacturer = "samsung",
+                model = "SM-X999X",
+                features = setOf("com.samsung.hardware.active_key"),
+            ),
+        )
+    }
+
+    @Test
+    fun `alt feature flag naming also honored`() {
+        // Documented as a defensive fallback in case Samsung publishes
+        // the flag under the `com.samsung.feature.*` namespace instead
+        // of `com.samsung.hardware.*`.
+        assertTrue(
+            SamsungActiveKey.isSupportedInternal(
+                manufacturer = "samsung",
+                model = "SM-X999X",
+                features = setOf("com.samsung.feature.active_key"),
+            ),
+        )
+    }
+
+    @Test
+    fun `feature flag on non-Samsung device → not supported`() {
+        assertFalse(
+            SamsungActiveKey.isSupportedInternal(
+                manufacturer = "Google",
+                model = "Pixel 9 Pro",
+                features = setOf("com.samsung.hardware.active_key"),
+            ),
+        )
+    }
+
+    // ============================================================
+    // Edge cases
+    // ============================================================
+
+    @Test
+    fun `blank manufacturer → not supported`() {
+        assertFalse(
+            SamsungActiveKey.isSupportedInternal(
+                manufacturer = "",
+                model = "SM-X306B",
+                features = emptySet(),
+            ),
+        )
+    }
+
+    @Test
+    fun `blank model on Samsung → not supported`() {
+        assertFalse(
+            SamsungActiveKey.isSupportedInternal(
+                manufacturer = "samsung",
+                model = "",
+                features = emptySet(),
+            ),
+        )
+    }
+
+    @Test
+    fun `mixed-case manufacturer still matches`() {
+        // Build.MANUFACTURER is empirically all-lowercase "samsung" on
+        // real hardware, but be tolerant of a future firmware quirk.
+        assertTrue(
+            SamsungActiveKey.isSupportedInternal(
+                manufacturer = "SAMSUNG",
+                model = "SM-X306B",
+                features = emptySet(),
+            ),
+        )
+    }
+
+    @Test
+    fun `mixed-case model still matches`() {
+        assertTrue(
+            SamsungActiveKey.isSupportedInternal(
+                manufacturer = "samsung",
+                model = "sm-x306b",
+                features = emptySet(),
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/atakmap/android/xv/util/SamsungActiveKeyTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/util/SamsungActiveKeyTest.kt
@@ -1,5 +1,7 @@
 package com.atakmap.android.xv.util
 
+import android.view.KeyEvent
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -258,6 +260,135 @@ class SamsungActiveKeyTest {
                 manufacturer = "samsung",
                 model = "sm-x306b",
                 features = emptySet(),
+            ),
+        )
+    }
+
+    // ============================================================
+    // handleKeyEvent — pure fallback classifier for the KeyEvent path
+    // ============================================================
+    // The foreground-KeyEvent fallback exists because on-device
+    // validation 2026-07-10 (Samsung Galaxy Tab Active5 / SM-X308U)
+    // confirmed the HARD_KEY_REPORT broadcast is NOT emitted by
+    // shipping firmware. The plain KeyEvent, in contrast, produces
+    // both ACTION_DOWN (with repeatCount == 0) and ACTION_UP for
+    // keyCode == 1015, so we route those into the same
+    // SAMSUNG_ACTIVE_KEY-tagged edges the broadcast path uses.
+
+    @Test
+    fun `handleKeyEvent — keyCode=1015 ACTION_DOWN repeat=0 → PTT_DOWN`() {
+        assertEquals(
+            SamsungActiveKey.FallbackAction.PTT_DOWN,
+            SamsungActiveKey.handleKeyEvent(
+                keyCode = SamsungActiveKey.KEY_CODE_PTT,
+                action = KeyEvent.ACTION_DOWN,
+                repeatCount = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun `handleKeyEvent — keyCode=1015 ACTION_UP → PTT_UP`() {
+        assertEquals(
+            SamsungActiveKey.FallbackAction.PTT_UP,
+            SamsungActiveKey.handleKeyEvent(
+                keyCode = SamsungActiveKey.KEY_CODE_PTT,
+                action = KeyEvent.ACTION_UP,
+                repeatCount = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun `handleKeyEvent — keyCode=1015 ACTION_DOWN repeat=1 → IGNORE (auto-repeat suppressed)`() {
+        // Physically-held key produces down events with repeatCount > 0.
+        // Dropping them keeps the log narrative honest (one "DOWN" line
+        // per press) and is belt-and-suspenders on top of PttDispatcher's
+        // OR-gate dedupe by source.
+        assertEquals(
+            SamsungActiveKey.FallbackAction.IGNORE,
+            SamsungActiveKey.handleKeyEvent(
+                keyCode = SamsungActiveKey.KEY_CODE_PTT,
+                action = KeyEvent.ACTION_DOWN,
+                repeatCount = 1,
+            ),
+        )
+    }
+
+    @Test
+    fun `handleKeyEvent — keyCode=1015 ACTION_DOWN repeat=5 → IGNORE (auto-repeat suppressed)`() {
+        assertEquals(
+            SamsungActiveKey.FallbackAction.IGNORE,
+            SamsungActiveKey.handleKeyEvent(
+                keyCode = SamsungActiveKey.KEY_CODE_PTT,
+                action = KeyEvent.ACTION_DOWN,
+                repeatCount = 5,
+            ),
+        )
+    }
+
+    @Test
+    fun `handleKeyEvent — keyCode=25 VOLUME_DOWN → IGNORE`() {
+        // Volume rockers must never fire PTT.
+        assertEquals(
+            SamsungActiveKey.FallbackAction.IGNORE,
+            SamsungActiveKey.handleKeyEvent(
+                keyCode = KeyEvent.KEYCODE_VOLUME_DOWN,
+                action = KeyEvent.ACTION_DOWN,
+                repeatCount = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun `handleKeyEvent — keyCode=24 VOLUME_UP → IGNORE`() {
+        assertEquals(
+            SamsungActiveKey.FallbackAction.IGNORE,
+            SamsungActiveKey.handleKeyEvent(
+                keyCode = KeyEvent.KEYCODE_VOLUME_UP,
+                action = KeyEvent.ACTION_DOWN,
+                repeatCount = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun `handleKeyEvent — keyCode=4 BACK → IGNORE`() {
+        // Any non-Active-Key keycode is passed through untouched.
+        assertEquals(
+            SamsungActiveKey.FallbackAction.IGNORE,
+            SamsungActiveKey.handleKeyEvent(
+                keyCode = KeyEvent.KEYCODE_BACK,
+                action = KeyEvent.ACTION_UP,
+                repeatCount = 0,
+            ),
+        )
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `handleKeyEvent — keyCode=1015 ACTION_MULTIPLE → IGNORE (unusual action dropped)`() {
+        // ACTION_MULTIPLE is deprecated and semantically ambiguous —
+        // treat it as a non-edge and drop.
+        assertEquals(
+            SamsungActiveKey.FallbackAction.IGNORE,
+            SamsungActiveKey.handleKeyEvent(
+                keyCode = SamsungActiveKey.KEY_CODE_PTT,
+                action = KeyEvent.ACTION_MULTIPLE,
+                repeatCount = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun `handleKeyEvent — keyCode=1015 with an unknown action code → IGNORE`() {
+        // Future firmware surfaces we've never seen shouldn't misfire.
+        assertEquals(
+            SamsungActiveKey.FallbackAction.IGNORE,
+            SamsungActiveKey.handleKeyEvent(
+                keyCode = SamsungActiveKey.KEY_CODE_PTT,
+                action = 99,
+                repeatCount = 0,
             ),
         )
     }


### PR DESCRIPTION
## Operator context

Adds the programmable side **Active Key** on Samsung ruggedized hardware
(Galaxy Tab Active5, Tab Active4 Pro, Tab Active3, XCover6 Pro, XCover7)
as an additional PTT source, alongside the existing on-screen PTT, the
primary AINA speakermic, and the External Button. Requested by the
operator 2026-07-10 for Tab Active5 (SM-X306 / SM-X300 series).

The option only appears in Settings on hardware that actually has the
key — non-Samsung devices see nothing. Default OFF. When the toggle is
OFF, the key's default Samsung-configured behaviour is unaffected.

## Research findings — mechanism chosen

The Samsung framework broadcasts a system intent on every press and
release of the Active / XCover key:

- **Action:** `com.samsung.android.knox.intent.action.HARD_KEY_REPORT`
- **Extras:**
  - `com.samsung.android.knox.intent.extra.KEY_CODE` (int) —
    `1015` = side PTT / Active Key, `1079` = top Emergency key
  - `com.samsung.android.knox.intent.extra.KEY_REPORT_TYPE` (int) —
    `1` = pressed, `2` = released

Sources:
- [Samsung Knox — Unmanaged key mappings](https://docs.samsungknox.com/dev/knox-sdk/features/independent-software-vendors-da/hardware-key-mappings/unmanaged-key-mappings/)
- [Samsung Knox — Hardware key mapping overview](https://docs.samsungknox.com/dev/knox-sdk/features/independent-software-vendors-da/hardware-key-mappings/hardware-key-mapping/)

### Why no Knox dependency

Despite the `knox` prefix on the action string, receiving the broadcast
requires **no Knox SDK, no Knox license, and no enterprise
entitlement**. The framework fires the intent on qualifying hardware
regardless of licensing; any app that registers a plain
`BroadcastReceiver` gets the events. XV therefore **does not depend on
the Knox SDK jar**. The unmanaged-key-mappings page linked above is
explicit that the "app implements a broadcast receiver" path is the
non-Knox integration.

### Why we can safely receive it while backgrounded

The broadcast is system-wide — not tied to app foreground state — and
XvVoiceService is a long-running foreground service in its own UID. So
Active-Key PTT works while ATAK is backgrounded, same as the AINA path.
No KeyEvent / IME / accessibility gymnastics needed.

### Device gate

- Zero-cost on non-Samsung hardware. `util.SamsungActiveKey.isSupported`
  returns false on anything that isn't a curated Samsung ruggedized
  model, so the reader is never instantiated and the Settings row is
  hidden entirely (`View.GONE` at inflate time — not greyed-out per
  operator direction).
- Model-prefix allow-list (Tab Active5 SM-X30x, Tab Active4 Pro
  SM-T63x, Tab Active3 SM-T57x, XCover6 Pro SM-G736, XCover7 SM-G556)
  is intentionally conservative and extendable.
- Speculative `PackageManager` feature-flag path
  (`com.samsung.hardware.active_key` / `com.samsung.feature.active_key`)
  is honoured as an additive positive signal so future ruggedized
  Samsung hardware we haven't hard-listed still lights up the toggle
  if firmware publishes the flag.

## What changed

- New `PttSource.SAMSUNG_ACTIVE_KEY` (dropsTrailingClick = false —
  bare rubber-dome switch, no release-click to trim).
- New `ptt/SamsungActiveKeyReader.kt` — registers a
  `RECEIVER_NOT_EXPORTED` broadcast receiver, filters on `KEYCODE_PTT`
  = 1015 only (ignores the top Emergency key — emergency routing stays
  wired to AINA PTTE only), fires down/up edges through `PttDispatcher`
  via `PttSource.SAMSUNG_ACTIVE_KEY`. Idempotent start/stop.
- New `util/SamsungActiveKey.kt` — pure `Object` with the capability
  check (test-seam `isSupportedInternal` for pure JVM unit tests) plus
  the well-known action/extras/key-code constants.
- `VoicePlant.startSamsungActiveKey` / `stopSamsungActiveKey` /
  `isSamsungActiveKeyRunning` + `teardown()` cleanup. `forgetSource`
  cascade on stop so a mid-press toggle-off doesn't strand a held
  source in the dispatcher's OR-gate.
- AIDL: `IXvVoice.setSamsungActiveKeyEnabled(boolean)` +
  `isSamsungActiveKeyRunning()`. Wired in `XvVoiceService` with the
  same `assertAuthorizedCaller()` gate as the AINA / secondary paths.
- `XvSettings` — new pref key `samsung_active_key_enabled`, default
  `false`.
- `xv_settings.xml` — new card row `xv_row_samsung_active_key` +
  `xv_switch_samsung_active_key` + help text. Both `View.GONE` at
  inflate; `XvDropDownReceiver.wireSamsungActiveKeySwitch` reveals
  them only when the capability check is true.
- `XvDropDownReceiver.Controller` gains `samsungActiveKeySupported` /
  `samsungActiveKeyEnabled` / `setSamsungActiveKeyEnabled`.
  `XvMapComponent` implements them, gates the service call on the
  capability check as defence-in-depth, and adds
  `autoStartSamsungActiveKeyIfEnabled` to the plugin startup path
  next to `autoConnectAina`.
- `README.md` — "What's different" § 3 amended to note the new PTT
  source. Hardware-tested list intentionally **not** amended pending
  end-to-end validation on real Samsung ruggedized hardware.

## Test coverage

- **`SamsungActiveKeyTest`** — 19 pure-function cases (no
  Robolectric): Tab Active5 (SM-X306B, SM-X300, SM-X308U), Tab Active4
  Pro (SM-T636), Tab Active3 (SM-T575), XCover6 Pro (SM-G736U),
  XCover7 (SM-G556B); negatives for Google Pixel 9 Pro, Motorola,
  Microsoft Surface Duo, Samsung S21 Ultra (SM-G998B), Samsung A53
  (SM-A536B); the feature-flag path (positive on Samsung, negative on
  non-Samsung); edge cases (blank manufacturer / model, mixed-case
  strings).
- **`SamsungActiveKeyReaderTest`** — 8 Robolectric cases: receiver
  registration succeeds; press broadcast fires
  `TxController.start(slot=0)`; press-then-release fires start then
  stop exactly once; stop unregisters the receiver;
  `KEY_CODE_EMERGENCY` (1079) is dropped; malformed `KEY_REPORT_TYPE`
  is dropped; double `start()` is a safe no-op (verifies no duplicate
  registration); `stop()` before `start()` is safe; edges carry the
  correct `PttSource.SAMSUNG_ACTIVE_KEY` tag.

## Explicit non-goals

- **No Knox dependency.** The research shows the mechanism does not
  require Knox, so we do not vendor or link the Knox SDK jar. The
  reader is a plain `BroadcastReceiver`.
- **No behaviour change on non-Samsung devices.** The Settings row is
  hidden, the reader is never instantiated,
  `autoStartSamsungActiveKeyIfEnabled` short-circuits.
- **No interference with the key when the toggle is OFF or a different
  app is in the foreground.** We don't register the receiver when off;
  the framework's default routing (whatever Samsung has the key mapped
  to) is unaffected. The broadcast is a fan-out — receiving it doesn't
  consume it.

## Test plan

- [x] `./gradlew ktlintCheck` — green
- [x] `./gradlew assembleCivDebug` — green
- [x] `./gradlew testCivDebugUnitTest` — green (19 pure + 8 Robolectric
      new; full suite unaffected)
- [ ] On a Samsung Tab Active5 (SM-X300 / SM-X306 / SM-X308): open
      Settings → Preferences, verify the "Use Samsung Active Key as
      PTT" row is visible under the auto-connect toggle. Toggle ON,
      press the side Active Key → TX engages on the current channel.
      Release → TX ends.
- [ ] On the same device: toggle OFF, press the Active Key → whatever
      Samsung has the key configured for (Settings → Advanced features
      → Active Key) fires normally. XV does not consume or interfere
      with the press.
- [ ] On a non-Samsung device (Pixel 9 Pro / Surface Duo / Motorola):
      open Settings → Preferences, verify the Samsung Active Key row is
      absent (hidden `View.GONE`, not just greyed out).
- [ ] Optional smoke check: hold the Active Key AND the on-screen PTT
      simultaneously. Release either one; TX should stay engaged until
      the last held source releases (OR-gate).

## Caveats

- Model prefix allow-list is intentionally conservative. If an
  operator has qualifying Samsung ruggedized hardware whose model
  prefix isn't on the list, the toggle will only appear if their
  firmware exposes one of the speculative feature-flag candidates
  (`com.samsung.hardware.active_key` / `com.samsung.feature.active_key`).
  If neither works, extending the model prefix list is a one-line
  change in `SamsungActiveKey`.
- On-device validation on a real Samsung Tab Active5 is the next step.
  The Tab Active5 will graduate to the README "Hardware tested" list
  once that validation completes, per the curated-hardware policy in
  CLAUDE.md.


## Fallback KeyEvent path (added 2026-07-10)

On-device validation on a Samsung Galaxy Tab Active5 (SM-X308U) proved
that shipping firmware does **not** emit the
`com.samsung.android.knox.intent.action.HARD_KEY_REPORT` broadcast for
the side Active Key. The operator's Settings → Advanced features →
Active Key surface only offers "launch app" mappings — one intent on
press, no release signal, so unusable as a PTT source.

The plain Android `KeyEvent` path, however, does fire on both edges:
`PhoneWindowManager.interceptKeyTq` routes `keycode=1015` through
`InputDispatcher` to the foreground activity, producing `ACTION_DOWN`
(with `repeatCount == 0`) and `ACTION_UP`. That's what PTT needs.

### What the fallback adds

- `SamsungActiveKey.handleKeyEvent(keyCode, action, repeatCount)` —
  pure, unit-testable classifier (`PTT_DOWN` / `PTT_UP` / `IGNORE`).
  Filters on `keyCode == 1015`; drops `ACTION_DOWN` with
  `repeatCount > 0` (auto-repeat); ignores anything that isn't a
  clean DOWN/UP edge (including the deprecated `ACTION_MULTIPLE`).
- `ptt/SamsungActiveKeyForegroundReader.kt` — attaches a
  `View.OnKeyListener` to the ATAK `MapView` (in ATAK's process, since
  `InputDispatcher` delivers non-broadcast keys only to the top
  activity). Owns an internal `held` flag as belt-and-suspenders so a
  redelivered UP after a foreground handoff can't fire a spurious
  `txController.stop()`, and a redelivered DOWN while already held
  can't fire a duplicate log line. Non-Active-Key events pass through
  untouched (returns `false`) — volume rockers etc. keep working.
- `XvMapComponent.startSamsungActiveKeyForeground` /
  `stopSamsungActiveKeyForeground` — same
  `SamsungActiveKey.isSupported` device gate as the broadcast path,
  driven by the same operator toggle, cleaned up in `onDestroyImpl`
  with a defensive `notifySamsungActiveKeyEdge(false)` so a plugin
  unload mid-press can't strand `SAMSUNG_ACTIVE_KEY` in the
  dispatcher's `heldButtons` OR-gate.
- `IXvVoice.notifySamsungActiveKeyEdge(boolean)` — new AIDL entry
  (additive; no API version bump, matches the "add-at-end is
  backwards compatible" contract already documented in the AIDL
  header). Routes the plugin-side foreground edge to the service's
  `PttDispatcher.down/up(0, PttSource.SAMSUNG_ACTIVE_KEY)` so both
  paths share the same source-tagged dispatch.

### Two-path coexistence

Both paths run concurrently when both apply:

- On firmware that **does** emit `HARD_KEY_REPORT` (the ideal), the
  broadcast reader fires backgrounded, and — when ATAK is foreground —
  the KeyEvent path fires too. `PttSource.SAMSUNG_ACTIVE_KEY` is a
  set-entry in the dispatcher, so a duplicate `down(...,
  SAMSUNG_ACTIVE_KEY)` while it's already held is a no-op (see
  `PttDispatcher.down()`), and a duplicate `up(...)` after the set is
  empty is idempotent (`txController.stop()` is a no-op when TX is
  already IDLE).
- On firmware that does **not** emit `HARD_KEY_REPORT` (Tab Active5
  today), the broadcast reader stays silent and the KeyEvent path is
  the sole Active-Key PTT source.

### Operational limitation — foreground only

The KeyEvent fallback works **only while ATAK is in the foreground**.
That's the same constraint any hardware-button PTT app has when it's
not a system app, IME, or accessibility service — `InputDispatcher`
routes non-broadcast keys to the top activity, so a backgrounded
plugin can't observe them. On Tab Active5-class firmware, this means
the Active Key is a foreground-only PTT source until (or unless)
Samsung starts emitting `HARD_KEY_REPORT` for `KEY_CODE == 1015` on
that hardware.

The broadcast path stays in place unchanged — it's still the ideal
for firmware that does emit it, and it does work backgrounded.

### Log narrative

Both paths log distinctly so the on-device evidence is unambiguous:

- Broadcast: `Samsung Active Key DOWN` / `... UP`
  (tag `XvSamsungActiveKey`)
- KeyEvent: `Samsung Active Key DOWN (via KeyEvent foreground)` /
  `... UP (via KeyEvent foreground)` (tag `XvSamsungActiveKeyFg`)

### Explicit non-changes

- Broadcast path is unchanged.
- No Knox SDK dependency added; no AndroidManifest surface change.
- No versionCode / versionName bump.
- No changes to any other PR's code path.

### New test coverage

- 9 pure-JVM cases for `SamsungActiveKey.handleKeyEvent` (auto-repeat
  drop, volume passthrough, unusual actions, correct edges for
  DOWN/UP@repeat=0, mixed-case negatives).
- 8 Robolectric cases for `SamsungActiveKeyForegroundReader`
  (single-fire on press, DOWN-then-UP ordering, duplicate DOWN
  suppression, orphan-UP suppression, correct source tag on every
  edge, non-Active-Key events not consumed, stop-before-start no-op).

`ktlintCheck`, `assembleCivDebug`, `testCivDebugUnitTest` all green.
