### PR TITLE
feat(audio): reflective active-HFP switch + system output-switcher fallback for BT device override

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/audio/AudioRouter.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/AudioRouter.kt
@@ -604,6 +604,78 @@ class AudioRouter(
         private const val TAG = "XvAudioRouter"
 
         /**
+         * Launches the system Media Output Switcher panel so the
+         * operator can pick which HFP device the OS marks active. Used
+         * as a fallback when the operator's chosen audio-device
+         * override MAC isn't in [android.media.AudioManager.getAvailableCommunicationDevices]
+         * (because only one HFP device can be active at a time on
+         * API 31+) AND [BtActiveDeviceController.trySetActive] can't
+         * programmatically switch it (Pixel 14+ enforces
+         * BLUETOOTH_PRIVILEGED as signature-only).
+         *
+         * The panel opens as an overlay — ATAK stays running behind
+         * it; when the operator dismisses, they return to XV. XV then
+         * picks up the newly-active HFP on the next
+         * [android.media.AudioManager.getAvailableCommunicationDevices]
+         * read via the existing AudioDeviceCallback wiring.
+         *
+         * Adds [android.content.Intent.FLAG_ACTIVITY_NEW_TASK] because
+         * this may be launched from a service Context (VoicePlant /
+         * XvVoiceService). If the media-output panel intent isn't
+         * resolvable (some OEM ROMs strip it), falls back to the
+         * generic system Bluetooth-settings screen — same fallback
+         * chain used by the BT-off banner in `XvDropDownReceiver`.
+         *
+         * Returns true when either intent launched successfully. No
+         * declared permission needed — both intents are exported by
+         * the system Settings package as normal-priority activities.
+         */
+        fun launchSystemOutputSwitcher(context: Context): Boolean {
+            // Preferred: the modern per-app "which output" panel. On
+            // API 30+ Android exposes this as the "media output" quick
+            // settings tile programmatically via a Settings.Panel
+            // action string. Pixel + Samsung both resolve it.
+            val panelIntent =
+                Intent("com.android.settings.panel.action.MEDIA_OUTPUT").apply {
+                    // EXTRA_APP_PACKAGE tells the panel which app is
+                    // asking, so the switcher's title reads "XV" and
+                    // the picked device applies to our audio session
+                    // hint instead of the currently-focused media
+                    // app. Field-observed on Pixel 9 Pro / API 35 —
+                    // without this, the panel opens on whichever app
+                    // last played media, which is confusing UX.
+                    putExtra(android.provider.Settings.EXTRA_APP_PACKAGE, context.packageName)
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                }
+            try {
+                context.startActivity(panelIntent)
+                Log.i(TAG, "launched media output switcher (per-app panel)")
+                return true
+            } catch (_: android.content.ActivityNotFoundException) {
+                Log.i(TAG, "media output panel not resolvable — falling back to BT settings")
+            } catch (t: Throwable) {
+                Log.w(TAG, "media output panel launch threw", t)
+            }
+            // Fallback: system Bluetooth settings screen. Same
+            // affordance used elsewhere (see XvDropDownReceiver's
+            // BT-off banner). Slower UX (extra taps to reach the
+            // output picker) but universally present on every
+            // shipped OEM build.
+            val btSettings =
+                Intent(android.provider.Settings.ACTION_BLUETOOTH_SETTINGS).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                }
+            return try {
+                context.startActivity(btSettings)
+                Log.i(TAG, "launched BT settings (media output panel unavailable)")
+                true
+            } catch (t: Throwable) {
+                Log.w(TAG, "BT settings launch threw — no switcher fallback available", t)
+                false
+            }
+        }
+
+        /**
          * How long the operator's preferred BT device (the AINA /
          * speakermic that matches [preferredBtMacHint]) is allowed to
          * stay unreachable in the audio-device output list before

--- a/app/src/main/java/com/atakmap/android/xv/audio/BtActiveDeviceController.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/BtActiveDeviceController.kt
@@ -1,0 +1,309 @@
+package com.atakmap.android.xv.audio
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothManager
+import android.content.Context
+import android.util.Log
+import com.atakmap.android.xv.aina.redactMac
+
+// Best-effort programmatic switch of the ACTIVE HFP device on the local
+// Bluetooth adapter, so [AudioManager.setCommunicationDevice] can pin the
+// operator's chosen headset instead of whichever HFP device the OS most
+// recently marked active.
+//
+// Background: on API 31+, [AudioManager.getAvailableCommunicationDevices]
+// only exposes the currently-ACTIVE HFP device — even when the phone has
+// two HFP profiles connected (e.g. an AINA speakermic AND a Shokz OpenMove
+// headset). XV's `outputBtOverrideMac` correctly detects the miss and
+// falls through, but the operator can't reach the second device for
+// voice comm without opening the system media picker manually. This
+// controller narrows that gap by trying the sanctioned system API
+// programmatically: [BluetoothAdapter.setActiveDevice(BluetoothDevice, int)]
+// with `ACTIVE_DEVICE_PHONE_CALL = 1`. That method is `@SystemApi` /
+// `@hide` and requires `BLUETOOTH_PRIVILEGED` — signature-only on
+// Pixel 14+ / AOSP 14+. Reflection is used because there is no
+// public API surface, exactly the same way [AinaA2dpController] gates
+// A2DP via reflective `setConnectionPolicy`.
+//
+// Two expected outcomes in the field:
+//   - Pixel 14+ / recent AOSP builds: reflection returns `false`
+//     (or a SecurityException gets swallowed as `REFUSED_BY_PLATFORM`).
+//     Confirmed by the same platform hardening that makes
+//     [AinaA2dpController] fall through to a manual-toggle prompt.
+//     XV then leans on the system-media-picker fallback so the operator
+//     can pick manually with one tap.
+//   - Samsung One UI + some OEMs: reflection can actually succeed
+//     because the platform doesn't gate the API as tightly. Logged at
+//     INFO so field logs make the difference visible.
+//   - API < 28: `setActiveDevice` did not exist. Reflection returns
+//     [TrySetActiveResult.NotSupported]; XV skips straight to the
+//     manual fallback.
+//
+// Zero declared permissions. Reflection needs none; a failed reflection
+// call surfaces as a plain result, not a runtime crash. The MAC value
+// is redacted in every log line per CLAUDE.md sensitive-content rules.
+@SuppressLint("MissingPermission")
+object BtActiveDeviceController {
+    private const val TAG = "XvBtActiveDev"
+
+    // BluetoothAdapter.ACTIVE_DEVICE_PHONE_CALL constant. Public
+    // documentation (Android source: BluetoothAdapter.java @SystemApi)
+    // pins the value at 1 across every version that has the API. We
+    // try to read the constant reflectively first (in case a future
+    // release renumbers it) and fall back to the literal — same
+    // strategy as [AinaA2dpController]'s inlined policy constants.
+    private const val ACTIVE_DEVICE_PHONE_CALL_FALLBACK = 1
+
+    /**
+     * Outcome of a single [trySetActive] attempt. Cached per-MAC by
+     * [trySetActive] so we don't hammer reflection on every PTT press
+     * when the platform has already told us "no."
+     */
+    sealed class TrySetActiveResult {
+        /** Reflection call returned true — the adapter accepted the
+         *  switch. Note that the OS still takes some milliseconds to
+         *  actually re-enumerate; callers should poll
+         *  [AudioManager.availableCommunicationDevices] briefly. */
+        object Success : TrySetActiveResult()
+
+        /** Reflection succeeded but the adapter returned false. Almost
+         *  always means BLUETOOTH_PRIVILEGED enforcement — the platform
+         *  silently refused. Pixel 14+ / AOSP 14+ typical. */
+        object RefusedByPlatform : TrySetActiveResult()
+
+        /** `setActiveDevice(BluetoothDevice, int)` not found on the
+         *  adapter class. API < 28 or heavily-stripped ROM. */
+        object NotSupported : TrySetActiveResult()
+
+        /** Reflection call threw an unexpected exception (typically an
+         *  InvocationTargetException wrapping SecurityException on some
+         *  OEMs). Cached so we don't keep hitting the same wall. */
+        data class Threw(val cause: Throwable) : TrySetActiveResult()
+    }
+
+    // Per-MAC cache of the last observed result. Keyed by MAC (case-
+    // insensitive canonicalized to upper-case). We cache SUCCESS as
+    // well as failures — a device that succeeded once will normally
+    // succeed again, and the log noise from re-issuing the call every
+    // PTT press adds up. Cache is cleared on process restart, which is
+    // fine: platform behaviour doesn't change mid-session.
+    private val resultCache: MutableMap<String, TrySetActiveResult> =
+        java.util.Collections.synchronizedMap(HashMap())
+
+    /**
+     * Attempt to set [mac] as the active HFP device on the local BT
+     * adapter. Result is cached per-MAC; a second call for the same
+     * MAC returns the cached outcome and logs at DEBUG.
+     *
+     * @param context any Context — used only to resolve the
+     *                [BluetoothManager] / [BluetoothAdapter]. Not
+     *                retained.
+     * @param mac     BT MAC address of the target device. Must be a
+     *                real bonded device address; unknown MACs surface
+     *                as [TrySetActiveResult.Threw] wrapping the
+     *                [BluetoothAdapter.getRemoteDevice] exception.
+     */
+    fun trySetActive(
+        context: Context,
+        mac: String,
+    ): TrySetActiveResult {
+        val key = mac.uppercase()
+        resultCache[key]?.let { cached ->
+            Log.d(TAG, "trySetActive(${redactMac(mac)}) cache hit: ${cached.javaClass.simpleName}")
+            return cached
+        }
+        val result = doTrySetActive(context, mac)
+        resultCache[key] = result
+        Log.i(TAG, "trySetActive(${redactMac(mac)}) → ${result.javaClass.simpleName}")
+        return result
+    }
+
+    /**
+     * Purge the cached outcome for [mac] so the next [trySetActive]
+     * call re-attempts reflection. Used when the platform's active-
+     * HFP set changes underneath us (e.g. the operator toggled
+     * something from system BT settings) and a previously-refused
+     * device might now succeed.
+     */
+    fun invalidate(mac: String) {
+        val key = mac.uppercase()
+        if (resultCache.remove(key) != null) {
+            Log.i(TAG, "invalidate(${redactMac(mac)})")
+        }
+    }
+
+    /** Test hook — clears the entire cache. Not for production use. */
+    @androidx.annotation.VisibleForTesting
+    internal fun clearCacheForTest() {
+        resultCache.clear()
+    }
+
+    private fun doTrySetActive(
+        context: Context,
+        mac: String,
+    ): TrySetActiveResult {
+        val adapter =
+            try {
+                val bm = context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+                bm?.adapter ?: BluetoothAdapter.getDefaultAdapter()
+            } catch (t: Throwable) {
+                return TrySetActiveResult.Threw(t)
+            } ?: return TrySetActiveResult.NotSupported
+
+        val device: BluetoothDevice =
+            try {
+                adapter.getRemoteDevice(mac)
+            } catch (t: Throwable) {
+                return TrySetActiveResult.Threw(t)
+            }
+
+        val method =
+            try {
+                adapter.javaClass.getMethod(
+                    "setActiveDevice",
+                    BluetoothDevice::class.java,
+                    Int::class.javaPrimitiveType,
+                )
+            } catch (_: NoSuchMethodException) {
+                return TrySetActiveResult.NotSupported
+            } catch (t: Throwable) {
+                return TrySetActiveResult.Threw(t)
+            }
+
+        val phoneCallProfile = resolveActiveDevicePhoneCallConstant(adapter)
+        return try {
+            val result = method.invoke(adapter, device, phoneCallProfile)
+            if (result is Boolean && !result) {
+                TrySetActiveResult.RefusedByPlatform
+            } else {
+                // Void return / null / non-boolean truthy — treat as
+                // success. Same policy as [AinaA2dpController.setConnectionPolicyReflective]:
+                // OEM builds that return Void still succeeded.
+                TrySetActiveResult.Success
+            }
+        } catch (t: Throwable) {
+            val cause =
+                if (t is java.lang.reflect.InvocationTargetException) {
+                    t.targetException ?: t
+                } else {
+                    t
+                }
+            if (cause is SecurityException) {
+                TrySetActiveResult.RefusedByPlatform
+            } else {
+                TrySetActiveResult.Threw(cause)
+            }
+        }
+    }
+
+    /**
+     * Read `BluetoothAdapter.ACTIVE_DEVICE_PHONE_CALL` reflectively so
+     * we track any future platform renumber. Falls back to the
+     * known-stable literal `1` when the field is missing (older APIs
+     * that still have `setActiveDevice` but haven't yet exposed the
+     * constant on the public class).
+     */
+    private fun resolveActiveDevicePhoneCallConstant(adapter: BluetoothAdapter): Int =
+        try {
+            val f = adapter.javaClass.getField("ACTIVE_DEVICE_PHONE_CALL")
+            (f.get(null) as? Int) ?: ACTIVE_DEVICE_PHONE_CALL_FALLBACK
+        } catch (_: Throwable) {
+            ACTIVE_DEVICE_PHONE_CALL_FALLBACK
+        }
+}
+
+/**
+ * Pure decision function for the override-routing state machine in
+ * [ScoLink]. Extracted so unit tests can pin every branch without
+ * standing up BluetoothAdapter / AudioManager / a live Context.
+ *
+ * Given the current state — override MAC, hint MAC, currently-available
+ * comm-device MACs, last [BtActiveDeviceController.trySetActive] outcome
+ * for the override, and the switcher-launch cooldown — return which
+ * action the caller should take next.
+ *
+ * The caller (production ScoLink) then executes the action:
+ *   - [OverrideRoutingAction.PIN_DIRECT]: pin the override MAC directly;
+ *     it's already in the available list.
+ *   - [OverrideRoutingAction.TRY_REFLECTION]: call
+ *     [BtActiveDeviceController.trySetActive]. On SUCCESS the caller
+ *     polls the available list briefly and re-runs this decision.
+ *   - [OverrideRoutingAction.LAUNCH_SWITCHER]: open the system output
+ *     switcher panel (cooldown observed by the caller before invoking
+ *     this — the decision has already checked it) and fall back to the
+ *     hint for the current SCO acquire.
+ *   - [OverrideRoutingAction.PIN_HINT]: skip the switcher (either
+ *     nothing else to try, or cooldown not yet expired) and pin the
+ *     hint MAC. Legacy behaviour.
+ */
+enum class OverrideRoutingAction {
+    PIN_DIRECT,
+    TRY_REFLECTION,
+    LAUNCH_SWITCHER,
+    PIN_HINT,
+}
+
+/**
+ * See [OverrideRoutingAction] KDoc.
+ *
+ * @param overrideMac         The operator's explicit "Audio device"
+ *                            override MAC. Null / blank → no override
+ *                            active; caller should route by hint.
+ * @param hintMac             The AINA hint MAC (fallback speakermic).
+ *                            Not consulted directly by this decision —
+ *                            passed through for symmetry so callers
+ *                            can log both values from the same site.
+ * @param availableMacs       Set of MACs currently in
+ *                            [android.media.AudioManager.getAvailableCommunicationDevices].
+ *                            Compared case-insensitively via caller
+ *                            upper-casing before the call.
+ * @param reflectionCached    Previous [BtActiveDeviceController.trySetActive]
+ *                            outcome for the override MAC, or null if
+ *                            we haven't tried yet. Used to decide
+ *                            whether reflection is worth attempting
+ *                            again.
+ * @param lastSwitcherLaunchMs Timestamp of the last switcher launch
+ *                            (ms since boot), or 0L if none this
+ *                            session.
+ * @param nowMs               Current timestamp (ms since boot).
+ * @param switcherCooldownMs  Minimum spacing between switcher launches.
+ *                            Prevents focus-pull spam when the operator
+ *                            hammers PTT while the override is out of
+ *                            range.
+ */
+fun decideOverrideAction(
+    overrideMac: String?,
+    @Suppress("UNUSED_PARAMETER") hintMac: String?,
+    availableMacs: Set<String>,
+    reflectionCached: BtActiveDeviceController.TrySetActiveResult?,
+    lastSwitcherLaunchMs: Long,
+    nowMs: Long,
+    switcherCooldownMs: Long,
+): OverrideRoutingAction {
+    if (overrideMac.isNullOrBlank()) return OverrideRoutingAction.PIN_HINT
+    val overrideUpper = overrideMac.uppercase()
+    if (availableMacs.contains(overrideUpper)) return OverrideRoutingAction.PIN_DIRECT
+    // Override present but not currently a comm device. If we've never
+    // tried reflection, try it — on Samsung / older builds it may
+    // succeed and the OS re-enumerates the override in.
+    if (reflectionCached == null) return OverrideRoutingAction.TRY_REFLECTION
+    // Reflection already resolved. If it succeeded but the override
+    // still isn't in the available set, we've hit a race or a platform
+    // that accepts the API call without honoring it — fall through to
+    // the switcher so the operator can complete the switch manually.
+    if (reflectionCached is BtActiveDeviceController.TrySetActiveResult.Success) {
+        return OverrideRoutingAction.LAUNCH_SWITCHER
+    }
+    // Reflection failed. Launch the switcher, but only if we're past
+    // the per-session cooldown — otherwise the operator gets a panel
+    // yanked over ATAK on every PTT press, which is worse than sitting
+    // on the hint.
+    val cooldownExpired = (nowMs - lastSwitcherLaunchMs) >= switcherCooldownMs
+    return if (cooldownExpired) {
+        OverrideRoutingAction.LAUNCH_SWITCHER
+    } else {
+        OverrideRoutingAction.PIN_HINT
+    }
+}

