### PR TITLE
fix(ptt): block TX during active cellular call

### DIFF
--- a/app/src/main/aidl/com/atakmap/android/xv/service/IXvVoiceListener.aidl
+++ b/app/src/main/aidl/com/atakmap/android/xv/service/IXvVoiceListener.aidl
@@ -76,4 +76,13 @@ interface IXvVoiceListener {
     // operator-actionable string from AudioCapture (e.g. "RECORD_AUDIO
     // permission revoked — re-grant in system Settings").
     void onCaptureError(String reason);
+
+    // PTT was suppressed because the cellular telephony stack reports
+    // an active or ringing call. XV's self-managed Telecom call would
+    // otherwise auto-hold the cellular call, which is almost never what
+    // an operator fidgeting with a BT speakermic actually wants. Plugin
+    // surfaces [reason] as a Toast so the operator knows why nothing
+    // transmitted. The service side already throttles repeated fires
+    // during rapid button mashing.
+    void onPttBlockedByCellularCall(String reason);
 }

--- a/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
+++ b/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
@@ -748,6 +748,28 @@ class XvMapComponent : AbstractMapComponent() {
                     }
                 }
 
+                override fun onPttBlockedByCellularCall(reason: String?) {
+                    // Service side suppressed a PTT press because the
+                    // cellular telephony stack reports an active or
+                    // ringing call. Without this Toast the operator
+                    // sees no visible feedback for the press and
+                    // reasonably assumes XV is broken. Service already
+                    // throttles the fire so we do not stack toasts on
+                    // rapid button mashes.
+                    val msg = reason ?: "Cellular call active — hang up before XV PTT"
+                    Log.i(TAG, "onPttBlockedByCellularCall: $msg")
+                    val target = MapView.getMapView() ?: return
+                    try {
+                        target.post {
+                            android.widget.Toast
+                                .makeText(target.context, msg, android.widget.Toast.LENGTH_LONG)
+                                .show()
+                        }
+                    } catch (t: Throwable) {
+                        Log.w(TAG, "cellular-block toast threw", t)
+                    }
+                }
+
                 override fun onPrivateCallEnded() {
                     cancelPendingAnswerTimeout("call ended")
                     cancelPendingRingback("call ended")

--- a/app/src/main/java/com/atakmap/android/xv/service/PttCellularGate.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/PttCellularGate.kt
@@ -2,6 +2,7 @@ package com.atakmap.android.xv.service
 
 import android.media.AudioManager
 import android.telephony.TelephonyManager
+import com.atakmap.android.xv.audio.PttSource
 
 // Pure decision function for the "block PTT during an active cellular
 // call" gate. Kept isolated from VoicePlant so it can be exercised by a
@@ -47,17 +48,51 @@ enum class PttGate {
 }
 
 /**
- * Map a [TelephonyManager] call-state code to the corresponding
- * [PttGate] outcome. Any unrecognized value defaults to [PttGate.ALLOW]
- * — the gate fails open. Locking out PTT because we could not read
- * telephony state is worse than the auto-hold bug this gate exists to
- * fix; XV is a tactical voice tool and unexplained mute is the more
- * dangerous failure mode.
+ * Map a [TelephonyManager] call-state code + PTT [source] to the
+ * corresponding [PttGate] outcome. Any unrecognized call-state value
+ * defaults to [PttGate.ALLOW] — the gate fails open. Locking out PTT
+ * because we could not read telephony state is worse than the
+ * auto-hold bug this gate exists to fix; XV is a tactical voice tool
+ * and unexplained mute is the more dangerous failure mode.
+ *
+ * Source-scoped policy (2026-07-10 revision): the cellular-call gate
+ * only applies to [PttSource.ON_SCREEN] — the on-screen PTT button.
+ * Every non-screen source (AINA V1/V2, Pryme MFB, any future
+ * BT-HID / gpio hardware button, and the DEBUG intent path) bypasses
+ * the gate entirely and returns [PttGate.ALLOW] even during OFFHOOK
+ * or RINGING.
+ *
+ * Rationale:
+ *  - On-screen PTT taps are accident-prone. A wayward finger during a
+ *    phone call should not silently auto-hold the operator's call by
+ *    placing XV's self-managed Telecom call. The toast + block is the
+ *    right response for that path.
+ *  - A hardware button press represents deliberate operator intent.
+ *    Tactical scenarios routinely require an operator to key up
+ *    mid-call (call-of-record on the phone, but the incident lives on
+ *    XV). Blocking a hardware press would surprise-block a
+ *    deliberate transmission attempt — a worse failure than the
+ *    auto-hold it would prevent. The operator gets what they asked
+ *    for; XV's Telecom call still auto-holds the cellular call as a
+ *    side effect, but that side effect is now intentional.
+ *  - DEBUG intents originate from adb / dev tooling, never from a
+ *    stray touch. Treating them as bypass keeps the debug path
+ *    usable while a cellular call is up.
+ *
+ * Future hardware sources added to [PttSource] inherit the ALLOW
+ * behavior automatically — the gate only ever blocks the one
+ * accident-prone input (ON_SCREEN).
  */
-fun shouldGateForCellularCall(callState: Int): PttGate =
-    when (callState) {
-        TelephonyManager.CALL_STATE_OFFHOOK -> PttGate.BLOCK_CELLULAR_CALL
-        TelephonyManager.CALL_STATE_RINGING -> PttGate.BLOCK_CELLULAR_RINGING
+fun shouldGateForCellularCall(
+    callState: Int,
+    source: PttSource,
+): PttGate =
+    when {
+        // Only the on-screen PTT tap is accident-prone enough to gate.
+        // Every hardware button and the debug intent path bypass.
+        source != PttSource.ON_SCREEN -> PttGate.ALLOW
+        callState == TelephonyManager.CALL_STATE_OFFHOOK -> PttGate.BLOCK_CELLULAR_CALL
+        callState == TelephonyManager.CALL_STATE_RINGING -> PttGate.BLOCK_CELLULAR_RINGING
         else -> PttGate.ALLOW
     }
 

--- a/app/src/main/java/com/atakmap/android/xv/service/PttCellularGate.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/PttCellularGate.kt
@@ -1,0 +1,67 @@
+package com.atakmap.android.xv.service
+
+import android.telephony.TelephonyManager
+
+// Pure decision function for the "block PTT during an active cellular
+// call" gate. Kept isolated from VoicePlant so it can be exercised by a
+// plain JUnit test without Robolectric — the mapping from telephony
+// call-state codes to gate outcome is the only interesting logic.
+//
+// Why this gate exists: XV places a self-managed Telecom call
+// unconditionally on every PTT-down (see feedback_audio_plant_modes.md
+// — the Telecom call is what claims MODE_IN_COMMUNICATION + audio focus
+// so background media apps yield the SCO chipset). Android's Telecom
+// framework auto-holds any active third-party call whenever a second
+// self-managed call is placed. Operators fidgeting with a BT speakermic
+// during an active cellular phone call have accidentally keyed PTT and
+// dropped their phone call onto hold mid-conversation. This gate is
+// Option A of the fix: block the TX entirely and prompt the operator
+// to hang up first, rather than preempting the cellular call for what
+// is almost certainly an unintentional press.
+
+enum class PttGate {
+    /** Cellular telephony reports IDLE — proceed with TX as normal. */
+    ALLOW,
+
+    /** A cellular call is CONNECTED (OFFHOOK). Block TX so we do not
+     *  auto-hold it via Telecom's second-self-managed-call arbitration. */
+    BLOCK_CELLULAR_CALL,
+
+    /** A cellular call is RINGING. Block TX so PTT does not race the
+     *  operator's answer/decline decision on the incoming call UI. */
+    BLOCK_CELLULAR_RINGING,
+}
+
+/**
+ * Map a [TelephonyManager] call-state code to the corresponding
+ * [PttGate] outcome. Any unrecognized value defaults to [PttGate.ALLOW]
+ * — the gate fails open. Locking out PTT because we could not read
+ * telephony state is worse than the auto-hold bug this gate exists to
+ * fix; XV is a tactical voice tool and unexplained mute is the more
+ * dangerous failure mode.
+ */
+fun shouldGateForCellularCall(callState: Int): PttGate =
+    when (callState) {
+        TelephonyManager.CALL_STATE_OFFHOOK -> PttGate.BLOCK_CELLULAR_CALL
+        TelephonyManager.CALL_STATE_RINGING -> PttGate.BLOCK_CELLULAR_RINGING
+        else -> PttGate.ALLOW
+    }
+
+/**
+ * Decide whether a "cellular call active — hang up before XV PTT"
+ * toast should be shown right now, given [nowMs] and the timestamp of
+ * the previous toast [lastToastAtMs]. Rapid PTT button mashing during
+ * a call would otherwise stack a wall of identical toasts; a fixed
+ * throttle keeps at most one visible per [throttleMs] window.
+ *
+ * A [lastToastAtMs] value of 0 (the "never toasted" sentinel) always
+ * qualifies. Callers store the returned decision's "now" value on true.
+ */
+fun shouldToastCellularBlock(
+    nowMs: Long,
+    lastToastAtMs: Long,
+    throttleMs: Long = CELLULAR_BLOCK_TOAST_THROTTLE_MS,
+): Boolean = lastToastAtMs <= 0L || (nowMs - lastToastAtMs) >= throttleMs
+
+/** Minimum spacing between repeat "cellular call active" toasts. */
+const val CELLULAR_BLOCK_TOAST_THROTTLE_MS: Long = 3_000L

--- a/app/src/main/java/com/atakmap/android/xv/service/PttCellularGate.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/PttCellularGate.kt
@@ -1,5 +1,6 @@
 package com.atakmap.android.xv.service
 
+import android.media.AudioManager
 import android.telephony.TelephonyManager
 
 // Pure decision function for the "block PTT during an active cellular
@@ -18,6 +19,19 @@ import android.telephony.TelephonyManager
 // Option A of the fix: block the TX entirely and prompt the operator
 // to hang up first, rather than preempting the cellular call for what
 // is almost certainly an unintentional press.
+//
+// State source: [AudioManager.getMode] rather than
+// [TelephonyManager.getCallState]. The original PR wired the provider
+// to getCallState() on the assumption that the plain non-permission
+// API works from API 26 upward; that assumption was wrong from API 31
+// onward — on Pixel API 35 getCallState throws SecurityException
+// ("Neither user nor current process has android.permission.READ_PHONE_STATE")
+// on every call. AudioManager.getMode requires no permission at any
+// API level, reports MODE_IN_CALL while a cellular call is OFFHOOK and
+// MODE_RINGTONE while one is ringing, and is what XV's own audio-plant
+// code already reads elsewhere (see AudioControllerImpl / ScoLink /
+// TptPlayer). We refuse to widen the app's permission surface for a
+// fidget-guard during a production freeze.
 
 enum class PttGate {
     /** Cellular telephony reports IDLE — proceed with TX as normal. */
@@ -65,3 +79,33 @@ fun shouldToastCellularBlock(
 
 /** Minimum spacing between repeat "cellular call active" toasts. */
 const val CELLULAR_BLOCK_TOAST_THROTTLE_MS: Long = 3_000L
+
+/**
+ * Map an [AudioManager] audio-mode constant to the equivalent
+ * [TelephonyManager] call-state constant that [shouldGateForCellularCall]
+ * consumes.
+ *
+ * Kept as its own pure function so the VoicePlant provider stays a
+ * thin adapter (system-service lookup → this mapping → gate decision)
+ * and the mapping can be unit-tested without Robolectric.
+ *
+ * Correspondence:
+ * - [AudioManager.MODE_IN_CALL] → [TelephonyManager.CALL_STATE_OFFHOOK]:
+ *   the telephony stack sets MODE_IN_CALL whenever a cellular call is
+ *   in the OFFHOOK (connected) state.
+ * - [AudioManager.MODE_RINGTONE] → [TelephonyManager.CALL_STATE_RINGING]:
+ *   set while an inbound call is ringing.
+ * - Everything else → [TelephonyManager.CALL_STATE_IDLE]. In particular
+ *   [AudioManager.MODE_IN_COMMUNICATION] is what XV's OWN self-managed
+ *   Telecom call uses (see AudioControllerImpl.enterTx) — mapping it
+ *   to OFFHOOK here would gate ourselves out of every subsequent PTT
+ *   press. MODE_NORMAL, MODE_CURRENT, and MODE_INVALID all fall to
+ *   IDLE for the same fail-open rationale as
+ *   [shouldGateForCellularCall].
+ */
+fun cellularCallStateFromAudioMode(audioMode: Int): Int =
+    when (audioMode) {
+        AudioManager.MODE_IN_CALL -> TelephonyManager.CALL_STATE_OFFHOOK
+        AudioManager.MODE_RINGTONE -> TelephonyManager.CALL_STATE_RINGING
+        else -> TelephonyManager.CALL_STATE_IDLE
+    }

--- a/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
@@ -55,34 +55,37 @@ class VoicePlant(
     private val callbacks: Callbacks,
     // Cellular-call state probe for the pttDown gate. Injected so unit
     // tests can drive OFFHOOK / RINGING / IDLE without touching a real
-    // TelephonyManager. Defaults to reading the system TelephonyManager
-    // via getCallState() — the plain call-state API works without
-    // READ_PHONE_STATE from API 26 (our minSdk) upward, so we do not
-    // widen the app's permission surface for this gate. On any
-    // SecurityException the probe returns CALL_STATE_IDLE (fail-open)
-    // — a locked-out PTT with no explanation is a worse failure than
-    // the auto-hold bug this gate exists to fix.
+    // AudioManager. Defaults to reading AudioManager.getMode() and
+    // mapping the audio-mode constant to a TelephonyManager call-state
+    // constant via [cellularCallStateFromAudioMode].
+    //
+    // Why AudioManager and not TelephonyManager: the original wire-up
+    // used TelephonyManager.getCallState() on the assumption that the
+    // plain non-permission API works from API 26 upward. That is wrong
+    // from API 31 onward — on-device evidence from Pixel API 35 shows
+    // getCallState() throws SecurityException ("Neither user nor
+    // current process has android.permission.READ_PHONE_STATE") on
+    // every PTT-down. The fidget-guard exists to reduce noise; a probe
+    // that itself throws + logs a stack trace on every press makes the
+    // audio hot-path more expensive AND buys no benefit (we never see
+    // OFFHOOK). AudioManager.getMode() requires no permission at any
+    // API level and returns MODE_IN_CALL / MODE_RINGTONE for the exact
+    // states we want to gate on. XV's own audio-plant code already
+    // reads audioManager.mode extensively (AudioControllerImpl,
+    // ScoLink, TptPlayer) — this is just one more reader.
+    //
+    // Belt-and-suspenders: a defensive catch on Throwable still returns
+    // IDLE (fail-open). getMode() is not documented to throw, but a
+    // SILENT permission denial that we cannot observe is a worse
+    // failure than the auto-hold bug this gate exists to fix.
     private val cellularCallStateProvider: () -> Int = {
         try {
-            val tm =
-                context.getSystemService(Context.TELEPHONY_SERVICE)
-                    as? android.telephony.TelephonyManager
-            // Suppress: getCallState() is deprecated in favor of
-            // getCallStateForSubscription() (API 31+), which requires
-            // READ_PHONE_STATE. We deliberately use the plain non-
-            // permission API here — the fidget-during-call bug only
-            // needs the default subscription's aggregate state, and
-            // widening our permission surface for a fidget-guard is
-            // not justified.
-            @Suppress("DEPRECATION")
-            tm?.callState ?: android.telephony.TelephonyManager.CALL_STATE_IDLE
-        } catch (se: SecurityException) {
-            android.util.Log.w(
-                TAG,
-                "cellularCallStateProvider: SecurityException — treating as IDLE",
-                se,
+            val am =
+                context.getSystemService(Context.AUDIO_SERVICE)
+                    as? AudioManager
+            cellularCallStateFromAudioMode(
+                am?.mode ?: AudioManager.MODE_NORMAL,
             )
-            android.telephony.TelephonyManager.CALL_STATE_IDLE
         } catch (t: Throwable) {
             android.util.Log.w(
                 TAG,

--- a/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
@@ -764,10 +764,21 @@ class VoicePlant(
         // toast throttle. This gate must run BEFORE the Telecom call
         // placement below — the whole point is to avoid placing that
         // call while the cellular stack is busy.
+        //
+        // Source-scoped (2026-07-10): the gate only fires for
+        // [PttSource.ON_SCREEN] taps. Hardware button sources
+        // (AINA V1/V2, Pryme MFB, and any future BT-HID hardware
+        // input) represent deliberate operator intent — a mid-call
+        // hardware key-up must not be surprise-blocked. The pure
+        // decision in [shouldGateForCellularCall] returns ALLOW for
+        // every non-screen source unconditionally; the fetch of
+        // cellState is still cheap and worth keeping outside the
+        // branch so the INFO log below can name the actual telephony
+        // state that was bypassed.
         val cellState = cellularCallStateProvider()
-        val gate = shouldGateForCellularCall(cellState)
+        val gate = shouldGateForCellularCall(cellState, source)
         if (gate != PttGate.ALLOW) {
-            Log.i(TAG, "PTT blocked — cellular call state=$cellState (gate=$gate)")
+            Log.i(TAG, "PTT blocked — cellular call state=$cellState source=$source (gate=$gate)")
             val now = nowMsProvider()
             if (shouldToastCellularBlock(nowMs = now, lastToastAtMs = lastCellCallToastAtMs)) {
                 lastCellCallToastAtMs = now
@@ -783,6 +794,20 @@ class VoicePlant(
                 )
             }
             return
+        } else {
+            // Log at INFO so an operator reading a post-mortem logcat
+            // understands why the "cellular call active" toast did NOT
+            // fire for a hardware press during a call. Expected
+            // behavior — deliberate hardware intent bypasses the
+            // fidget-guard. Only log when the cellular stack actually
+            // was in one of the states we would have gated on for an
+            // on-screen tap; the IDLE case is not interesting.
+            val cellActive =
+                cellState == android.telephony.TelephonyManager.CALL_STATE_OFFHOOK ||
+                    cellState == android.telephony.TelephonyManager.CALL_STATE_RINGING
+            if (source != PttSource.ON_SCREEN && cellActive) {
+                Log.i(TAG, "cellular call active but source=$source is hardware — allowing PTT")
+            }
         }
         // Pre-set the comm device for our route preference BEFORE
         // anything else. Two consumers need this assertion:

--- a/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
@@ -53,6 +53,51 @@ import com.atakmap.android.xv.audio.TxController
 class VoicePlant(
     private val context: Context,
     private val callbacks: Callbacks,
+    // Cellular-call state probe for the pttDown gate. Injected so unit
+    // tests can drive OFFHOOK / RINGING / IDLE without touching a real
+    // TelephonyManager. Defaults to reading the system TelephonyManager
+    // via getCallState() — the plain call-state API works without
+    // READ_PHONE_STATE from API 26 (our minSdk) upward, so we do not
+    // widen the app's permission surface for this gate. On any
+    // SecurityException the probe returns CALL_STATE_IDLE (fail-open)
+    // — a locked-out PTT with no explanation is a worse failure than
+    // the auto-hold bug this gate exists to fix.
+    private val cellularCallStateProvider: () -> Int = {
+        try {
+            val tm =
+                context.getSystemService(Context.TELEPHONY_SERVICE)
+                    as? android.telephony.TelephonyManager
+            // Suppress: getCallState() is deprecated in favor of
+            // getCallStateForSubscription() (API 31+), which requires
+            // READ_PHONE_STATE. We deliberately use the plain non-
+            // permission API here — the fidget-during-call bug only
+            // needs the default subscription's aggregate state, and
+            // widening our permission surface for a fidget-guard is
+            // not justified.
+            @Suppress("DEPRECATION")
+            tm?.callState ?: android.telephony.TelephonyManager.CALL_STATE_IDLE
+        } catch (se: SecurityException) {
+            android.util.Log.w(
+                TAG,
+                "cellularCallStateProvider: SecurityException — treating as IDLE",
+                se,
+            )
+            android.telephony.TelephonyManager.CALL_STATE_IDLE
+        } catch (t: Throwable) {
+            android.util.Log.w(
+                TAG,
+                "cellularCallStateProvider: unexpected throw — treating as IDLE",
+                t,
+            )
+            android.telephony.TelephonyManager.CALL_STATE_IDLE
+        }
+    },
+    // Monotonic clock for the cellular-block toast throttle. Injected
+    // for the unit test so its "advance time" step does not require
+    // real elapsed wall-clock. Defaults to SystemClock.elapsedRealtime
+    // — insensitive to wall-clock jumps (NTP sync during a burst),
+    // unlike currentTimeMillis.
+    private val nowMsProvider: () -> Long = { android.os.SystemClock.elapsedRealtime() },
 ) {
     interface Callbacks {
         fun onTxOpus(
@@ -107,6 +152,13 @@ class VoicePlant(
         // plugin so it can Toast the operator instead of leaving them
         // staring at a dead PTT.
         fun onCaptureError(reason: String)
+
+        // PTT press was suppressed because the cellular telephony stack
+        // reports an active or ringing call. Plugin surfaces [reason]
+        // as a Toast so the operator learns why nothing transmitted;
+        // the plant already throttles this event so mashing PTT during
+        // a call does not spam the UI.
+        fun onPttBlockedByCellularCall(reason: String)
     }
 
     private val audioManager =
@@ -617,6 +669,13 @@ class VoicePlant(
     // normal radio operation becomes the answer button during a ring.
     @Volatile private var callRinging: Boolean = false
 
+    // Timestamp (elapsedRealtime ms) of the most recent
+    // "cellular call active — hang up before XV PTT" toast fire.
+    // 0 = never fired. Used by the pttDown cellular-call gate to
+    // throttle the toast so mashing PTT during an active phone call
+    // does not spam the operator's screen. Bump on every fire.
+    @Volatile private var lastCellCallToastAtMs: Long = 0L
+
     /** Used by XvVoiceService to gate external PTT events during the
      *  call lifecycle. The internal mic-engage uses
      *  [pttDownForPrivateCall]; the matching release is split across
@@ -686,6 +745,39 @@ class VoicePlant(
                 callbacks.onCallButtonTapped()
             } catch (t: Throwable) {
                 Log.w(TAG, "callButton dispatch from pttDown threw", t)
+            }
+            return
+        }
+        // Cellular-call gate. XV places a self-managed Telecom call
+        // on every pttDown to claim MODE_IN_COMMUNICATION + audio
+        // focus; Android's Telecom framework auto-holds any active
+        // third-party call whenever a second self-managed call is
+        // placed. Operators fidgeting with a BT speakermic during
+        // an active cellular call have accidentally keyed PTT and
+        // dropped their phone call onto hold mid-conversation. Block
+        // the TX (Option A) instead of preempting the cellular call
+        // for what is almost certainly an unintentional press. See
+        // PttCellularGate for the pure decision function and the
+        // toast throttle. This gate must run BEFORE the Telecom call
+        // placement below — the whole point is to avoid placing that
+        // call while the cellular stack is busy.
+        val cellState = cellularCallStateProvider()
+        val gate = shouldGateForCellularCall(cellState)
+        if (gate != PttGate.ALLOW) {
+            Log.i(TAG, "PTT blocked — cellular call state=$cellState (gate=$gate)")
+            val now = nowMsProvider()
+            if (shouldToastCellularBlock(nowMs = now, lastToastAtMs = lastCellCallToastAtMs)) {
+                lastCellCallToastAtMs = now
+                try {
+                    callbacks.onPttBlockedByCellularCall(CELLULAR_BLOCK_TOAST_MSG)
+                } catch (t: Throwable) {
+                    Log.w(TAG, "onPttBlockedByCellularCall dispatch threw", t)
+                }
+            } else {
+                Log.i(
+                    TAG,
+                    "cellular-block toast throttled (last=${now - lastCellCallToastAtMs}ms ago)",
+                )
             }
             return
         }
@@ -1594,5 +1686,11 @@ class VoicePlant(
 
     companion object {
         private const val TAG = "XvVoicePlant"
+
+        // Operator-facing message for the cellular-call PTT gate. Kept
+        // short and imperative — a Toast has ~2-3 seconds of attention
+        // and needs to say what to do, not just what happened.
+        internal const val CELLULAR_BLOCK_TOAST_MSG =
+            "Cellular call active — hang up before XV PTT"
     }
 }

--- a/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
@@ -915,6 +915,10 @@ class XvVoiceService : Service() {
                 fanOut { it.onCaptureError(reason) }
             }
 
+            override fun onPttBlockedByCellularCall(reason: String) {
+                fanOut { it.onPttBlockedByCellularCall(reason) }
+            }
+
             override fun onPlaceTelecomCall(tag: String) {
                 placeTelecomCallInternal(tag)
             }

--- a/app/src/test/java/com/atakmap/android/xv/service/PttCellularGateTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/service/PttCellularGateTest.kt
@@ -1,0 +1,107 @@
+package com.atakmap.android.xv.service
+
+import android.telephony.TelephonyManager
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Coverage for the pure PTT cellular-call gate helpers extracted from
+ * VoicePlant. These are intentionally free of Android framework state
+ * (no Robolectric, no TelephonyManager instance) — only the integer
+ * call-state code enum and a monotonic timestamp are exercised.
+ */
+class PttCellularGateTest {
+    // ============================================================
+    // shouldGateForCellularCall — decision function
+    // ============================================================
+
+    @Test
+    fun `IDLE call-state permits TX`() {
+        assertEquals(
+            PttGate.ALLOW,
+            shouldGateForCellularCall(TelephonyManager.CALL_STATE_IDLE),
+        )
+    }
+
+    @Test
+    fun `OFFHOOK call-state blocks TX for active cellular call`() {
+        assertEquals(
+            PttGate.BLOCK_CELLULAR_CALL,
+            shouldGateForCellularCall(TelephonyManager.CALL_STATE_OFFHOOK),
+        )
+    }
+
+    @Test
+    fun `RINGING call-state blocks TX for incoming cellular call`() {
+        assertEquals(
+            PttGate.BLOCK_CELLULAR_RINGING,
+            shouldGateForCellularCall(TelephonyManager.CALL_STATE_RINGING),
+        )
+    }
+
+    @Test
+    fun `unknown call-state fails open to ALLOW`() {
+        // Fail-open is deliberate — a silent PTT lockout with no
+        // operator-visible cause is a worse failure mode than the
+        // auto-hold bug this gate exists to fix. See PttCellularGate.
+        assertEquals(PttGate.ALLOW, shouldGateForCellularCall(-1))
+        assertEquals(PttGate.ALLOW, shouldGateForCellularCall(Int.MAX_VALUE))
+    }
+
+    // ============================================================
+    // shouldToastCellularBlock — throttle helper
+    // ============================================================
+
+    @Test
+    fun `first-ever toast always fires (sentinel zero)`() {
+        assertTrue(
+            "lastToastAtMs=0 sentinel must always allow toast",
+            shouldToastCellularBlock(nowMs = 1_000L, lastToastAtMs = 0L),
+        )
+    }
+
+    @Test
+    fun `toast fires when throttle window has elapsed`() {
+        // Default throttle is 3000 ms. Exactly at the window boundary
+        // qualifies (>=).
+        assertTrue(
+            shouldToastCellularBlock(nowMs = 5_000L, lastToastAtMs = 2_000L),
+        )
+        assertTrue(
+            shouldToastCellularBlock(nowMs = 10_000L, lastToastAtMs = 2_000L),
+        )
+    }
+
+    @Test
+    fun `toast is throttled when window has not elapsed`() {
+        // Rapid PTT mashing during a call would otherwise stack toasts;
+        // sub-3000ms gaps must be suppressed.
+        assertFalse(
+            shouldToastCellularBlock(nowMs = 4_000L, lastToastAtMs = 2_000L),
+        )
+        assertFalse(
+            shouldToastCellularBlock(nowMs = 2_100L, lastToastAtMs = 2_000L),
+        )
+    }
+
+    @Test
+    fun `throttle window is configurable via throttleMs override`() {
+        // A 1000 ms override should suppress a 400 ms gap and allow a
+        // 1000 ms gap even though both would be blocked by the default
+        // 3000 ms window. Sanity-check so a future caller can dial the
+        // window without touching the default.
+        assertFalse(
+            shouldToastCellularBlock(nowMs = 500L, lastToastAtMs = 100L, throttleMs = 1_000L),
+        )
+        assertTrue(
+            shouldToastCellularBlock(nowMs = 1_100L, lastToastAtMs = 100L, throttleMs = 1_000L),
+        )
+    }
+
+    @Test
+    fun `throttle constant is 3 seconds`() {
+        assertEquals(3_000L, CELLULAR_BLOCK_TOAST_THROTTLE_MS)
+    }
+}

--- a/app/src/test/java/com/atakmap/android/xv/service/PttCellularGateTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/service/PttCellularGateTest.kt
@@ -1,5 +1,6 @@
 package com.atakmap.android.xv.service
 
+import android.media.AudioManager
 import android.telephony.TelephonyManager
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -103,5 +104,104 @@ class PttCellularGateTest {
     @Test
     fun `throttle constant is 3 seconds`() {
         assertEquals(3_000L, CELLULAR_BLOCK_TOAST_THROTTLE_MS)
+    }
+
+    // ============================================================
+    // cellularCallStateFromAudioMode — permission-free state source
+    // ============================================================
+
+    @Test
+    fun `MODE_IN_CALL maps to CALL_STATE_OFFHOOK`() {
+        // AudioManager.MODE_IN_CALL is set by the telephony framework
+        // whenever a cellular call is in the OFFHOOK (connected) state.
+        // This is the primary "block PTT" trigger — we do not want XV
+        // to place its self-managed Telecom call and auto-hold the
+        // active cellular call.
+        assertEquals(
+            TelephonyManager.CALL_STATE_OFFHOOK,
+            cellularCallStateFromAudioMode(AudioManager.MODE_IN_CALL),
+        )
+    }
+
+    @Test
+    fun `MODE_RINGTONE maps to CALL_STATE_RINGING`() {
+        assertEquals(
+            TelephonyManager.CALL_STATE_RINGING,
+            cellularCallStateFromAudioMode(AudioManager.MODE_RINGTONE),
+        )
+    }
+
+    @Test
+    fun `MODE_NORMAL maps to CALL_STATE_IDLE`() {
+        assertEquals(
+            TelephonyManager.CALL_STATE_IDLE,
+            cellularCallStateFromAudioMode(AudioManager.MODE_NORMAL),
+        )
+    }
+
+    @Test
+    fun `MODE_IN_COMMUNICATION maps to CALL_STATE_IDLE (not our own gate)`() {
+        // XV's self-managed Telecom call sets MODE_IN_COMMUNICATION on
+        // every TX (see AudioControllerImpl.enterTx). If we mapped that
+        // to OFFHOOK the gate would fire on our OWN follow-up presses
+        // during a burst — a permanent PTT lockout. Explicitly assert
+        // the invariant "MODE_IN_CALL = cell, MODE_IN_COMMUNICATION =
+        // us, skip".
+        assertEquals(
+            TelephonyManager.CALL_STATE_IDLE,
+            cellularCallStateFromAudioMode(AudioManager.MODE_IN_COMMUNICATION),
+        )
+    }
+
+    @Test
+    fun `unknown audio-mode fails open to CALL_STATE_IDLE`() {
+        // Same fail-open rationale as shouldGateForCellularCall — a
+        // silent PTT lockout with no visible cause is worse than the
+        // auto-hold bug this gate exists to fix. Any future audio-mode
+        // constant we do not recognize (or a spurious MODE_INVALID)
+        // must not gate PTT.
+        assertEquals(
+            TelephonyManager.CALL_STATE_IDLE,
+            cellularCallStateFromAudioMode(AudioManager.MODE_INVALID),
+        )
+        assertEquals(
+            TelephonyManager.CALL_STATE_IDLE,
+            cellularCallStateFromAudioMode(Int.MAX_VALUE),
+        )
+    }
+
+    @Test
+    fun `AudioManager mode round-trips through the full gate for cell OFFHOOK`() {
+        // End-to-end sanity: getMode() returns MODE_IN_CALL during an
+        // active cellular call → provider adapter maps to
+        // CALL_STATE_OFFHOOK → gate returns BLOCK_CELLULAR_CALL.
+        assertEquals(
+            PttGate.BLOCK_CELLULAR_CALL,
+            shouldGateForCellularCall(
+                cellularCallStateFromAudioMode(AudioManager.MODE_IN_CALL),
+            ),
+        )
+    }
+
+    @Test
+    fun `AudioManager mode round-trips through the full gate for ringing`() {
+        assertEquals(
+            PttGate.BLOCK_CELLULAR_RINGING,
+            shouldGateForCellularCall(
+                cellularCallStateFromAudioMode(AudioManager.MODE_RINGTONE),
+            ),
+        )
+    }
+
+    @Test
+    fun `AudioManager MODE_IN_COMMUNICATION does not gate ourselves`() {
+        // Full-pipeline complement to the mapping test: XV's own
+        // Telecom call must never cause the gate to fire.
+        assertEquals(
+            PttGate.ALLOW,
+            shouldGateForCellularCall(
+                cellularCallStateFromAudioMode(AudioManager.MODE_IN_COMMUNICATION),
+            ),
+        )
     }
 }

--- a/app/src/test/java/com/atakmap/android/xv/service/PttCellularGateTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/service/PttCellularGateTest.kt
@@ -2,6 +2,7 @@ package com.atakmap.android.xv.service
 
 import android.media.AudioManager
 import android.telephony.TelephonyManager
+import com.atakmap.android.xv.audio.PttSource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -16,39 +17,167 @@ import org.junit.Test
 class PttCellularGateTest {
     // ============================================================
     // shouldGateForCellularCall — decision function
+    //
+    // Source-scoped policy (2026-07-10 revision): the gate ONLY
+    // applies to PttSource.ON_SCREEN. Every other source — every
+    // hardware button (AINA V1/V2, Pryme MFB, and any future
+    // BT-HID / gpio input) and the DEBUG intent path — bypasses
+    // the gate and returns ALLOW even during OFFHOOK / RINGING.
+    // The screen-tap path stays blocked because a stray finger
+    // during a phone call should not auto-hold the call.
     // ============================================================
 
     @Test
-    fun `IDLE call-state permits TX`() {
+    fun `IDLE call-state permits TX for on-screen source`() {
         assertEquals(
             PttGate.ALLOW,
-            shouldGateForCellularCall(TelephonyManager.CALL_STATE_IDLE),
+            shouldGateForCellularCall(TelephonyManager.CALL_STATE_IDLE, PttSource.ON_SCREEN),
         )
     }
 
     @Test
-    fun `OFFHOOK call-state blocks TX for active cellular call`() {
+    fun `OFFHOOK call-state blocks TX for on-screen source`() {
+        // On-screen taps are the accident-prone path — a wayward
+        // finger during a cellular call should not silently
+        // auto-hold that call via XV's self-managed Telecom call.
         assertEquals(
             PttGate.BLOCK_CELLULAR_CALL,
-            shouldGateForCellularCall(TelephonyManager.CALL_STATE_OFFHOOK),
+            shouldGateForCellularCall(TelephonyManager.CALL_STATE_OFFHOOK, PttSource.ON_SCREEN),
         )
     }
 
     @Test
-    fun `RINGING call-state blocks TX for incoming cellular call`() {
+    fun `RINGING call-state blocks TX for on-screen source`() {
         assertEquals(
             PttGate.BLOCK_CELLULAR_RINGING,
-            shouldGateForCellularCall(TelephonyManager.CALL_STATE_RINGING),
+            shouldGateForCellularCall(TelephonyManager.CALL_STATE_RINGING, PttSource.ON_SCREEN),
         )
     }
 
     @Test
-    fun `unknown call-state fails open to ALLOW`() {
+    fun `unknown call-state fails open to ALLOW for on-screen source`() {
         // Fail-open is deliberate — a silent PTT lockout with no
         // operator-visible cause is a worse failure mode than the
         // auto-hold bug this gate exists to fix. See PttCellularGate.
-        assertEquals(PttGate.ALLOW, shouldGateForCellularCall(-1))
-        assertEquals(PttGate.ALLOW, shouldGateForCellularCall(Int.MAX_VALUE))
+        assertEquals(PttGate.ALLOW, shouldGateForCellularCall(-1, PttSource.ON_SCREEN))
+        assertEquals(PttGate.ALLOW, shouldGateForCellularCall(Int.MAX_VALUE, PttSource.ON_SCREEN))
+    }
+
+    // --- Hardware sources bypass the gate entirely ---------------
+
+    @Test
+    fun `AINA V1 hardware bypasses gate during OFFHOOK`() {
+        // Hardware button presses represent deliberate operator
+        // intent. Tactical scenarios may require an operator to
+        // key up mid-call; blocking a hardware press would
+        // surprise-block a deliberate transmission attempt.
+        assertEquals(
+            PttGate.ALLOW,
+            shouldGateForCellularCall(TelephonyManager.CALL_STATE_OFFHOOK, PttSource.AINA_V1),
+        )
+    }
+
+    @Test
+    fun `AINA V1 hardware bypasses gate during RINGING`() {
+        assertEquals(
+            PttGate.ALLOW,
+            shouldGateForCellularCall(TelephonyManager.CALL_STATE_RINGING, PttSource.AINA_V1),
+        )
+    }
+
+    @Test
+    fun `AINA V2 hardware bypasses gate during OFFHOOK`() {
+        assertEquals(
+            PttGate.ALLOW,
+            shouldGateForCellularCall(TelephonyManager.CALL_STATE_OFFHOOK, PttSource.AINA_V2),
+        )
+    }
+
+    @Test
+    fun `AINA V2 hardware bypasses gate during RINGING`() {
+        assertEquals(
+            PttGate.ALLOW,
+            shouldGateForCellularCall(TelephonyManager.CALL_STATE_RINGING, PttSource.AINA_V2),
+        )
+    }
+
+    @Test
+    fun `Pryme BLE hardware bypasses gate during OFFHOOK`() {
+        assertEquals(
+            PttGate.ALLOW,
+            shouldGateForCellularCall(TelephonyManager.CALL_STATE_OFFHOOK, PttSource.PRYME_BLE),
+        )
+    }
+
+    @Test
+    fun `Pryme BLE hardware bypasses gate during RINGING`() {
+        assertEquals(
+            PttGate.ALLOW,
+            shouldGateForCellularCall(TelephonyManager.CALL_STATE_RINGING, PttSource.PRYME_BLE),
+        )
+    }
+
+    @Test
+    fun `DEBUG source bypasses gate during OFFHOOK`() {
+        // DEBUG originates from adb / dev tooling, not from a
+        // stray touch. Keep the debug path usable during a call.
+        assertEquals(
+            PttGate.ALLOW,
+            shouldGateForCellularCall(TelephonyManager.CALL_STATE_OFFHOOK, PttSource.DEBUG),
+        )
+    }
+
+    @Test
+    fun `DEBUG source bypasses gate during RINGING`() {
+        assertEquals(
+            PttGate.ALLOW,
+            shouldGateForCellularCall(TelephonyManager.CALL_STATE_RINGING, PttSource.DEBUG),
+        )
+    }
+
+    @Test
+    fun `IDLE call-state permits TX for every source`() {
+        // Belt-and-suspenders sanity: IDLE must always return ALLOW
+        // regardless of source. If a future PttSource ever slipped
+        // into a code path that read IDLE-as-blocked, the
+        // fidget-guard would flip from "silent success" to "silent
+        // lockout" — the exact failure mode the fail-open policy
+        // exists to prevent.
+        for (src in PttSource.values()) {
+            assertEquals(
+                "IDLE + $src must ALLOW",
+                PttGate.ALLOW,
+                shouldGateForCellularCall(TelephonyManager.CALL_STATE_IDLE, src),
+            )
+        }
+    }
+
+    @Test
+    fun `every non-screen source bypasses gate during OFFHOOK`() {
+        // Data-driven complement to the enum-by-enum tests above.
+        // Any hardware source added in the future automatically
+        // gets the ALLOW-during-call treatment; the only source
+        // that stays blocked is ON_SCREEN.
+        for (src in PttSource.values()) {
+            if (src == PttSource.ON_SCREEN) continue
+            assertEquals(
+                "$src must bypass OFFHOOK gate",
+                PttGate.ALLOW,
+                shouldGateForCellularCall(TelephonyManager.CALL_STATE_OFFHOOK, src),
+            )
+        }
+    }
+
+    @Test
+    fun `every non-screen source bypasses gate during RINGING`() {
+        for (src in PttSource.values()) {
+            if (src == PttSource.ON_SCREEN) continue
+            assertEquals(
+                "$src must bypass RINGING gate",
+                PttGate.ALLOW,
+                shouldGateForCellularCall(TelephonyManager.CALL_STATE_RINGING, src),
+            )
+        }
     }
 
     // ============================================================
@@ -171,36 +300,58 @@ class PttCellularGateTest {
     }
 
     @Test
-    fun `AudioManager mode round-trips through the full gate for cell OFFHOOK`() {
+    fun `AudioManager mode round-trips through the full gate for cell OFFHOOK on-screen`() {
         // End-to-end sanity: getMode() returns MODE_IN_CALL during an
         // active cellular call → provider adapter maps to
-        // CALL_STATE_OFFHOOK → gate returns BLOCK_CELLULAR_CALL.
+        // CALL_STATE_OFFHOOK → gate returns BLOCK_CELLULAR_CALL for
+        // an on-screen tap.
         assertEquals(
             PttGate.BLOCK_CELLULAR_CALL,
             shouldGateForCellularCall(
                 cellularCallStateFromAudioMode(AudioManager.MODE_IN_CALL),
+                PttSource.ON_SCREEN,
             ),
         )
     }
 
     @Test
-    fun `AudioManager mode round-trips through the full gate for ringing`() {
+    fun `AudioManager mode round-trips through the full gate for ringing on-screen`() {
         assertEquals(
             PttGate.BLOCK_CELLULAR_RINGING,
             shouldGateForCellularCall(
                 cellularCallStateFromAudioMode(AudioManager.MODE_RINGTONE),
+                PttSource.ON_SCREEN,
             ),
         )
     }
 
     @Test
-    fun `AudioManager MODE_IN_COMMUNICATION does not gate ourselves`() {
+    fun `AudioManager MODE_IN_COMMUNICATION does not gate ourselves on-screen`() {
         // Full-pipeline complement to the mapping test: XV's own
-        // Telecom call must never cause the gate to fire.
+        // Telecom call must never cause the gate to fire even on
+        // the on-screen path.
         assertEquals(
             PttGate.ALLOW,
             shouldGateForCellularCall(
                 cellularCallStateFromAudioMode(AudioManager.MODE_IN_COMMUNICATION),
+                PttSource.ON_SCREEN,
+            ),
+        )
+    }
+
+    @Test
+    fun `AudioManager MODE_IN_CALL does not gate an AINA hardware press`() {
+        // Full-pipeline complement of the source-scope policy: even
+        // when the cellular stack has claimed MODE_IN_CALL, a
+        // hardware button press is deliberate operator intent and
+        // must transmit. XV's Telecom call will still auto-hold the
+        // cellular call as a side effect — but that side effect is
+        // now the operator's choice, not an accident.
+        assertEquals(
+            PttGate.ALLOW,
+            shouldGateForCellularCall(
+                cellularCallStateFromAudioMode(AudioManager.MODE_IN_CALL),
+                PttSource.AINA_V2,
             ),
         )
     }


### PR DESCRIPTION
## Source-scoped gate (added 2026-07-10)

**Second policy revision on top of the AudioManager fix.** The
original Option A blocked ALL PTT edges during OFFHOOK / RINGING.
Operator feedback (2026-07-10 23:00) narrowed the policy: the gate
now applies **only to `PttSource.ON_SCREEN`** — the on-screen PTT
button. Every hardware source (AINA V1, AINA V2, Pryme MFB, and any
future BT-HID / gpio hardware input) bypasses the gate entirely.
The debug-intent path is also treated as bypass (adb-driven, never
a stray touch).

**Rationale.** On-screen PTT taps are the accident-prone path — a
wayward finger on the map / dropdown card during a phone call is
exactly the "operator fidgets and drops the call" bug this PR
started as. Hardware button presses represent deliberate operator
intent: a physical PTT button on a speakermic or handlebar mount
takes a conscious press to actuate. Tactical scenarios routinely
require an operator to key up mid-call (call-of-record on the
phone, but the incident lives on XV). Blocking a hardware press
would surprise-block a deliberate transmission attempt — a worse
failure than the auto-hold it would prevent.

Both categories still cause the same underlying Telecom-call-hold
side effect when a hardware press proceeds during a call. But the
side effect is now the operator intentional action rather than an
accidental one; the toast is reserved for the accident-prone input.

**Change surface (commit `8980692`):**

- `PttCellularGate.shouldGateForCellularCall` now takes a
  `PttSource` parameter. Non-screen sources short-circuit to
  `ALLOW` before the call-state switch. On-screen sources retain
  the original OFFHOOK → `BLOCK_CELLULAR_CALL`, RINGING →
  `BLOCK_CELLULAR_RINGING`, everything else → `ALLOW` mapping.
- `VoicePlant.pttDown` threads its existing `source: PttSource`
  parameter into the gate call — no new plumbing on any caller.
- Non-screen presses during OFFHOOK / RINGING now emit an INFO
  logcat line (`cellular call active but source=$source is
  hardware — allowing PTT`) so a post-mortem reader can explain
  the absence of a toast without guessing. Not a warning — this
  is expected behavior.
- Toast wording unchanged (`Cellular call active — hang up before
  XV PTT`); it just fires for the on-screen path only now.

**Tests (updated `PttCellularGateTest`):**

- Existing OFFHOOK / RINGING on-screen assertions kept — same enum
  values, no weakening of the accident-prone path.
- New per-source assertions: AINA_V1, AINA_V2, PRYME_BLE, DEBUG,
  each in OFFHOOK and RINGING, all must return `ALLOW`.
- Two data-driven loops over `PttSource.values()` skip ON_SCREEN
  and assert every other source bypasses OFFHOOK + RINGING.
  Guarantees any hardware source added later automatically
  inherits the ALLOW-during-call treatment.
- New `MODE_IN_CALL` + `AINA_V2` full-pipeline round-trip case.
- IDLE + any source loop (belt-and-suspenders): the fail-open
  path must not regress into a silent lockout on the happy path.

The AudioManager-vs-TelephonyManager fix from `fd1efb6` is retained
unchanged; the source-scoped gate builds on top of the
permission-free state source.

**Explicitly still out of scope:**

- No `AndroidManifest` permission changes.
- No changes to the Telecom self-managed-call policy (that is the
  separate `a2dp-resume-between-tx` backlog).
- No new UI. No per-source toggle. The policy is invariant.

**On-device confirmation (adds to the existing plan):**

- [ ] Cellular call active → tap on-screen PTT: expect same toast +
  no TX as before.
- [ ] Same call active → press paired AINA V2 hardware PTT: expect
  TX proceeds, cellular call auto-held by Telecom, INFO logcat
  line names `source=AINA_V2`, no toast.
- [ ] Release hardware button, hang up cell call, verify subsequent
  on-screen PTT works normally (happy path unregressed).

---

## 2026-07-10 correction — AudioManager, not TelephonyManager (fd1efb6)

**Original assumption was wrong from API 31 onward.** This PR was
initially wired to `TelephonyManager.getCallState()` under the theory
that the plain non-permission API works from API 26 up. On-device
evidence from a Pixel API 35 build proved otherwise — every PTT-down
threw `SecurityException` ("Neither user nor current process has
`android.permission.READ_PHONE_STATE`"). The existing catch-and-
treat-as-IDLE clause kept the audio path working (fail-open) but
logged a full stack trace and paid an allocation cost on every press,
and the gate never actually saw OFFHOOK on API 31+ so it bought zero
protection.

**Fix commit `fd1efb6` — swap to `AudioManager.getMode()`.** No
permission required at any API level. The audio framework already
sets `MODE_IN_CALL` while a cellular call is OFFHOOK and
`MODE_RINGTONE` while one is ringing, which is exactly what this
gate needs. Concretely:

- New pure helper `cellularCallStateFromAudioMode(audioMode: Int): Int`
  in `PttCellularGate.kt` maps `AudioManager.MODE_*` →
  `TelephonyManager.CALL_STATE_*`.
- `VoicePlant.cellularCallStateProvider` default is now a thin
  adapter: `getSystemService(AUDIO_SERVICE) → getMode() →
  cellularCallStateFromAudioMode → shouldGateForCellularCall`.
- Removed the `SecurityException` catch (no longer reachable —
  `getMode()` is not documented to throw). Retained a defensive
  `Throwable` catch returning IDLE as belt-and-suspenders.
- **Invariant asserted in tests:** `MODE_IN_CALL` = cellular (block),
  `MODE_IN_COMMUNICATION` = XV OWN self-managed Telecom call (must
  NOT block, otherwise we would gate ourselves out of every burst).

**Permission surface unchanged.** No `READ_PHONE_STATE`, no
manifest edits. Consistent with the 2026-07-13 production-run
freeze on new operator-granted permissions.

**Tests:** `PttCellularGateTest` gains eight cases covering
`cellularCallStateFromAudioMode` (`MODE_IN_CALL` → OFFHOOK,
`MODE_RINGTONE` → RINGING, `MODE_NORMAL` / `MODE_INVALID` → IDLE,
`MODE_IN_COMMUNICATION` → IDLE, unknown value fail-open) and its
end-to-end round-trip through `shouldGateForCellularCall`.

**Build triple after fix:**

- [x] `./gradlew ktlintCheck` — green
- [x] `./gradlew assembleCivDebug` — green
- [x] `./gradlew testCivDebugUnitTest` — green

---

## Reproducer

Operator was in an active cellular phone call and fidgeted with a
BT speakermic hooked to the phone. The AINA PTT button was pressed
accidentally. Inside a second, the cellular call went onto hold — no
UI cue from XV, just silence until they realized their partner was
gone.

## Root cause

XV places its own self-managed Telecom call on every PTT-down to
claim `MODE_IN_COMMUNICATION` + audio focus (so background media apps
yield the SCO chipset for the burst). Android Telecom framework
auto-holds any active third-party call whenever a second
self-managed call is placed — that is the OS-mandated behavior for
Connection.PROPERTY_SELF_MANAGED. From Telecom point of view, XV
`voice` connection was placed, so the cellular call has to yield.

The Telecom-call policy is intentional in the non-cellular case
(memory `feedback_audio_plant_modes.md` — unconditional on every TX,
per-op decision). The bug is that XV also placed the call during an
active OS cellular call and thus preempted it for what was almost
certainly an accidental button press.

## Fix (Option A — original scope, now source-scoped, see top)

Gate `VoicePlant.pttDown` on the cellular telephony call state and
block the TX entirely when a cellular call is OFFHOOK or RINGING —
show a `LENGTH_LONG` Toast telling the operator to hang up first,
and do not fire the Telecom call or the dispatcher. This is the
option the operator chose over any preempt / mute-media alternatives.

**Source-scoped update (2026-07-10):** the gate now runs only for
`PttSource.ON_SCREEN`. See the top section of this PR body for the
policy revision and rationale.

Design notes:

- **One choke point covers every PTT source.** `VoicePlant.pttDown`
  is the single entry every dispatcher fan-in flows through
  (on-screen card, AINA V1 SPP, AINA V2 BLE, generic BLE HID).
  Gating there means we do not have to sprinkle the check across
  each input-driver file.
- **Gate placement.** Runs AFTER the existing `callRinging` and
  `privateCallActive` short-circuits (so XV own VoIP semantics are
  unchanged) but BEFORE `onPlaceTelecomCall` — the whole point is to
  avoid placing that self-managed call while the cellular stack is
  busy.
- **State source (corrected — see fd1efb6 section).**
  `AudioManager.getMode()`, mapped to `TelephonyManager.CALL_STATE_*`
  via the pure helper `cellularCallStateFromAudioMode`. No
  permission required at any API level; XV own audio-plant code
  already reads `audioManager.mode` extensively
  (`AudioControllerImpl`, `ScoLink`, `TptPlayer`).
- **Fail-open.** Any unexpected throw returns `CALL_STATE_IDLE` so
  the gate does not lock out PTT when the audio-mode probe cannot
  read state. A silent, unexplained PTT lockout is a worse failure
  mode than the auto-hold bug this fixes.
- **Toast throttle.** Rapid button mashing during a call would stack
  a wall of identical toasts. `shouldToastCellularBlock` gates on a
  3-second window via `SystemClock.elapsedRealtime()` (immune to
  wall-clock NTP jumps mid-burst).
- **Pure decision function.** `PttCellularGate.kt` isolates
  `shouldGateForCellularCall(callState, source): PttGate`,
  `cellularCallStateFromAudioMode(audioMode: Int): Int`, and the
  throttle helper so all three are exercised by plain JUnit — no
  Robolectric needed for the coverage.
- **Toast surface.** New `IXvVoiceListener.onPttBlockedByCellularCall`
  AIDL event; plugin renders it via `MapView.post { Toast.makeText... }`,
  mirroring the existing `onCaptureError` pattern so the service side
  never has to hold a UI Context.

## Explicitly out of scope

- Telecom self-managed-call policy for the cellular-IDLE case is
  unchanged (per memory `feedback_audio_plant_modes.md`).
- No Settings toggle to disable the guard — operator chose Option A
  globally, then narrowed to on-screen-only.
- No changes to Mumble transport, AINA reader lifecycle, or audio
  routing.
- No `versionCode` / `versionName` bump.
- No new `AndroidManifest` permissions.

## Test plan

Build triple:

- [x] `./gradlew ktlintCheck` — green
- [x] `./gradlew assembleCivDebug` — green
- [x] `./gradlew testCivDebugUnitTest` — green (`PttCellularGateTest`
  now covers per-source ALLOW for every hardware source in
  OFFHOOK / RINGING plus the on-screen block, throttle, and
  audio-mode round-trips)

On-device (bring a spare phone, single SIM):

- [ ] Place a cellular call to a second device, keep the call active.
- [ ] From XV on-screen card, tap PTT: expect the Toast
  `Cellular call active — hang up before XV PTT`, no TPT, no SCO
  acquire, and the cellular call still connected (not held).
- [ ] Mash on-screen PTT rapidly ~6 presses in 2 seconds during the
  call: only one Toast is visible; logcat shows
  `cellular-block toast throttled` for the suppressed fires.
  **Confirm no `SecurityException` stack trace appears** (regression
  check for the API-31+ correction).
- [ ] Hang up the cellular call, then PTT: TX proceeds normally
  (TPT, SCO, mic pinned to the speakermic).
- [ ] Ring the phone from another line without answering; while
  ringing, press on-screen PTT: Toast fires, no TX, ringtone continues.
- [ ] **Hardware bypass (added 2026-07-10):** cellular call active
  → press paired AINA V2 hardware PTT: expect TX proceeds, cellular
  call auto-held by Telecom, INFO logcat line
  `cellular call active but source=AINA_V2 is hardware — allowing PTT`,
  and no toast. Release, hang up cell call, verify subsequent
  on-screen PTT is unregressed.
