### PR TITLE
fix(tpt): widen preRoll+postRoll silence padding for higher-latency device audio pipelines

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/audio/TptPlayer.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/TptPlayer.kt
@@ -898,18 +898,33 @@ class TptPlayer(
          * when the AudioTrack opens and the audio path transitions
          * from "off" to "active." Pre-rolling silence absorbs the
          * transient on a silent buffer; the tone PCM then lands on a
-         * stable stream. 50 ms covers worst-case BT chipset settling
-         * (measured on AINA V1) without pushing back the perceived
-         * TPT start by anything an operator can detect.
+         * stable stream.
+         *
+         * 80 ms — sized for the highest-latency device in the fleet
+         * (Samsung Tab Active5 SM-X308U speaker HAL warmup). Pixel's
+         * BT chipset settles inside ~50 ms so it gets a small
+         * unnecessary silence prefix but no operator can detect an
+         * 80 ms front-of-tone latency delta. Was 50 ms tuned solely
+         * against AINA V1 — field observation 2026-07-11 on Tab5
+         * built-in speaker: leading chirp intermittently clipped.
          */
-        private const val SILENCE_PREROLL_MS: Int = 50
+        private const val SILENCE_PREROLL_MS: Int = 80
 
         // Trailing silence appended after the tone PCM so the
         // notification marker fires on silent samples — that way the
         // t.stop() call in finalize() flushes silence out of the
         // hardware output pipeline rather than the tone's last few ms.
-        // Matched to the preRoll size so total added latency (before +
-        // after) is symmetric.
-        private const val SILENCE_POSTROLL_MS: Int = 50
+        //
+        // 100 ms — the AudioTrack head-position counter (which the
+        // marker fires on) advances when samples are consumed by the
+        // DAC internal buffer, NOT when they physically leave the
+        // speaker. Pixel's DAC pipeline is 10-30 ms deep; Samsung
+        // Tab Active5's is larger. Was 50 ms and field-observed
+        // 2026-07-11 to occasionally clip the ASTRO 25 tone tail on
+        // Tab5 — the marker fires with the last 50 ms of tone still
+        // in the DAC and `t.stop()` cancels them. 100 ms gives
+        // margin for both device families without pushing perceived
+        // TPT-to-TX gap into operator-noticeable territory.
+        private const val SILENCE_POSTROLL_MS: Int = 100
     }
 }


### PR DESCRIPTION
## Field observation 2026-07-11

Samsung Galaxy Tab Active5 SM-X308U: ASTRO 25 TPT intermittently clipped at leading and/or trailing chirp on the built-in speaker route. Operator flagged as \"minor tweak needed.\"

## Log evidence

\`\`\`
09:20:23.752 playing ASTRO_25 (7200 tone + 2400 preRoll + 2400 postRoll = 12000 total samples, marker@12000, useSco=false)
09:20:23.956 ASTRO_25 marker reached — finalizing (playback complete)   ← 204ms after play, buffer is 250ms
09:20:23.974 TX transmitting started — frames will flow now             ← 18ms after marker
\`\`\`

Marker fires when the DAC has *consumed* the samples, not when they've *physically emitted*. On Pixel that gap is 10-30ms; on Samsung Tab Active5's speaker HAL it's larger. \`finalize()\`'s \`t.stop()\` at marker time cancels the in-flight samples — the last 40-60ms of tone tail gets clipped.

Same shape at the leading edge: 50ms preRoll was tuned against Pixel + AINA V1 BT chipset settling; Samsung's speaker HAL warmup can exceed that window, occasionally clipping the first chirp.

## Fix

Widen the silence padding constants in \`TptPlayer.kt:905-913\`:

- \`SILENCE_PREROLL_MS\`: 50 → **80 ms**
- \`SILENCE_POSTROLL_MS\`: 50 → **100 ms**

Sized for the highest-latency device in the current fleet without introducing operator-noticeable PTT-to-TX gap. Adds ~80 ms of total added latency per TPT burst, well under any operator's perceptual threshold. No API changes.

## Test plan

- [x] \`ktlintCheck\` — green
- [x] \`assembleCivDebug\` — green
- [x] \`testCivDebugUnitTest\` — green (existing TptPlayer + TxController tests continue to pass; the constants are load-bearing but the shape of the write / marker / finalize sequence is unchanged)
- [ ] On-device Samsung Tab Active5: press PTT 5-10 times, verify no ASTRO 25 chirp clipped at start or end
- [ ] On-device Pixel 9 Pro: press PTT 5-10 times, verify no regression in perceived TPT-to-TX latency
- [ ] Log post-fix should still show consistent marker-reached times relative to \`playing\` — expect ~250-280ms marker window instead of ~200ms

## Non-goals

- No per-device conditionals — the extra latency is negligible and applies uniformly.
- No SCO-tail-guard tuning (SCO_TAIL_GUARD_MS at 350ms is separate and covers the SCO path).
- No changes to any other tone (bonk / deny / status chirps / timeout cutoff) — they use their own wall-clock teardown paths.