--- a/app/src/main/java/com/atakmap/android/xv/audio/ScoLink.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/ScoLink.kt
@@ -46,6 +46,15 @@ class ScoLink(
     // most-recently-connected device wins and XV's voice routes to
     // whichever the OS picked, not the operator's chosen speakermic.
     private val preferredBtMac: () -> String? = { null },
+    // Human-readable display name for the audio-device override MAC.
+    // Populated from [AudioRouter.availableBtOutputs] / the persisted
+    // display name — never derived from the raw MAC. Injected as a
+    // lookup so ScoLink doesn't need to reach across to AudioRouter
+    // or the preferences DAO; VoicePlant closes the lambda over the
+    // router. Returns null when the operator hasn't set an override
+    // or when the device name isn't cached; the toast omits the name
+    // segment in that case.
+    private val overrideDisplayName: () -> String? = { null },
 ) {
     // SUSPENDED is a transient broken state inserted between CONNECTED
     // and DISCONNECTED. It indicates the physical SCO link was torn
@@ -175,8 +184,195 @@ class ScoLink(
                 "outputBtOverrideMac ${com.atakmap.android.xv.aina.redactMac(override)} not available " +
                     "as comm device — falling back to preferredBtMacHint / speaker",
             )
+            // Try to nudge the OS into making the override the active
+            // HFP device (reflection into BluetoothAdapter.setActiveDevice)
+            // and, if that fails, open the system output switcher so the
+            // operator can pick manually. On SUCCESS, re-read the comm
+            // devices briefly — if the override now appears, pin to it
+            // instead of the fallback. See [handleOverrideMissed] for
+            // the decision tree.
+            val pinned = handleOverrideMissed(override)
+            if (pinned != null) return pinned
         }
         return result.pick?.audioDevice as AudioDeviceInfo?
