### PR TITLE
feat(audio): nudge active-HFP for primary speakermic hint when audio device is Auto

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/audio/BtActiveDeviceController.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/BtActiveDeviceController.kt
@@ -215,28 +215,38 @@ object BtActiveDeviceController {
 }
 
 /**
- * Pure decision function for the override-routing state machine in
+ * Pure decision function for the target-routing state machine in
  * [ScoLink]. Extracted so unit tests can pin every branch without
  * standing up BluetoothAdapter / AudioManager / a live Context.
  *
+ * The "effective target" MAC is `overrideMac ?: hintMac`. The state
+ * machine treats both the same way — reflection nudge + switcher
+ * fallback — but the caller distinguishes them for toast wording
+ * (override vs. primary-speakermic-hint messaging). The extension to
+ * cover the hint case landed 2026-07-11 for the Auto + primary-AINA +
+ * secondary-BT-headset field scenario where the OS's active HFP peer
+ * is not the AINA hint and XV was silently falling through to whichever
+ * device the OS gave us in `getAvailableCommunicationDevices`.
+ *
  * Given the current state — override MAC, hint MAC, currently-available
  * comm-device MACs, last [BtActiveDeviceController.trySetActive] outcome
- * for the override, and the switcher-launch cooldown — return which
- * action the caller should take next.
+ * for the effective target, and the switcher-launch cooldown — return
+ * which action the caller should take next.
  *
  * The caller (production ScoLink) then executes the action:
- *   - [OverrideRoutingAction.PIN_DIRECT]: pin the override MAC directly;
- *     it's already in the available list.
+ *   - [OverrideRoutingAction.PIN_DIRECT]: pin the effective target MAC
+ *     directly; it's already in the available list.
  *   - [OverrideRoutingAction.TRY_REFLECTION]: call
- *     [BtActiveDeviceController.trySetActive]. On SUCCESS the caller
- *     polls the available list briefly and re-runs this decision.
+ *     [BtActiveDeviceController.trySetActive] against the effective
+ *     target. On SUCCESS the caller polls the available list briefly
+ *     and re-runs this decision.
  *   - [OverrideRoutingAction.LAUNCH_SWITCHER]: open the system output
  *     switcher panel (cooldown observed by the caller before invoking
  *     this — the decision has already checked it) and fall back to the
- *     hint for the current SCO acquire.
+ *     hint / auto chain for the current SCO acquire.
  *   - [OverrideRoutingAction.PIN_HINT]: skip the switcher (either
- *     nothing else to try, or cooldown not yet expired) and pin the
- *     hint MAC. Legacy behaviour.
+ *     no effective target to try, or cooldown not yet expired) and
+ *     pin whatever the hint / auto chain resolves to. Legacy behaviour.
  */
 enum class OverrideRoutingAction {
     PIN_DIRECT,
@@ -249,47 +259,60 @@ enum class OverrideRoutingAction {
  * See [OverrideRoutingAction] KDoc.
  *
  * @param overrideMac         The operator's explicit "Audio device"
- *                            override MAC. Null / blank → no override
- *                            active; caller should route by hint.
- * @param hintMac             The AINA hint MAC (fallback speakermic).
- *                            Not consulted directly by this decision —
- *                            passed through for symmetry so callers
- *                            can log both values from the same site.
+ *                            override MAC. Null / blank → no explicit
+ *                            override; caller should consult the hint.
+ * @param hintMac             The AINA hint MAC (primary speakermic
+ *                            picked from the AINA dropdown, or null
+ *                            when no AINA is paired). Used as the
+ *                            effective target when [overrideMac] is
+ *                            null / blank. Null / blank hint AND null
+ *                            override → PIN_HINT (nothing to nudge).
  * @param availableMacs       Set of MACs currently in
  *                            [android.media.AudioManager.getAvailableCommunicationDevices].
  *                            Compared case-insensitively via caller
  *                            upper-casing before the call.
  * @param reflectionCached    Previous [BtActiveDeviceController.trySetActive]
- *                            outcome for the override MAC, or null if
- *                            we haven't tried yet. Used to decide
- *                            whether reflection is worth attempting
- *                            again.
+ *                            outcome for the effective target MAC, or
+ *                            null if we haven't tried yet. Used to
+ *                            decide whether reflection is worth
+ *                            attempting again.
  * @param lastSwitcherLaunchMs Timestamp of the last switcher launch
  *                            (ms since boot), or 0L if none this
- *                            session.
+ *                            session. Cooldown is shared across both
+ *                            the override-target and hint-target paths
+ *                            — one switcher panel per 30 s regardless
+ *                            of which target triggered it.
  * @param nowMs               Current timestamp (ms since boot).
  * @param switcherCooldownMs  Minimum spacing between switcher launches.
  *                            Prevents focus-pull spam when the operator
- *                            hammers PTT while the override is out of
+ *                            hammers PTT while the target is out of
  *                            range.
  */
 fun decideOverrideAction(
     overrideMac: String?,
-    @Suppress("UNUSED_PARAMETER") hintMac: String?,
+    hintMac: String?,
     availableMacs: Set<String>,
     reflectionCached: BtActiveDeviceController.TrySetActiveResult?,
     lastSwitcherLaunchMs: Long,
     nowMs: Long,
     switcherCooldownMs: Long,
 ): OverrideRoutingAction {
-    if (overrideMac.isNullOrBlank()) return OverrideRoutingAction.PIN_HINT
-    val overrideUpper = overrideMac.uppercase()
-    if (availableMacs.contains(overrideUpper)) return OverrideRoutingAction.PIN_DIRECT
-    // Override present but not currently a comm device. If we've never
-    // tried reflection, try it — on Samsung / older builds it may
-    // succeed and the OS re-enumerates the override in.
+    // Effective target: explicit override wins; otherwise the hint MAC
+    // set by connectAinaInternal. Null / blank on both means there's
+    // nothing to nudge — the caller's existing hint / auto pick stands.
+    val target =
+        when {
+            !overrideMac.isNullOrBlank() -> overrideMac
+            !hintMac.isNullOrBlank() -> hintMac
+            else -> return OverrideRoutingAction.PIN_HINT
+        }
+    val targetUpper = target.uppercase()
+    if (availableMacs.contains(targetUpper)) return OverrideRoutingAction.PIN_DIRECT
+    // Target present but not currently a comm device. If we've never
+    // tried reflection for this target, try it — on Samsung / older
+    // builds it may succeed and the OS re-enumerates the target in.
     if (reflectionCached == null) return OverrideRoutingAction.TRY_REFLECTION
-    // Reflection already resolved. If it succeeded but the override
+    // Reflection already resolved. If it succeeded but the target
     // still isn't in the available set, we've hit a race or a platform
     // that accepts the API call without honoring it — fall through to
     // the switcher so the operator can complete the switch manually.
@@ -299,7 +322,7 @@ fun decideOverrideAction(
     // Reflection failed. Launch the switcher, but only if we're past
     // the per-session cooldown — otherwise the operator gets a panel
     // yanked over ATAK on every PTT press, which is worse than sitting
-    // on the hint.
+    // on the hint / auto pick.
     val cooldownExpired = (nowMs - lastSwitcherLaunchMs) >= switcherCooldownMs
     return if (cooldownExpired) {
         OverrideRoutingAction.LAUNCH_SWITCHER

--- a/app/src/main/java/com/atakmap/android/xv/audio/ScoLink.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/ScoLink.kt
@@ -189,49 +189,84 @@ class ScoLink(
             // and, if that fails, open the system output switcher so the
             // operator can pick manually. On SUCCESS, re-read the comm
             // devices briefly — if the override now appears, pin to it
-            // instead of the fallback. See [handleOverrideMissed] for
+            // instead of the fallback. See [handleTargetMissed] for
             // the decision tree.
-            val pinned = handleOverrideMissed(override)
+            val pinned = handleTargetMissed(override, isHint = false)
+            if (pinned != null) return pinned
+        } else if (result.hintMissed && override.isNullOrBlank() && !hint.isNullOrBlank()) {
+            // No explicit override — Auto path. The hint (primary AINA)
+            // is set but not currently a comm device. Field 2026-07-11:
+            // Pixel + AINA APTT + Shokz OpenMove both HFP-connected;
+            // OpenMove is the OS's active HFP and
+            // [AudioManager.availableCommunicationDevices] only returns
+            // OpenMove. Without a nudge, [pickBtCommDeviceFromCandidates]
+            // falls through to "first BT SCO" = OpenMove and audio routes
+            // to the wrong device. Same reflection → switcher fallback
+            // path as the override case, just against the hint MAC and
+            // with hint-side toast wording.
+            Log.w(
+                TAG,
+                "preferredBtMacHint ${com.atakmap.android.xv.aina.redactMac(hint)} not available " +
+                    "as comm device — attempting active-HFP nudge for primary speakermic",
+            )
+            val pinned = handleTargetMissed(hint, isHint = true)
             if (pinned != null) return pinned
         }
         return result.pick?.audioDevice as AudioDeviceInfo?
     }
 
     // ============================================================
-    // Override-unreachable handling (feat/bt-active-device-controller)
+    // Target-unreachable handling (feat/bt-active-device-controller +
+    // feat/bt-active-device-nudge-primary-hint)
     // ============================================================
     //
     // Timestamp of the last system output-switcher launch, ms since
-    // boot. Rate-limits the Intent so a stuck-out-of-range override
-    // + repeated PTT presses doesn't yank the system panel over ATAK
-    // every burst. See [SWITCHER_COOLDOWN_MS].
+    // boot. Rate-limits the Intent so a stuck-out-of-range target
+    // (either override or primary AINA hint) + repeated PTT presses
+    // doesn't yank the system panel over ATAK every burst. The
+    // cooldown is shared across both entry points — one switcher
+    // launch per 30 s regardless of which target triggered it. See
+    // [SWITCHER_COOLDOWN_MS].
     @Volatile
     private var lastSwitcherLaunchMs: Long = 0L
 
     /**
-     * Called from [pickBtCommDevice] when the override MAC is set but
-     * not in the currently-available comm-device list. Wraps the pure
-     * [decideOverrideAction] state machine and executes the resulting
-     * action:
+     * Called from [pickBtCommDevice] when the effective target MAC —
+     * either the operator's explicit "Audio device" override, or the
+     * primary AINA hint set by connectAinaInternal — is not currently a
+     * comm device in [AudioManager.availableCommunicationDevices]. Wraps
+     * the pure [decideOverrideAction] state machine and executes the
+     * resulting action:
      *
      *   - `PIN_DIRECT` never happens here (we're already inside the
      *     "miss" branch), but the enum includes it for the outer
      *     re-poll after a successful reflection.
-     *   - `TRY_REFLECTION`: call [BtActiveDeviceController.trySetActive].
-     *     On SUCCESS, poll [AudioManager.availableCommunicationDevices]
-     *     briefly and re-pin to the override if it now appears.
+     *   - `TRY_REFLECTION`: call [BtActiveDeviceController.trySetActive]
+     *     against [targetMac]. On SUCCESS, poll
+     *     [AudioManager.availableCommunicationDevices] briefly and
+     *     re-pin to [targetMac] if it now appears.
      *   - `LAUNCH_SWITCHER`: fire the media-output panel intent + a
      *     one-time toast so the operator knows what happened. Falls
-     *     through to `null` — the caller keeps the hint pin.
-     *   - `PIN_HINT`: no-op; caller keeps the hint pin. This is the
-     *     silent path taken while the cooldown is running.
+     *     through to `null` — the caller keeps the hint / auto pick.
+     *   - `PIN_HINT`: no-op; caller keeps the hint / auto pick. This
+     *     is the silent path taken while the cooldown is running.
      *
-     * Returns the override AudioDeviceInfo when reflection succeeded
-     * fast enough for the OS to re-enumerate — the caller pins to it
+     * @param targetMac The MAC we want to make the active HFP device.
+     * @param isHint    True when [targetMac] came from the AINA hint
+     *                  (Auto path). False when it came from the
+     *                  explicit override. Only affects the operator-
+     *                  facing toast wording — the reflection + switcher
+     *                  path itself is identical.
+     *
+     * Returns the target AudioDeviceInfo when reflection succeeded fast
+     * enough for the OS to re-enumerate — the caller pins to it
      * directly. Returns null when the caller should fall back to the
-     * hint / speaker.
+     * hint / auto chain.
      */
-    private fun handleOverrideMissed(overrideMac: String): AudioDeviceInfo? {
+    private fun handleTargetMissed(
+        targetMac: String,
+        isHint: Boolean,
+    ): AudioDeviceInfo? {
         val availableMacs =
             try {
                 audioManager.availableCommunicationDevices
@@ -240,17 +275,24 @@ class ScoLink(
             } catch (_: Throwable) {
                 emptySet()
             }
+        // Pass BOTH override and hint to the pure decision so the state
+        // machine sees the same view of the world as the caller. In the
+        // hint-side entry [targetMac] equals `hint` and `override` is
+        // null; in the override-side entry [targetMac] equals `override`
+        // and `hint` is passed through for completeness. The decision
+        // function resolves the effective target the same way we did.
+        val override = outputOverrideMac()
         val hint = preferredBtMac()
         // Peek at our per-MAC record of the last reflection outcome. We
         // maintain [lastReflectionByMac] alongside BtActiveDeviceController's
         // own cache because [decideOverrideAction] wants a nullable
         // "never tried this session" signal — the controller's cache
         // doesn't expose null vs. cached-but-uninteresting cleanly.
-        val cached = lastReflectionByMac[overrideMac.uppercase()]
+        val cached = lastReflectionByMac[targetMac.uppercase()]
         val nowMs = android.os.SystemClock.elapsedRealtime()
         val action =
             decideOverrideAction(
-                overrideMac = overrideMac,
+                overrideMac = override,
                 hintMac = hint,
                 availableMacs = availableMacs,
                 reflectionCached = cached,
@@ -260,25 +302,25 @@ class ScoLink(
             )
         Log.i(
             TAG,
-            "handleOverrideMissed(${com.atakmap.android.xv.aina.redactMac(overrideMac)}) → $action" +
+            "handleTargetMissed(${com.atakmap.android.xv.aina.redactMac(targetMac)}, isHint=$isHint) → $action" +
                 " (cached=${cached?.javaClass?.simpleName ?: "none"})",
         )
         return when (action) {
             OverrideRoutingAction.PIN_DIRECT -> null // structurally impossible here; caller path stands
             OverrideRoutingAction.PIN_HINT -> null
             OverrideRoutingAction.TRY_REFLECTION -> {
-                val result = BtActiveDeviceController.trySetActive(context, overrideMac)
-                lastReflectionByMac[overrideMac.uppercase()] = result
+                val result = BtActiveDeviceController.trySetActive(context, targetMac)
+                lastReflectionByMac[targetMac.uppercase()] = result
                 if (result is BtActiveDeviceController.TrySetActiveResult.Success) {
                     // Wait briefly for the OS to re-enumerate. 25 ms
                     // polls × 8 = ~200 ms budget, same shape as the
                     // startCommDevice readiness poll.
-                    val rePin = pollForOverrideAvailability(overrideMac)
+                    val rePin = pollForOverrideAvailability(targetMac)
                     if (rePin != null) {
                         Log.i(
                             TAG,
-                            "active HFP switched via reflection — pinning override " +
-                                com.atakmap.android.xv.aina.redactMac(overrideMac),
+                            "active HFP switched via reflection — pinning target " +
+                                com.atakmap.android.xv.aina.redactMac(targetMac),
                         )
                         return rePin
                     }
@@ -286,16 +328,16 @@ class ScoLink(
                     // move the device into the available list. Fall
                     // through to the switcher so the operator can
                     // complete the swap.
-                    Log.i(TAG, "reflection SUCCESS but override still absent — opening switcher")
-                    launchSwitcherIfPermitted(overrideMac, nowMs)
+                    Log.i(TAG, "reflection SUCCESS but target still absent — opening switcher")
+                    launchSwitcherIfPermitted(targetMac, nowMs, isHint)
                     return null
                 }
                 Log.d(TAG, "reflection non-success (${result.javaClass.simpleName}) — will consider switcher")
-                launchSwitcherIfPermitted(overrideMac, nowMs)
+                launchSwitcherIfPermitted(targetMac, nowMs, isHint)
                 null
             }
             OverrideRoutingAction.LAUNCH_SWITCHER -> {
-                launchSwitcherIfPermitted(overrideMac, nowMs)
+                launchSwitcherIfPermitted(targetMac, nowMs, isHint)
                 null
             }
         }
@@ -310,13 +352,13 @@ class ScoLink(
     private val lastReflectionByMac: MutableMap<String, BtActiveDeviceController.TrySetActiveResult> =
         java.util.Collections.synchronizedMap(HashMap())
 
-    private fun pollForOverrideAvailability(overrideMac: String): AudioDeviceInfo? {
-        val overrideUpper = overrideMac.uppercase()
+    private fun pollForOverrideAvailability(targetMac: String): AudioDeviceInfo? {
+        val targetUpper = targetMac.uppercase()
         val deadline = System.nanoTime() + POST_SET_ACTIVE_POLL_BUDGET_MS * 1_000_000L
         while (System.nanoTime() < deadline) {
             try {
                 val devs = audioManager.availableCommunicationDevices
-                val hit = devs.firstOrNull { macOf(it).equals(overrideUpper, ignoreCase = true) }
+                val hit = devs.firstOrNull { macOf(it).equals(targetUpper, ignoreCase = true) }
                 if (hit != null) return hit
             } catch (_: Throwable) {
             }
@@ -331,8 +373,9 @@ class ScoLink(
     }
 
     private fun launchSwitcherIfPermitted(
-        overrideMac: String,
+        targetMac: String,
         nowMs: Long,
+        isHint: Boolean,
     ) {
         if (nowMs - lastSwitcherLaunchMs < SWITCHER_COOLDOWN_MS) {
             Log.d(
@@ -343,7 +386,6 @@ class ScoLink(
             return
         }
         lastSwitcherLaunchMs = nowMs
-        val name = overrideDisplayName()
         // Toast on the main thread. Uses the device's display name
         // (from AudioRouter.availableBtOutputs) rather than the raw
         // MAC per CLAUDE.md sensitive-content rules. When the name
@@ -352,11 +394,26 @@ class ScoLink(
         // rather than fall back to the redacted MAC — a redacted MAC
         // in a Toast is worse UX than "system requires manual
         // selection" with no name.
+        //
+        // Wording differs slightly by target source. The override case
+        // is the explicit-picker path — operator picked a device and
+        // it's not reachable. The hint case is the Auto path with a
+        // primary AINA — operator didn't pick anything explicitly but
+        // the primary speakermic isn't where the OS is routing audio.
+        val name = overrideDisplayName()
         val msg =
-            if (!name.isNullOrBlank()) {
-                "Route override to $name: system requires manual selection. Opening switcher…"
+            if (isHint) {
+                if (!name.isNullOrBlank()) {
+                    "Primary speakermic ($name) not active — opening switcher to fix"
+                } else {
+                    "Primary speakermic (AINA) not active — opening switcher to fix"
+                }
             } else {
-                "Route override: system requires manual selection. Opening switcher…"
+                if (!name.isNullOrBlank()) {
+                    "Route override to $name: system requires manual selection. Opening switcher…"
+                } else {
+                    "Route override: system requires manual selection. Opening switcher…"
+                }
             }
         mainHandler.post {
             try {
@@ -364,14 +421,14 @@ class ScoLink(
                     .makeText(context, msg, android.widget.Toast.LENGTH_LONG)
                     .show()
             } catch (t: Throwable) {
-                Log.w(TAG, "override-unreachable toast threw", t)
+                Log.w(TAG, "target-unreachable toast threw", t)
             }
         }
         val launched = AudioRouter.launchSystemOutputSwitcher(context)
         Log.i(
             TAG,
-            "opened system output switcher for override " +
-                "${com.atakmap.android.xv.aina.redactMac(overrideMac)} launched=$launched",
+            "opened system output switcher for target " +
+                "${com.atakmap.android.xv.aina.redactMac(targetMac)} (isHint=$isHint) launched=$launched",
         )
     }
 
@@ -793,11 +850,18 @@ class ScoLink(
          * Outcome of the two-input selector [pickBtCommDeviceWithOverride].
          * [overrideMissed] is true when the caller passed an [overrideMac]
          * that didn't match any BT candidate — the production wrapper
-         * uses this signal to emit the fall-back warning log.
+         * uses this signal to emit the fall-back warning log and enter
+         * the active-HFP-nudge path. [hintMissed] is true when the
+         * override was null / blank AND a non-blank [hintMac] failed to
+         * match any BT candidate — the extension to the nudge path
+         * added 2026-07-11 for the Auto + primary-AINA + secondary-BT
+         * field scenario. Both flags are mutually exclusive: if
+         * [overrideMissed] fires the code never consults the hint side.
          */
         internal data class Selection(
             val pick: Candidate?,
             val overrideMissed: Boolean,
+            val hintMissed: Boolean = false,
         )
 
         /**
@@ -810,7 +874,11 @@ class ScoLink(
          *      single-arg selector on [hintMac], and flag the miss so
          *      the caller can log a warning.
          *   3. [overrideMac] null/blank → single-arg selector on
-         *      [hintMac] (legacy behavior).
+         *      [hintMac]. When [hintMac] is non-blank but doesn't
+         *      match any BT candidate, flag [Selection.hintMissed]
+         *      so the caller can attempt the active-HFP nudge for
+         *      the primary speakermic (Auto path — 2026-07-11 field
+         *      extension).
          *
          * Split out from [pickBtCommDevice] so tests can pin every
          * precedence branch without standing up AudioManager. See the
@@ -824,9 +892,25 @@ class ScoLink(
             hintMac: String?,
         ): Selection {
             if (overrideMac.isNullOrBlank()) {
+                val pick = pickBtCommDeviceFromCandidates(candidates, hintMac)
+                // Hint-missed only fires when the operator has a hint
+                // set (primary AINA MAC pushed by connectAinaInternal)
+                // AND that MAC didn't match any BT candidate. Blank
+                // hint = no speakermic paired at all; there's no
+                // primary target to nudge toward.
+                val hintMissed =
+                    !hintMac.isNullOrBlank() &&
+                        candidates.none {
+                            it.mac.equals(hintMac, ignoreCase = true) &&
+                                (
+                                    it.type == android.media.AudioDeviceInfo.TYPE_BLUETOOTH_SCO ||
+                                        it.type == android.media.AudioDeviceInfo.TYPE_BLUETOOTH_A2DP
+                                    )
+                        }
                 return Selection(
-                    pick = pickBtCommDeviceFromCandidates(candidates, hintMac),
+                    pick = pick,
                     overrideMissed = false,
+                    hintMissed = hintMissed,
                 )
             }
             // Override set — try to match it first. Use the same

--- a/app/src/test/java/com/atakmap/android/xv/audio/BtActiveDeviceControllerTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/audio/BtActiveDeviceControllerTest.kt
@@ -4,17 +4,35 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
- * Pure-Kotlin coverage for the override-routing decision function used
- * by [ScoLink.handleOverrideMissed]. Real reflective
+ * Pure-Kotlin coverage for the target-routing decision function used
+ * by [ScoLink.handleTargetMissed]. Real reflective
  * [BtActiveDeviceController.trySetActive] behavior varies by OEM /
  * platform release; the decision matrix around it does not, and is
  * pinned here so future refactors don't regress the "don't spam the
  * switcher" or "try reflection before giving up" contracts.
+ *
+ * The state machine handles two entry points via a single "effective
+ * target" concept:
+ *
+ *   - Explicit override — the operator picked a specific "Audio device"
+ *     in Settings and it isn't the OS's currently-active HFP peer.
+ *   - Primary AINA hint — Auto path with an AINA paired as primary
+ *     speakermic, but the OS's active HFP is some other BT device
+ *     (e.g. Shokz OpenMove that connected after the AINA). Added
+ *     2026-07-11 to fix a field observation on Pixel 9 Pro / API 35.
+ *
+ * Both use the same reflection → switcher fallback → cooldown path;
+ * the caller distinguishes them for toast wording only.
  */
 class BtActiveDeviceControllerTest {
     private val overrideMac = "AA:BB:CC:DD:EE:FF"
     private val hintMac = "11:22:33:44:55:66"
+    private val otherMac = "99:88:77:66:55:44"
     private val cooldown = 30_000L
+
+    // ============================================================
+    // Override path (PR #41 pinned behaviour — unchanged)
+    // ============================================================
 
     @Test
     fun `override present in available set — PIN_DIRECT`() {
@@ -164,8 +182,15 @@ class BtActiveDeviceControllerTest {
         assertEquals(OverrideRoutingAction.LAUNCH_SWITCHER, action)
     }
 
+    // ============================================================
+    // Hint path (2026-07-11 extension — Auto + primary AINA)
+    // ============================================================
+
     @Test
-    fun `override null — PIN_HINT (caller resolves absence of hint separately)`() {
+    fun `override null, hint present in available set — PIN_DIRECT`() {
+        // Effective target = hint. Hint is in the available set →
+        // pin directly. No override → the hint IS the effective
+        // target, not a fallback.
         val action =
             decideOverrideAction(
                 overrideMac = null,
@@ -176,11 +201,13 @@ class BtActiveDeviceControllerTest {
                 nowMs = 1_000L,
                 switcherCooldownMs = cooldown,
             )
-        assertEquals(OverrideRoutingAction.PIN_HINT, action)
+        assertEquals(OverrideRoutingAction.PIN_DIRECT, action)
     }
 
     @Test
-    fun `override blank — PIN_HINT`() {
+    fun `override blank, hint present in available set — PIN_DIRECT`() {
+        // Same as above with a whitespace override — !isBlank guard
+        // treats "   " as unset.
         val action =
             decideOverrideAction(
                 overrideMac = "   ",
@@ -191,19 +218,109 @@ class BtActiveDeviceControllerTest {
                 nowMs = 1_000L,
                 switcherCooldownMs = cooldown,
             )
+        assertEquals(OverrideRoutingAction.PIN_DIRECT, action)
+    }
+
+    @Test
+    fun `override null, hint absent from available set — TRY_REFLECTION on hint`() {
+        // Field 2026-07-11: Auto path, primary AINA hint set, available
+        // comm devices only include a different BT device (Shokz OpenMove
+        // is the OS's active HFP peer). Attempt the reflection nudge
+        // for the AINA MAC, same as the override case.
+        val action =
+            decideOverrideAction(
+                overrideMac = null,
+                hintMac = hintMac,
+                availableMacs = setOf(otherMac.uppercase()),
+                reflectionCached = null,
+                lastSwitcherLaunchMs = 0L,
+                nowMs = 1_000L,
+                switcherCooldownMs = cooldown,
+            )
+        assertEquals(OverrideRoutingAction.TRY_REFLECTION, action)
+    }
+
+    @Test
+    fun `override null, hint absent, reflection REFUSED, cooldown expired — LAUNCH_SWITCHER`() {
+        // Pixel 14+ path in the hint-side flow. Reflection was refused
+        // (platform-hardened setActiveDevice); cooldown has expired so
+        // the switcher fires. Toast wording differs at the caller (hint-
+        // side vs. override-side) but the decision itself is identical.
+        val action =
+            decideOverrideAction(
+                overrideMac = null,
+                hintMac = hintMac,
+                availableMacs = setOf(otherMac.uppercase()),
+                reflectionCached = BtActiveDeviceController.TrySetActiveResult.RefusedByPlatform,
+                lastSwitcherLaunchMs = 0L,
+                nowMs = cooldown + 1L,
+                switcherCooldownMs = cooldown,
+            )
+        assertEquals(OverrideRoutingAction.LAUNCH_SWITCHER, action)
+    }
+
+    @Test
+    fun `override null, hint absent, reflection REFUSED, cooldown not expired — PIN_HINT`() {
+        // Cooldown protects the operator from a torrent of switcher
+        // panels during rapid PTT — even on the hint-side path. Falls
+        // through to whatever the caller's hint / auto chain picks
+        // (typically the OS's active HFP peer).
+        val action =
+            decideOverrideAction(
+                overrideMac = null,
+                hintMac = hintMac,
+                availableMacs = setOf(otherMac.uppercase()),
+                reflectionCached = BtActiveDeviceController.TrySetActiveResult.RefusedByPlatform,
+                lastSwitcherLaunchMs = 100L,
+                nowMs = 100L + cooldown - 1L,
+                switcherCooldownMs = cooldown,
+            )
         assertEquals(OverrideRoutingAction.PIN_HINT, action)
     }
 
     @Test
-    fun `override null AND hint null — PIN_HINT (caller falls into speaker chain)`() {
-        // The spec calls out this case explicitly: when neither
-        // override nor hint is set we return PIN_HINT and let the
-        // caller's existing "no hint, speaker" logic take over. We
-        // don't invent a new state for it here.
+    fun `override null, hint absent, reflection SUCCESS but hint still absent — LAUNCH_SWITCHER`() {
+        // Same defensive branch as the override version: reflection
+        // reported success but the OS didn't re-enumerate the hint in.
+        val action =
+            decideOverrideAction(
+                overrideMac = null,
+                hintMac = hintMac,
+                availableMacs = setOf(otherMac.uppercase()),
+                reflectionCached = BtActiveDeviceController.TrySetActiveResult.Success,
+                lastSwitcherLaunchMs = 0L,
+                nowMs = 1_000L,
+                switcherCooldownMs = cooldown,
+            )
+        assertEquals(OverrideRoutingAction.LAUNCH_SWITCHER, action)
+    }
+
+    @Test
+    fun `override null, hint null — PIN_HINT (nothing to nudge)`() {
+        // Neither override nor hint is set — no effective target. Falls
+        // through to the caller's existing "no hint, speaker" chain
+        // without invoking the reflection / switcher path at all. Also
+        // the zero-cost path when no BT is paired.
         val action =
             decideOverrideAction(
                 overrideMac = null,
                 hintMac = null,
+                availableMacs = emptySet(),
+                reflectionCached = null,
+                lastSwitcherLaunchMs = 0L,
+                nowMs = 1_000L,
+                switcherCooldownMs = cooldown,
+            )
+        assertEquals(OverrideRoutingAction.PIN_HINT, action)
+    }
+
+    @Test
+    fun `override null, hint blank — PIN_HINT`() {
+        // Whitespace hint counts as unset, same as null.
+        val action =
+            decideOverrideAction(
+                overrideMac = null,
+                hintMac = "   ",
                 availableMacs = emptySet(),
                 reflectionCached = null,
                 lastSwitcherLaunchMs = 0L,

--- a/app/src/test/java/com/atakmap/android/xv/audio/ScoLinkPickerTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/audio/ScoLinkPickerTest.kt
@@ -285,4 +285,120 @@ class ScoLinkPickerTest {
         assertEquals(AudioDeviceInfo.TYPE_BLUETOOTH_SCO, result.pick!!.type)
         assertEquals(false, result.overrideMissed)
     }
+
+    // ============================================================
+    // hintMissed flag (2026-07-11 extension — Auto + primary AINA)
+    // ============================================================
+    //
+    // Regression coverage for the field observation where Auto + primary
+    // AINA + a secondary BT headset (Shokz OpenMove) resulted in audio
+    // routing to the headset instead of the AINA. The selector still
+    // returns the fallback pick (whatever the single-arg selector picks
+    // from the candidate list) but the caller uses [hintMissed] to
+    // decide whether to run the active-HFP-nudge state machine against
+    // the hint MAC.
+
+    @Test
+    fun `no override, hint present in candidates — hintMissed false`() {
+        // Baseline: hint is set AND matches a BT candidate. No nudge
+        // needed; the caller pins directly to the hint.
+        val list =
+            listOf(
+                sco("AA:BB:CC:DD:EE:FF"), // hint (AINA)
+                sco("11:22:33:44:55:66"), // OpenMove
+            )
+        val result =
+            ScoLink.pickBtCommDeviceWithOverride(
+                candidates = list,
+                overrideMac = null,
+                hintMac = "AA:BB:CC:DD:EE:FF",
+            )
+        assertEquals("AA:BB:CC:DD:EE:FF", result.pick!!.mac)
+        assertEquals(false, result.overrideMissed)
+        assertEquals(false, result.hintMissed)
+    }
+
+    @Test
+    fun `no override, hint missing from candidates — hintMissed true`() {
+        // Field 2026-07-11: Auto path with primary AINA set. The AINA
+        // MAC isn't in the candidate list because the OS's active HFP
+        // is a different device (Shokz OpenMove). The selector still
+        // returns the OpenMove SCO as a fallback pick — the caller uses
+        // [hintMissed] to fire the active-HFP nudge against the AINA
+        // MAC before returning that fallback.
+        val list =
+            listOf(
+                sco("11:22:33:44:55:66"), // OpenMove — the only comm device
+            )
+        val result =
+            ScoLink.pickBtCommDeviceWithOverride(
+                candidates = list,
+                overrideMac = null,
+                hintMac = "AA:BB:CC:DD:EE:FF", // AINA — not in candidates
+            )
+        assertEquals("11:22:33:44:55:66", result.pick!!.mac)
+        assertEquals(false, result.overrideMissed)
+        assertEquals(true, result.hintMissed)
+    }
+
+    @Test
+    fun `no override, null hint — hintMissed false (nothing to nudge toward)`() {
+        // No hint = no primary AINA paired. Nothing to nudge; the flag
+        // stays false and the caller's existing hint / auto chain stands.
+        val list = listOf(sco("11:22:33:44:55:66"))
+        val result =
+            ScoLink.pickBtCommDeviceWithOverride(
+                candidates = list,
+                overrideMac = null,
+                hintMac = null,
+            )
+        assertEquals("11:22:33:44:55:66", result.pick!!.mac)
+        assertEquals(false, result.overrideMissed)
+        assertEquals(false, result.hintMissed)
+    }
+
+    @Test
+    fun `no override, blank hint — hintMissed false`() {
+        val list = listOf(sco("11:22:33:44:55:66"))
+        val result =
+            ScoLink.pickBtCommDeviceWithOverride(
+                candidates = list,
+                overrideMac = null,
+                hintMac = "   ",
+            )
+        assertEquals(false, result.hintMissed)
+    }
+
+    @Test
+    fun `no override, hint absent, empty candidates — hintMissed true, pick null`() {
+        // No BT at all — but the operator still has a hint set. The flag
+        // fires so the caller can attempt the nudge even when there's
+        // nothing to fall back to (the nudge itself is a no-op with no
+        // candidates present; the caller still gets accurate state).
+        val result =
+            ScoLink.pickBtCommDeviceWithOverride(
+                candidates = emptyList(),
+                overrideMac = null,
+                hintMac = "AA:BB:CC:DD:EE:FF",
+            )
+        assertNull(result.pick)
+        assertEquals(true, result.hintMissed)
+    }
+
+    @Test
+    fun `override missed does not also set hintMissed`() {
+        // The two flags are mutually exclusive. When the override is
+        // set-but-missed, the caller enters the override-side of the
+        // nudge; hintMissed stays false regardless of whether the hint
+        // matches or not.
+        val list = listOf(sco("77:77:77:77:77:77")) // neither override nor hint
+        val result =
+            ScoLink.pickBtCommDeviceWithOverride(
+                candidates = list,
+                overrideMac = "AA:BB:CC:DD:EE:FF",
+                hintMac = "11:22:33:44:55:66",
+            )
+        assertEquals(true, result.overrideMissed)
+        assertEquals(false, result.hintMissed)
+    }
 }


### PR DESCRIPTION
## Summary

Extends PR #41's reflective-`setActiveDevice` + system-output-switcher
fallback so the nudge also fires on the **Auto** path when the primary
AINA hint isn't the OS's currently-active HFP peer. PR #41 only ran
the nudge when the operator had picked an explicit "Audio device"
override; this PR widens that to cover the "picked a primary but never
set an override" configuration, which is the common Auto-mode setup.

## Reproducer (field observation 2026-07-11)

On a Pixel-class handset with API 35:

1. Audio device set to **Auto** (no explicit override).
2. Primary AINA speakermic connected + persisted (an `APTT`-family
   puck). Hint MAC pushed via `connectAinaInternal`.
3. Second HFP-capable BT device also connected (Shokz OpenMove
   headphones observed in the field, but any HFP-capable BT device
   suffices — car BT stack, second headset, etc.).
4. OpenMove is the OS's currently-active HFP peer.
5. `AudioManager.getAvailableCommunicationDevices()` returns only
   OpenMove (+ Speaker, Earpiece).

Before this PR: `ScoLink.pickBtCommDeviceWithOverride` finds no override,
falls through to the single-arg selector on the hint. Hint doesn't match
any candidate, selector returns first BT SCO = OpenMove. Audio routes
to the wrong device silently — the operator's mental model is
"primary + Auto = AINA," but they hear peer voice out of the OpenMove.

After this PR: same flow, but `Selection.hintMissed` now fires, and
`ScoLink.handleTargetMissed(hint, isHint = true)` runs the same
reflection → switcher fallback state machine PR #41 uses for the
override case, with hint-side toast wording.

## Decision-table extension

`decideOverrideAction` now takes both `overrideMac` and `hintMac` and
resolves an effective target = `override ?: hint`. All PR #41 override-
path branches keep their semantics; the added hint branches:

| override | hint | available | reflection cache | cooldown | action |
|----------|------|-----------|------------------|----------|--------|
| null | Y | {Y} | — | — | `PIN_DIRECT` |
| null | Y | {Z} | none | — | `TRY_REFLECTION` on Y |
| null | Y | {Z} | REFUSED | expired | `LAUNCH_SWITCHER` (hint-side toast) |
| null | Y | {Z} | REFUSED | active | `PIN_HINT` (silent — no panel spam) |
| null | Y | {Z} | SUCCESS but Y absent | — | `LAUNCH_SWITCHER` |
| null | null | any | — | — | `PIN_HINT` (nothing to nudge) |

The 30 s switcher-launch cooldown is **shared** across the override and
hint paths — one panel per 30 s regardless of which target triggered
it. This prevents a rapid PTT loop from alternating override/hint and
firing two panels.

## Toast wording

- Override case (unchanged): `"Route override to <name>: system requires
  manual selection. Opening switcher…"`
- Hint case (new): `"Primary speakermic (<name>) not active — opening
  switcher to fix"` — omits the `(<name>)` segment when the display
  name isn't cached, per CLAUDE.md sensitive-content rules (never
  fall back to a redacted MAC in a Toast).

## Non-goals (Sunday production-freeze scope)

- No new permissions, no manifest changes, no AIDL bump.
- No AudioTrack / MediaSession routing changes — media path is
  separate.
- No new UI elements. Existing Settings picker + AINA dropdown drive
  the state machine.
- When the audio device is set to Speaker / Earpiece / a valid BT
  MAC override, the code path is unchanged. When no BT hint is
  set at all (no AINA paired) the new branch is a zero-cost no-op.

## Test plan

- [x] `./gradlew ktlintCheck` green
- [x] `./gradlew assembleCivDebug` green
- [x] `./gradlew testCivDebugUnitTest` green with new coverage
- [x] `BtActiveDeviceControllerTest` extended with 8 new hint-side
      cases (PIN_DIRECT / TRY_REFLECTION / LAUNCH_SWITCHER × cooldown
      / SUCCESS-but-absent / both-null / blank-hint) plus regression
      coverage that override-side cases still match PR #41 behaviour.
- [x] `ScoLinkPickerTest` extended with 5 new `hintMissed` cases
      (present / missed / null-hint / blank-hint / empty-candidates)
      plus a regression that `overrideMissed` and `hintMissed` are
      mutually exclusive.
- [ ] Field: Auto + primary AINA + a second HFP-capable BT device;
      confirm switcher panel opens on first PTT and audio routes to
      the AINA after operator selection.
- [ ] Field: Auto + primary AINA only (no second BT device);
      confirm zero panel launches and audio routes to the AINA as
      before.
- [ ] Field: explicit "Audio device" override that isn't reachable;
      confirm PR #41 behaviour is intact (override-side toast wording,
      switcher panel).

Base pattern: PR #41 (`3dd917d`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)