### PR TITLE
fix(bt): suppress redundant STATE_DISCONNECTED callback during intentional reader teardown

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/aina/BitmaskGattPttReader.kt
+++ b/app/src/main/java/com/atakmap/android/xv/aina/BitmaskGattPttReader.kt
@@ -90,6 +90,18 @@ open class BitmaskGattPttReader(
     @Volatile
     private var intentionalDisconnect: Boolean = false
 
+    // Sticky "reader is being torn down for good" flag. Set by
+    // [dispose] before the owner (VoicePlant) drops its reference.
+    // Guards against late callbacks from the OS's binder queue — the
+    // stale GATT callback closure can still be live for a few ms
+    // after we've closed the gatt handle, and if VoicePlant has
+    // already swapped in a fresh reader those late events would fire
+    // into the plugin with a stale [PttSource] identity. Any
+    // callback dispatch path (connection state, button events) short-
+    // circuits when this is true.
+    @Volatile
+    private var disposed: Boolean = false
+
     private var directRetryCount: Int = 0
     private var autoConnectArmed: Boolean = false
 
@@ -110,6 +122,10 @@ open class BitmaskGattPttReader(
         }
 
     fun connect(device: BluetoothDevice) {
+        if (disposed) {
+            Log.w(config.tag, "connect() called on disposed reader — ignoring")
+            return
+        }
         disconnect()
         intentionalDisconnect = false
         targetDevice = device
@@ -136,7 +152,43 @@ open class BitmaskGattPttReader(
         targetDevice = null
         handler.removeCallbacks(retryRunnable)
         closeGatt()
-        onConnectionState(false)
+        dispatchConnectionState(false)
+    }
+
+    /**
+     * Permanent teardown. Marks the reader disposed so any late
+     * callback still queued behind the OS's binder short-circuits
+     * before it can fire back into the plugin with a stale identity.
+     * Callers (VoicePlant on external-button swap / plugin shutdown)
+     * should invoke this BEFORE nulling out their reference — after
+     * dispose, [connect] is a no-op and every callback dispatch path
+     * is muted. Idempotent.
+     */
+    fun dispose() {
+        disposed = true
+        disconnect()
+    }
+
+    /**
+     * Single choke point for connection-state fan-out so [disposed]
+     * gates every path — direct call from [disconnect] as well as
+     * the GATT-callback path.
+     */
+    private fun dispatchConnectionState(up: Boolean) {
+        if (disposed) return
+        onConnectionState(up)
+    }
+
+    /**
+     * Single choke point for button-event fan-out so [disposed]
+     * gates late notifications too.
+     */
+    private fun dispatchEvent(
+        button: AinaButton,
+        isDown: Boolean,
+    ) {
+        if (disposed) return
+        onEvent(button, isDown)
     }
 
     private fun closeGatt() {
@@ -189,15 +241,35 @@ open class BitmaskGattPttReader(
                         Log.i(config.tag, "Connected (status=$status), discovering services")
                         directRetryCount = 0
                         autoConnectArmed = false
-                        onConnectionState(true)
+                        dispatchConnectionState(true)
                         g.discoverServices()
                     }
                     BluetoothProfile.STATE_DISCONNECTED -> {
                         Log.i(config.tag, "Disconnected (status=$status)")
                         lastHeld = emptySet()
-                        onConnectionState(false)
-                        if (!intentionalDisconnect) {
-                            scheduleReconnect("status=$status")
+                        // Two paths can land here in the same
+                        // millisecond during a controlled teardown:
+                        //   1. [disconnect] already fired the false
+                        //      callback synchronously.
+                        //   2. The OS then delivers its async
+                        //      STATE_DISCONNECTED echo via this
+                        //      callback.
+                        // Gate on [intentionalDisconnect] so the
+                        // async echo is a no-op — it would otherwise
+                        // fire a duplicate `up=false` into VoicePlant
+                        // and log-spam the field capture (see the
+                        // 2026-07-10 Pryme reconnect trace).
+                        // Real disconnects (link drop, power-off,
+                        // out-of-range) still fall through to both
+                        // the callback AND scheduleReconnect.
+                        when (classifyDisconnect(intentionalDisconnect, disposed)) {
+                            DisconnectAction.NOTIFY_AND_RECONNECT -> {
+                                dispatchConnectionState(false)
+                                scheduleReconnect("status=$status")
+                            }
+                            DisconnectAction.SUPPRESS_INTENTIONAL,
+                            DisconnectAction.SUPPRESS_DISPOSED,
+                            -> Unit
                         }
                     }
                 }
@@ -299,8 +371,8 @@ open class BitmaskGattPttReader(
                 val prev = lastHeld
                 val edges = diffEdges(prev, nowHeld) ?: return
                 lastHeld = nowHeld
-                for (btn in edges.down) onEvent(btn, true)
-                for (btn in edges.up) onEvent(btn, false)
+                for (btn in edges.down) dispatchEvent(btn, true)
+                for (btn in edges.up) dispatchEvent(btn, false)
             }
         }
 
@@ -330,6 +402,24 @@ open class BitmaskGattPttReader(
         val up: List<AinaButton>,
     )
 
+    /**
+     * What to do when the OS delivers `STATE_DISCONNECTED`.
+     *
+     * Split out from [onConnectionStateChange] as a pure decision
+     * function so unit tests can pin the state table without an
+     * Android GATT stack.
+     */
+    enum class DisconnectAction {
+        /** Real link drop — fire the callback and schedule reconnect. */
+        NOTIFY_AND_RECONNECT,
+
+        /** Controlled teardown — [disconnect] already fired the callback synchronously; the OS's async echo is redundant. */
+        SUPPRESS_INTENTIONAL,
+
+        /** Reader has been [dispose]d — the owner has moved on, do not fire back. */
+        SUPPRESS_DISPOSED,
+    }
+
     companion object {
         private const val MAX_DIRECT_RETRIES = 4
         private const val INITIAL_RETRY_DELAY_MS = 2_000L
@@ -347,5 +437,20 @@ open class BitmaskGattPttReader(
             val up = prev.filter { it !in now }
             return Edges(down = down, up = up)
         }
+
+        /**
+         * Decision table for `STATE_DISCONNECTED` handling.
+         * `disposed` beats `intentional` — a disposed reader should
+         * never fire back into the plugin under any circumstances.
+         */
+        fun classifyDisconnect(
+            intentional: Boolean,
+            disposed: Boolean,
+        ): DisconnectAction =
+            when {
+                disposed -> DisconnectAction.SUPPRESS_DISPOSED
+                intentional -> DisconnectAction.SUPPRESS_INTENTIONAL
+                else -> DisconnectAction.NOTIFY_AND_RECONNECT
+            }
     }
 }

--- a/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
@@ -1333,7 +1333,15 @@ class VoicePlant(
         ainaSecondaryBle = null
         ainaSecondarySpp?.disconnect()
         ainaSecondarySpp = null
-        prymeSecondaryBle?.disconnect()
+        // dispose() (not just disconnect()) so any late GATT callback
+        // still queued behind the OS's binder cannot fire back into
+        // VoicePlant after we swap in a fresh reader — otherwise a
+        // stale up=false from the OLD PrymeBleReader can echo through
+        // and log-spam / confuse mid-TX state. See fix/reader-
+        // duplicate-disconnect-suppression: dispose() sets a sticky
+        // flag on BitmaskGattPttReader that short-circuits both the
+        // connection-state and button-event dispatch paths.
+        prymeSecondaryBle?.dispose()
         prymeSecondaryBle = null
         // Clear any held-source bookkeeping the secondary left behind
         // mid-burst — otherwise the OR-gate would think a press is
@@ -1357,7 +1365,9 @@ class VoicePlant(
         ainaBle = null
         ainaSpp?.disconnect()
         ainaSpp = null
-        prymeBle?.disconnect()
+        // dispose() rather than disconnect() — see the analogous
+        // block in [disconnectAinaSecondary] for the rationale.
+        prymeBle?.dispose()
         prymeBle = null
         // Drop the BT routing hint — no AINA selected means no implicit
         // BT preference. Operator's explicit override (if any) still wins.

--- a/app/src/test/java/com/atakmap/android/xv/aina/BitmaskGattPttReaderTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/aina/BitmaskGattPttReaderTest.kt
@@ -7,9 +7,12 @@ import org.junit.Test
 
 /**
  * Coverage for [BitmaskGattPttReader.diffEdges] (the base's edge-
- * triggered press/release derivation) and [PrymeBleReader]'s mask
- * decoder. Exercised as pure functions so no Android context / GATT
- * stack is needed.
+ * triggered press/release derivation), [PrymeBleReader]'s mask
+ * decoder, and [BitmaskGattPttReader.classifyDisconnect] (the pure
+ * decision function that decides whether an incoming
+ * `STATE_DISCONNECTED` callback should propagate or be suppressed).
+ * Exercised as pure functions so no Android context / GATT stack is
+ * needed.
  */
 class BitmaskGattPttReaderTest {
     // ============================================================
@@ -88,5 +91,67 @@ class BitmaskGattPttReaderTest {
                 PrymeBleReader.decodePrymeMask(m),
             )
         }
+    }
+
+    // ============================================================
+    // classifyDisconnect — decision table for STATE_DISCONNECTED
+    // ============================================================
+    //
+    // Field bug 2026-07-10: Pryme BT-PTT reconnect emitted two
+    // `up=false` callbacks in the same millisecond — one from the
+    // synchronous [disconnect] path, one from the OS's async
+    // STATE_DISCONNECTED echo. classifyDisconnect encodes the
+    // suppression policy that dedupes them.
+
+    @Test
+    fun `classifyDisconnect suppresses when reader is disposed`() {
+        // disposed beats every other reason — the owner has moved on
+        // and the reader must never fire back into stale state, even
+        // if this is technically a real link drop.
+        assertEquals(
+            BitmaskGattPttReader.DisconnectAction.SUPPRESS_DISPOSED,
+            BitmaskGattPttReader.classifyDisconnect(
+                intentional = false,
+                disposed = true,
+            ),
+        )
+        assertEquals(
+            BitmaskGattPttReader.DisconnectAction.SUPPRESS_DISPOSED,
+            BitmaskGattPttReader.classifyDisconnect(
+                intentional = true,
+                disposed = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `classifyDisconnect suppresses the async echo of an intentional teardown`() {
+        // disconnect() already fired onConnectionState(false)
+        // synchronously; the OS's STATE_DISCONNECTED echo lands
+        // here and MUST be swallowed so the plugin doesn't log
+        // the duplicate `External button connection up=false`.
+        assertEquals(
+            BitmaskGattPttReader.DisconnectAction.SUPPRESS_INTENTIONAL,
+            BitmaskGattPttReader.classifyDisconnect(
+                intentional = true,
+                disposed = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `classifyDisconnect notifies and reconnects on a real link drop`() {
+        // Neither the app nor a dispose caused this — it's a real
+        // BT link loss (out-of-range, device power-off, adapter
+        // toggle). Fire the callback so PttDispatcher can release
+        // any stuck slot, and schedule reconnect so an operator
+        // walking back into range doesn't have to fiddle with UI.
+        assertEquals(
+            BitmaskGattPttReader.DisconnectAction.NOTIFY_AND_RECONNECT,
+            BitmaskGattPttReader.classifyDisconnect(
+                intentional = false,
+                disposed = false,
+            ),
+        )
     }
 }


### PR DESCRIPTION
## Summary

Field-observed on a Pixel 9 Pro reconnect against a Pryme BT-PTT puck 2026-07-10 22:10:46 — `BitmaskGattPttReader` fired `onConnectionState(false)` twice in the same millisecond during a controlled teardown:

```
XX:XX:46.541 connectExternalButton kind=ble-hid mac=<redacted>
XX:XX:46.543 External button connection up=false source=PRYME_BLE
XX:XX:46.543 PTT source PRYME_BLE died mid-transmission — forcing release of slot 0
XX:XX:46.543 External button connection up=false source=PRYME_BLE   <- duplicate
XX:XX:46.543 PTT source PRYME_BLE died mid-transmission — forcing release of slot 0
XX:XX:46.749 External button connection up=true source=PRYME_BLE
```

## Root cause

Two paths fire `onConnectionState(false)` in the same millisecond during controlled teardown:

1. `VoicePlant.disconnectAinaSecondary()` calls `reader.disconnect()` (`BitmaskGattPttReader.kt:139`, sets `intentionalDisconnect=true` then fires the callback).
2. The OS's async STATE_DISCONNECTED echo delivers via `onConnectionStateChange()` (`BitmaskGattPttReader.kt:195-202`), which also fires the callback.

The `intentionalDisconnect` flag only gated `scheduleReconnect`, not `onConnectionState(false)`.

## Fix (minimal)

- `classifyDisconnect(intentional, disposed)` companion function → `DisconnectAction` enum (`NOTIFY_AND_RECONNECT` / `SUPPRESS_INTENTIONAL` / `SUPPRESS_DISPOSED`). `onConnectionStateChange` now uses it, so the async echo of an intentional teardown is a no-op. Real link drops still fire both the callback and reconnect.
- Sticky `@Volatile disposed` flag + `dispose()` method. All callback dispatch paths (connection state + button events) go through single choke points that short-circuit when disposed. Guards against a late GATT callback from an old reader bleeding into a freshly-swapped-in reader after `VoicePlant` has moved on.
- `VoicePlant.disconnectAina()` and `disconnectAinaSecondary()` now call `dispose()` on their `PrymeBleReader` before nulling the field.

Explicitly out of scope: `AinaBleReader` / `AinaSppReader` (different lifecycles, no observed dupe), `releaseStuckPttOnTransportDrop` (unchanged).

## Impact

Log noise + potential mid-TX confusion when reading a field capture. No functional TX drop — `PttDispatcher.forgetSource` is idempotent, so the double `releaseStuckPttOnTransportDrop` call was harmless. This PR removes the noise and closes the stale-callback latent risk before Sunday's production run.

## Test plan

- [x] `./gradlew ktlintCheck` — green
- [x] `./gradlew assembleCivDebug` — green
- [x] `./gradlew testCivDebugUnitTest` — green (3 new `classifyDisconnect` cases + existing `diffEdges` / decoder cases)
- [ ] On-device: mid-session Pryme reconnect no longer shows a duplicate `External button connection up=false` in logcat
- [ ] On-device: real Pryme link drop (device power-off) still triggers callback + reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)