+    }
+
+    // ============================================================
+    // Override-unreachable handling (feat/bt-active-device-controller)
+    // ============================================================
+    //
+    // Timestamp of the last system output-switcher launch, ms since
+    // boot. Rate-limits the Intent so a stuck-out-of-range override
+    // + repeated PTT presses doesn't yank the system panel over ATAK
+    // every burst. See [SWITCHER_COOLDOWN_MS].
+    @Volatile
+    private var lastSwitcherLaunchMs: Long = 0L
+
+    /**
+     * Called from [pickBtCommDevice] when the override MAC is set but
+     * not in the currently-available comm-device list. Wraps the pure
+     * [decideOverrideAction] state machine and executes the resulting
+     * action:
+     *
+     *   - `PIN_DIRECT` never happens here (we're already inside the
+     *     "miss" branch), but the enum includes it for the outer
+     *     re-poll after a successful reflection.
+     *   - `TRY_REFLECTION`: call [BtActiveDeviceController.trySetActive].
+     *     On SUCCESS, poll [AudioManager.availableCommunicationDevices]
+     *     briefly and re-pin to the override if it now appears.
+     *   - `LAUNCH_SWITCHER`: fire the media-output panel intent + a
+     *     one-time toast so the operator knows what happened. Falls
+     *     through to `null` — the caller keeps the hint pin.
+     *   - `PIN_HINT`: no-op; caller keeps the hint pin. This is the
+     *     silent path taken while the cooldown is running.
+     *
+     * Returns the override AudioDeviceInfo when reflection succeeded
+     * fast enough for the OS to re-enumerate — the caller pins to it
+     * directly. Returns null when the caller should fall back to the
+     * hint / speaker.
+     */
+    private fun handleOverrideMissed(overrideMac: String): AudioDeviceInfo? {
+        val availableMacs =
+            try {
+                audioManager.availableCommunicationDevices
+                    .map { macOf(it).uppercase() }
+                    .toSet()
+            } catch (_: Throwable) {
+                emptySet()
+            }
+        val hint = preferredBtMac()
+        // Peek at our per-MAC record of the last reflection outcome. We
+        // maintain [lastReflectionByMac] alongside BtActiveDeviceController's
+        // own cache because [decideOverrideAction] wants a nullable
+        // "never tried this session" signal — the controller's cache
+        // doesn't expose null vs. cached-but-uninteresting cleanly.
+        val cached = lastReflectionByMac[overrideMac.uppercase()]
+        val nowMs = android.os.SystemClock.elapsedRealtime()
+        val action =
+            decideOverrideAction(
+                overrideMac = overrideMac,
+                hintMac = hint,
+                availableMacs = availableMacs,
+                reflectionCached = cached,
+                lastSwitcherLaunchMs = lastSwitcherLaunchMs,
+                nowMs = nowMs,
+                switcherCooldownMs = SWITCHER_COOLDOWN_MS,
+            )
+        Log.i(
+            TAG,
+            "handleOverrideMissed(${com.atakmap.android.xv.aina.redactMac(overrideMac)}) → $action" +
+                " (cached=${cached?.javaClass?.simpleName ?: "none"})",
+        )
+        return when (action) {
+            OverrideRoutingAction.PIN_DIRECT -> null // structurally impossible here; caller path stands
+            OverrideRoutingAction.PIN_HINT -> null
+            OverrideRoutingAction.TRY_REFLECTION -> {
+                val result = BtActiveDeviceController.trySetActive(context, overrideMac)
+                lastReflectionByMac[overrideMac.uppercase()] = result
+                if (result is BtActiveDeviceController.TrySetActiveResult.Success) {
+                    // Wait briefly for the OS to re-enumerate. 25 ms
+                    // polls × 8 = ~200 ms budget, same shape as the
+                    // startCommDevice readiness poll.
+                    val rePin = pollForOverrideAvailability(overrideMac)
+                    if (rePin != null) {
+                        Log.i(
+                            TAG,
+                            "active HFP switched via reflection — pinning override " +
+                                com.atakmap.android.xv.aina.redactMac(overrideMac),
+                        )
+                        return rePin
+                    }
+                    // Reflection claimed success but the OS didn't
+                    // move the device into the available list. Fall
+                    // through to the switcher so the operator can
+                    // complete the swap.
+                    Log.i(TAG, "reflection SUCCESS but override still absent — opening switcher")
+                    launchSwitcherIfPermitted(overrideMac, nowMs)
+                    return null
+                }
+                Log.d(TAG, "reflection non-success (${result.javaClass.simpleName}) — will consider switcher")
+                launchSwitcherIfPermitted(overrideMac, nowMs)
+                null
+            }
+            OverrideRoutingAction.LAUNCH_SWITCHER -> {
+                launchSwitcherIfPermitted(overrideMac, nowMs)
+                null
+            }
+        }
+    }
+
+    // Per-MAC cache of the last reflection result seen through this
+    // ScoLink instance. Deliberately shadowed here (in addition to
+    // [BtActiveDeviceController]'s own cache) so [decideOverrideAction]
+    // can see a nullable "never tried in this session" signal without
+    // the controller having to expose its internal map. Cleared on
+    // [forceStop] (implicit — new plant → new ScoLink → new map).
+    private val lastReflectionByMac: MutableMap<String, BtActiveDeviceController.TrySetActiveResult> =
+        java.util.Collections.synchronizedMap(HashMap())
+
+    private fun pollForOverrideAvailability(overrideMac: String): AudioDeviceInfo? {
+        val overrideUpper = overrideMac.uppercase()
+        val deadline = System.nanoTime() + POST_SET_ACTIVE_POLL_BUDGET_MS * 1_000_000L
+        while (System.nanoTime() < deadline) {
+            try {
+                val devs = audioManager.availableCommunicationDevices
+                val hit = devs.firstOrNull { macOf(it).equals(overrideUpper, ignoreCase = true) }
+                if (hit != null) return hit
+            } catch (_: Throwable) {
+            }
+            try {
+                Thread.sleep(POST_SET_ACTIVE_POLL_STEP_MS)
+            } catch (_: InterruptedException) {
+                Thread.currentThread().interrupt()
+                return null
+            }
+        }
+        return null
+    }
+
+    private fun launchSwitcherIfPermitted(
+        overrideMac: String,
+        nowMs: Long,
+    ) {
+        if (nowMs - lastSwitcherLaunchMs < SWITCHER_COOLDOWN_MS) {
+            Log.d(
+                TAG,
+                "switcher launch throttled — last=${nowMs - lastSwitcherLaunchMs}ms ago " +
+                    "(cooldown=${SWITCHER_COOLDOWN_MS}ms)",
+            )
+            return
+        }
+        lastSwitcherLaunchMs = nowMs
+        val name = overrideDisplayName()
+        // Toast on the main thread. Uses the device's display name
+        // (from AudioRouter.availableBtOutputs) rather than the raw
+        // MAC per CLAUDE.md sensitive-content rules. When the name
+        // isn't available (device was picked before it was ever seen
+        // in the output list) we omit the device segment entirely
+        // rather than fall back to the redacted MAC — a redacted MAC
+        // in a Toast is worse UX than "system requires manual
+        // selection" with no name.
+        val msg =
+            if (!name.isNullOrBlank()) {
+                "Route override to $name: system requires manual selection. Opening switcher…"
+            } else {
+                "Route override: system requires manual selection. Opening switcher…"
+            }
+        mainHandler.post {
+            try {
+                android.widget.Toast
+                    .makeText(context, msg, android.widget.Toast.LENGTH_LONG)
+                    .show()
+            } catch (t: Throwable) {
+                Log.w(TAG, "override-unreachable toast threw", t)
+            }
+        }
+        val launched = AudioRouter.launchSystemOutputSwitcher(context)
+        Log.i(
+            TAG,
+            "opened system output switcher for override " +
+                "${com.atakmap.android.xv.aina.redactMac(overrideMac)} launched=$launched",
+        )
     }
 
     /**
@@ -717,5 +913,35 @@ class ScoLink(
         // anything past 90s of continuous hold means a holder isn't
         // releasing as expected. Below this, the watchdog logs at DEBUG.
         private const val WATCHDOG_WARN_THRESHOLD_MS = 90_000L
+
+        /**
+         * Cooldown between system output-switcher launches. When the
+         * operator's audio-device override MAC isn't reachable, we
+         * fire the switcher panel intent + a toast — but only once
+         * per this window, per ScoLink lifetime. Without this, PTT
+         * hammering during a stuck-out-of-range override would yank
+         * the system panel over ATAK on every burst.
+         *
+         * 30 s is a compromise: long enough that a run of ~5 quick
+         * PTT presses doesn't re-trigger, short enough that if the
+         * operator dismissed the panel by accident they can PTT
+         * again to get it back within the same conversation window.
+         */
+        internal const val SWITCHER_COOLDOWN_MS: Long = 30_000L
+
+        /**
+         * Total time budget for polling
+         * [android.media.AudioManager.getAvailableCommunicationDevices]
+         * after a successful [BtActiveDeviceController.trySetActive]
+         * call. On Samsung / older AOSP where reflection actually
+         * takes effect, the OS re-enumerates within ~50-100 ms.
+         * Beyond ~200 ms we assume the platform accepted the call
+         * without honoring the switch (or racing something else) and
+         * fall through to the switcher fallback.
+         */
+        private const val POST_SET_ACTIVE_POLL_BUDGET_MS: Long = 200L
+
+        /** Poll cadence during [POST_SET_ACTIVE_POLL_BUDGET_MS]. */
+        private const val POST_SET_ACTIVE_POLL_STEP_MS: Long = 25L
     }
 }

--- a/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
@@ -208,6 +208,24 @@ class VoicePlant(
             // pins comm to the hint (which is typically the AINA
             // that owns the PTT button).
             preferredBtMac = { router.preferredBtMacHint },
+            // Display-name lookup for the audio-device override
+            // MAC. Used only for the operator-facing Toast when
+            // ScoLink can't reach the override programmatically
+            // and is about to open the system output switcher.
+            // Reads from the router's live output enumeration —
+            // when the operator picked the device from the XV
+            // Settings picker the name was captured then. Returns
+            // null when the device isn't currently in the output
+            // list, in which case ScoLink omits the name segment
+            // of the Toast rather than fall back to the redacted
+            // MAC (worse UX than a nameless prompt).
+            overrideDisplayName = overrideDisplayName@{
+                val mac = router.outputBtOverrideMac ?: return@overrideDisplayName null
+                router
+                    .availableBtOutputs()
+                    .firstOrNull { it.address.equals(mac, ignoreCase = true) }
+                    ?.displayName
+            },
         ).also { link ->
             // Wire ScoLink into AudioControllerImpl so focus-loss
             // teardown publishes SUSPENDED instead of the controller

--- a/app/src/test/java/com/atakmap/android/xv/audio/BtActiveDeviceControllerTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/audio/BtActiveDeviceControllerTest.kt
@@ -1,0 +1,234 @@
+package com.atakmap.android.xv.audio
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-Kotlin coverage for the override-routing decision function used
+ * by [ScoLink.handleOverrideMissed]. Real reflective
+ * [BtActiveDeviceController.trySetActive] behavior varies by OEM /
+ * platform release; the decision matrix around it does not, and is
+ * pinned here so future refactors don't regress the "don't spam the
+ * switcher" or "try reflection before giving up" contracts.
+ */
+class BtActiveDeviceControllerTest {
+    private val overrideMac = "AA:BB:CC:DD:EE:FF"
+    private val hintMac = "11:22:33:44:55:66"
+    private val cooldown = 30_000L
+
+    @Test
+    fun `override present in available set — PIN_DIRECT`() {
+        val action =
+            decideOverrideAction(
+                overrideMac = overrideMac,
+                hintMac = hintMac,
+                availableMacs = setOf("AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66"),
+                reflectionCached = null,
+                lastSwitcherLaunchMs = 0L,
+                nowMs = 1_000L,
+                switcherCooldownMs = cooldown,
+            )
+        assertEquals(OverrideRoutingAction.PIN_DIRECT, action)
+    }
+
+    @Test
+    fun `override present is case-insensitive`() {
+        // The comparator uppercases before hitting the set — a mixed-
+        // case override MAC still matches an upper-cased available set.
+        val action =
+            decideOverrideAction(
+                overrideMac = "aa:bb:cc:dd:ee:ff",
+                hintMac = hintMac,
+                availableMacs = setOf("AA:BB:CC:DD:EE:FF"),
+                reflectionCached = null,
+                lastSwitcherLaunchMs = 0L,
+                nowMs = 1_000L,
+                switcherCooldownMs = cooldown,
+            )
+        assertEquals(OverrideRoutingAction.PIN_DIRECT, action)
+    }
+
+    @Test
+    fun `override absent, no reflection cache — TRY_REFLECTION`() {
+        val action =
+            decideOverrideAction(
+                overrideMac = overrideMac,
+                hintMac = hintMac,
+                availableMacs = setOf("11:22:33:44:55:66"),
+                reflectionCached = null,
+                lastSwitcherLaunchMs = 0L,
+                nowMs = 1_000L,
+                switcherCooldownMs = cooldown,
+            )
+        assertEquals(OverrideRoutingAction.TRY_REFLECTION, action)
+    }
+
+    @Test
+    fun `override absent, reflection SUCCESS but override still absent — LAUNCH_SWITCHER`() {
+        // Defensive branch: reflection said the switch worked but the
+        // override never appeared in availableCommunicationDevices.
+        // Could be an OEM that returns Void on the reflective call
+        // without actually honoring the switch, or a race with a
+        // parallel platform-side re-enumeration. Either way, escalate
+        // to the switcher so the operator can complete the swap.
+        val action =
+            decideOverrideAction(
+                overrideMac = overrideMac,
+                hintMac = hintMac,
+                availableMacs = setOf("11:22:33:44:55:66"),
+                reflectionCached = BtActiveDeviceController.TrySetActiveResult.Success,
+                lastSwitcherLaunchMs = 0L,
+                nowMs = 1_000L,
+                switcherCooldownMs = cooldown,
+            )
+        assertEquals(OverrideRoutingAction.LAUNCH_SWITCHER, action)
+    }
+
+    @Test
+    fun `override absent, reflection REFUSED_BY_PLATFORM, cooldown expired — LAUNCH_SWITCHER`() {
+        val action =
+            decideOverrideAction(
+                overrideMac = overrideMac,
+                hintMac = hintMac,
+                availableMacs = setOf("11:22:33:44:55:66"),
+                reflectionCached = BtActiveDeviceController.TrySetActiveResult.RefusedByPlatform,
+                lastSwitcherLaunchMs = 0L,
+                nowMs = cooldown + 1L,
+                switcherCooldownMs = cooldown,
+            )
+        assertEquals(OverrideRoutingAction.LAUNCH_SWITCHER, action)
+    }
+
+    @Test
+    fun `override absent, reflection REFUSED_BY_PLATFORM, cooldown not expired — PIN_HINT`() {
+        // PTT hammered right after a switcher launch. Silent fall-back
+        // to the hint prevents the panel from being yanked back in
+        // front of ATAK on every burst.
+        val action =
+            decideOverrideAction(
+                overrideMac = overrideMac,
+                hintMac = hintMac,
+                availableMacs = setOf("11:22:33:44:55:66"),
+                reflectionCached = BtActiveDeviceController.TrySetActiveResult.RefusedByPlatform,
+                lastSwitcherLaunchMs = 100L,
+                nowMs = 100L + cooldown - 1L,
+                switcherCooldownMs = cooldown,
+            )
+        assertEquals(OverrideRoutingAction.PIN_HINT, action)
+    }
+
+    @Test
+    fun `override absent, reflection NOT_SUPPORTED, cooldown expired — LAUNCH_SWITCHER`() {
+        // API < 28 / stripped ROM — same terminal outcome as
+        // REFUSED_BY_PLATFORM: switcher is the only way forward.
+        val action =
+            decideOverrideAction(
+                overrideMac = overrideMac,
+                hintMac = hintMac,
+                availableMacs = setOf("11:22:33:44:55:66"),
+                reflectionCached = BtActiveDeviceController.TrySetActiveResult.NotSupported,
+                lastSwitcherLaunchMs = 0L,
+                nowMs = cooldown + 1L,
+                switcherCooldownMs = cooldown,
+            )
+        assertEquals(OverrideRoutingAction.LAUNCH_SWITCHER, action)
+    }
+
+    @Test
+    fun `override absent, reflection NOT_SUPPORTED, cooldown not expired — PIN_HINT`() {
+        val action =
+            decideOverrideAction(
+                overrideMac = overrideMac,
+                hintMac = hintMac,
+                availableMacs = setOf("11:22:33:44:55:66"),
+                reflectionCached = BtActiveDeviceController.TrySetActiveResult.NotSupported,
+                lastSwitcherLaunchMs = 100L,
+                nowMs = 100L + cooldown - 1L,
+                switcherCooldownMs = cooldown,
+            )
+        assertEquals(OverrideRoutingAction.PIN_HINT, action)
+    }
+
+    @Test
+    fun `override absent, reflection THREW, cooldown expired — LAUNCH_SWITCHER`() {
+        val action =
+            decideOverrideAction(
+                overrideMac = overrideMac,
+                hintMac = hintMac,
+                availableMacs = setOf("11:22:33:44:55:66"),
+                reflectionCached = BtActiveDeviceController.TrySetActiveResult.Threw(RuntimeException("boom")),
+                lastSwitcherLaunchMs = 0L,
+                nowMs = cooldown + 1L,
+                switcherCooldownMs = cooldown,
+            )
+        assertEquals(OverrideRoutingAction.LAUNCH_SWITCHER, action)
+    }
+
+    @Test
+    fun `override null — PIN_HINT (caller resolves absence of hint separately)`() {
+        val action =
+            decideOverrideAction(
+                overrideMac = null,
+                hintMac = hintMac,
+                availableMacs = setOf("11:22:33:44:55:66"),
+                reflectionCached = null,
+                lastSwitcherLaunchMs = 0L,
+                nowMs = 1_000L,
+                switcherCooldownMs = cooldown,
+            )
+        assertEquals(OverrideRoutingAction.PIN_HINT, action)
+    }
+
+    @Test
+    fun `override blank — PIN_HINT`() {
+        val action =
+            decideOverrideAction(
+                overrideMac = "   ",
+                hintMac = hintMac,
+                availableMacs = setOf("11:22:33:44:55:66"),
+                reflectionCached = null,
+                lastSwitcherLaunchMs = 0L,
+                nowMs = 1_000L,
+                switcherCooldownMs = cooldown,
+            )
+        assertEquals(OverrideRoutingAction.PIN_HINT, action)
+    }
+
+    @Test
+    fun `override null AND hint null — PIN_HINT (caller falls into speaker chain)`() {
+        // The spec calls out this case explicitly: when neither
+        // override nor hint is set we return PIN_HINT and let the
+        // caller's existing "no hint, speaker" logic take over. We
+        // don't invent a new state for it here.
+        val action =
+            decideOverrideAction(
+                overrideMac = null,
+                hintMac = null,
+                availableMacs = emptySet(),
+                reflectionCached = null,
+                lastSwitcherLaunchMs = 0L,
+                nowMs = 1_000L,
+                switcherCooldownMs = cooldown,
+            )
+        assertEquals(OverrideRoutingAction.PIN_HINT, action)
+    }
+
+    @Test
+    fun `cooldown exactly at boundary counts as expired`() {
+        // nowMs - lastSwitcherLaunchMs == cooldown → cooldown expired
+        // (>= comparison). Boundary pinned so a future refactor to
+        // strict-greater-than doesn't silently regress the "one
+        // launch per 30s" spec.
+        val action =
+            decideOverrideAction(
+                overrideMac = overrideMac,
+                hintMac = hintMac,
+                availableMacs = setOf("11:22:33:44:55:66"),
+                reflectionCached = BtActiveDeviceController.TrySetActiveResult.RefusedByPlatform,
+                lastSwitcherLaunchMs = 100L,
+                nowMs = 100L + cooldown,
+                switcherCooldownMs = cooldown,
+            )
+        assertEquals(OverrideRoutingAction.LAUNCH_SWITCHER, action)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `BtActiveDeviceController` — a reflective wrapper around `BluetoothAdapter.setActiveDevice(BluetoothDevice, ACTIVE_DEVICE_PHONE_CALL)` so XV can nudge the OS's active HFP selection to match the operator's "Audio device" override MAC. Best-effort, per-MAC-cached, zero declared permissions. Same idiom as `AinaA2dpController`'s reflective `setConnectionPolicy`.
- Adds `AudioRouter.launchSystemOutputSwitcher()` — a fallback that fires the Settings.Panel MEDIA_OUTPUT overlay (attributed to XV via `EXTRA_APP_PACKAGE`) so the operator can pick the intended device manually with one tap. Falls back to `ACTION_BLUETOOTH_SETTINGS` on ROMs that strip the panel.
- Wires both into `ScoLink`'s existing "override not available as comm device" fallback branch via a pure `decideOverrideAction(...)` state machine. Rate-limits the switcher to at most one launch per 30 s so PTT mashing doesn't yank the panel over ATAK on every burst.

## Field observation

Confirmed on-device 2026-07-10: with an AINA speakermic and a Shokz OpenMove headset both HFP-connected to a Pixel 9 Pro (API 35), setting the OpenMove as XV's Audio device override was correctly detected but never routed there. `AudioManager.getAvailableCommunicationDevices()` only exposes the currently-ACTIVE HFP device, so `setCommunicationDevice()` can pin the ACTIVE one but not switch which is active. XV logged the fallback exactly as PR #33 designed — and stopped there.

## Research summary

- `BluetoothAdapter.setActiveDevice()` is `@SystemApi` / `@hide` and requires `BLUETOOTH_PRIVILEGED`, which is signature-only on Pixel 14+ / AOSP 14+. Reflection returns `false` on Pixel; on Samsung One UI + some other OEM builds it can actually succeed.
- Every consumer PTT / voice-comm Android app hits the same wall — [Twilio's `audioswitch` issue #15](https://github.com/twilio/audioswitch/issues/15) documents Zoom, Meet, WhatsApp, and Zello all requiring the operator to manually switch active HFP via the system media picker. The system output-switcher panel is the sanctioned public escape hatch.
- The MEDIA_OUTPUT Settings panel is exported at normal priority and reachable without any declared permission. `EXTRA_APP_PACKAGE` makes the panel title read "XV" and applies the picked device to XV's audio session hint instead of whichever media app last played.

## Mechanism

1. `ScoLink.pickBtCommDevice` observes `outputBtOverrideMac` isn't in `availableCommunicationDevices`.
2. `handleOverrideMissed(overrideMac)` reads `availableCommunicationDevices`, the cached last reflection outcome, and the switcher cooldown, then calls the pure `decideOverrideAction(...)` — the same function pinned by unit tests.
3. On `TRY_REFLECTION`, calls `BtActiveDeviceController.trySetActive`. On `Success`, polls `availableCommunicationDevices` on a 25 ms cadence for 200 ms; if the override re-appears, pins to it directly ("active HFP switched via reflection" log at INFO).
4. On `LAUNCH_SWITCHER` (either reflection refused / not supported / threw with cooldown expired, or reflection claimed success but the OS didn't re-enumerate), posts a `LENGTH_LONG` toast naming the target device (display name from `AudioRouter.availableBtOutputs` — never a raw MAC per CLAUDE.md) and fires the MEDIA_OUTPUT panel intent. Fallback: `ACTION_BLUETOOTH_SETTINGS`.
5. Cooldown enforced by `@Volatile lastSwitcherLaunchMs: Long` on the ScoLink instance. Field-safe rate limit; no persistent state.

## Compatibility caveats (documented in code KDoc)

- Pixel 14+ / API 34+: reflection will almost certainly return `false`. Fallback path is what actually helps.
- Samsung One UI + some other OEMs: reflection may succeed. INFO log so field logs make it visible.
- API < 28: `setActiveDevice` didn't exist. `NotSupported` → skip straight to fallback.

## Non-goals

- No new `AndroidManifest.xml` permissions.
- No AIDL bumps.
- No changes to `AudioRouter.preferredDevice()` or the AudioTrack-side routing — this is comm-device / SCO-pin only.
- No Settings toggle gating this reflection — it's automatic + fail-open.
- No `AccessibilityService` (backlogged).
- README not updated: the affordance is an under-the-hood upgrade to a picker that was already documented as best-effort.

## Test plan

- [x] `./gradlew ktlintCheck` — green
- [x] `./gradlew assembleCivDebug` — green
- [x] `./gradlew testCivDebugUnitTest` — green (13 new `BtActiveDeviceControllerTest` cases)
- [ ] On-device (Pixel 9 Pro, API 35): pair AINA + OpenMove. Set OpenMove as XV Audio device override. Press PTT.
  - Expected: `outputBtOverrideMac … not available as comm device — falling back …` log fires, `handleOverrideMissed → TRY_REFLECTION` follows, reflection returns `RefusedByPlatform` (Pixel signature gate), toast appears (`Route override to <OpenMove name>: system requires manual selection. Opening switcher…`), system media output panel opens over ATAK. Operator taps OpenMove in the panel. Next PTT press pins to OpenMove (`available comm devices` list now includes it).
- [ ] On-device (Samsung Tab5 or comparable One UI): same scenario. Expected: reflection may return `Success` and XV re-pins to the override without opening the switcher — INFO log `active HFP switched via reflection` visible.
- [ ] On-device: PTT rapidly 5+ times while an override is out of range. Expected: switcher opens at most once per 30 s; intervening presses land silently on the hint / speaker with `switcher launch throttled` at DEBUG.

Ships pre-production-run 2026-07-13. Blocking BT car stereo + BT headphones use cases surfaced by the operator as critical for that run.