### PR TITLE
fix(ptt): External Button config-change respawns reader (mirror #35 for External slot)

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/aina/AinaReaderKindResolver.kt
+++ b/app/src/main/java/com/atakmap/android/xv/aina/AinaReaderKindResolver.kt
@@ -26,39 +26,21 @@ package com.atakmap.android.xv.aina
  * kinds ([AinaDeviceInfo.ButtonProtocol.SPP],
  * [AinaDeviceInfo.ButtonProtocol.BLE], [AinaDeviceInfo.ButtonProtocol.BLE_HID])
  * demands a reader.
+ *
+ * The AINA-specific "kind → hasReader" collapse lives here; the actual
+ * NO_OP / TEARDOWN_ONLY / RESPAWN decision matrix lives in the shared
+ * [PttReaderRespawnDecision] object so the External Button slot can
+ * reuse the same matrix without duplicating the truth table (see
+ * PR mirroring #35 for the External slot).
  */
 object AinaReaderKindResolver {
     /**
-     * What the caller should do with the currently-running reader in
-     * response to an operator kind flip.
+     * Historical alias for [PttReaderRespawnDecision.Decision]. Kept
+     * so existing call sites and tests continue to compile
+     * unchanged. New callers should reference the shared type
+     * directly.
      */
-    enum class Decision {
-        /**
-         * Nothing to do. Either the primary AINA isn't connected (so
-         * there's no live reader to worry about — the change is
-         * persist-only and takes effect on the next connect edge), or
-         * the new kind is functionally equivalent to the old kind
-         * (both "no reader" or both the same real reader kind).
-         */
-        NO_OP,
-
-        /**
-         * Tear the reader down but keep the audio route hint. Used
-         * when the operator flips from "SPP / BLE / BLE_HID" to
-         * "AUDIO_ONLY / UNKNOWN / null" — they still want the
-         * speakermic's HFP audio, they just don't want XV listening
-         * for button events on it.
-         */
-        TEARDOWN_ONLY,
-
-        /**
-         * Tear the current reader down AND spin up a new one under
-         * the new kind. Used for real-reader → real-reader flips
-         * (e.g. SPP → BLE when the operator manually corrects an
-         * SDP-cache misclassification).
-         */
-        RESPAWN,
-    }
+    typealias Decision = PttReaderRespawnDecision.Decision
 
     /**
      * Decide what to do given [currentKind] (the kind the running
@@ -67,31 +49,23 @@ object AinaReaderKindResolver {
      * primary AINA is currently connected — i.e. whether there IS a
      * live reader).
      *
-     * If [isConnected] is false, the decision is always [Decision.NO_OP]
-     * regardless of the kinds: the persistence write is the only side
-     * effect, and the next connect edge will pick up the new value via
-     * the existing per-MAC override path.
+     * If [isConnected] is false, the decision is always
+     * [PttReaderRespawnDecision.Decision.NO_OP] regardless of the
+     * kinds: the persistence write is the only side effect, and the
+     * next connect edge will pick up the new value via the existing
+     * per-MAC override path.
      */
     fun shouldRespawnReader(
         currentKind: AinaDeviceInfo.ButtonProtocol?,
         newKind: AinaDeviceInfo.ButtonProtocol?,
         isConnected: Boolean,
-    ): Decision {
-        if (!isConnected) return Decision.NO_OP
-        val currentHasReader = hasReader(currentKind)
-        val newHasReader = hasReader(newKind)
-        // "no reader → no reader" and identical reader kinds are both
-        // no-ops. Idempotent so a rapid toggle A → B → A doesn't churn
-        // the reader mid-tap.
-        if (!currentHasReader && !newHasReader) return Decision.NO_OP
-        if (currentKind == newKind) return Decision.NO_OP
-        // Live reader → "no reader": drop the reader, keep audio.
-        if (currentHasReader && !newHasReader) return Decision.TEARDOWN_ONLY
-        // Everything else (no reader → live, or live → different live)
-        // needs a fresh connect path so the SDP probe, retry logic,
-        // and callback wiring all get re-invoked.
-        return Decision.RESPAWN
-    }
+    ): PttReaderRespawnDecision.Decision =
+        PttReaderRespawnDecision.decide(
+            currentHasReader = hasReader(currentKind),
+            newHasReader = hasReader(newKind),
+            currentEqualsNew = currentKind == newKind,
+            isConnected = isConnected,
+        )
 
     /**
      * True iff the given kind demands a live button reader. Null +

--- a/app/src/main/java/com/atakmap/android/xv/aina/ExternalButtonReaderResolver.kt
+++ b/app/src/main/java/com/atakmap/android/xv/aina/ExternalButtonReaderResolver.kt
@@ -1,0 +1,102 @@
+package com.atakmap.android.xv.aina
+
+/**
+ * Pure decision logic for how to react to an operator config change on
+ * the External Button PTT slot. Mirrors [AinaReaderKindResolver] for
+ * the primary AINA slot — same NO_OP / TEARDOWN_ONLY / RESPAWN matrix
+ * routed through the shared [PttReaderRespawnDecision] — but the
+ * domain input is a MAC address rather than a button-protocol enum
+ * because the External Button slot's kind is auto-derived from the
+ * BluetoothDevice classification at connect time, not set by the
+ * operator.
+ *
+ * Reader lifecycle background: the External Button reader
+ * (AinaSppReader / AinaBleReader / PrymeBleReader) is spun up inside
+ * the voice service on every connectExternalButton call. The picker's
+ * on-select handler filters out same-MAC picks before calling into
+ * [Controller.setSelectedExternalButton], but any programmatic caller
+ * (post-restart auto-connect, debug intent, future automation) can
+ * hand the plugin a MAC that already matches the running reader OR a
+ * MAC that differs from the running one. This resolver centralises
+ * the "should we tear down the current reader?" decision so those
+ * callers all agree.
+ *
+ * Field bug it closes: on 2026-07-11 (Pixel 9 Pro, Pryme BT-PTT-Z puck)
+ * the picker showed the puck as "Connected" but physical button
+ * presses did NOT reach [XvVoicePlant] — no `external button PTT
+ * down=true` log lines. Only toggling the picker to "(none)" and back
+ * to the puck restarted the reader. Same class of reader-lifecycle
+ * race PR #35 fixed for the primary AINA — the External Button slot
+ * was left with the pre-existing behaviour and now exhibits the same
+ * bug shape. Mirror the fix: give the External slot the same
+ * config-change respawn path so a same-MAC re-select (or any
+ * programmatic re-attach) reliably re-runs the connect flow.
+ *
+ * A blank/null MAC means "no reader" — the operator picked "(none)"
+ * or hasn't picked anything. Any non-blank MAC demands a reader.
+ */
+object ExternalButtonReaderResolver {
+    /**
+     * Historical alias for [PttReaderRespawnDecision.Decision]. Kept
+     * so the External Button caller can reference a slot-local type
+     * name without cross-package churn if the shared decision moves
+     * in the future.
+     */
+    typealias Decision = PttReaderRespawnDecision.Decision
+
+    /**
+     * Decide what to do given [currentMac] (the MAC the running
+     * External Button reader — if any — was constructed under),
+     * [newMac] (the MAC the operator just picked, or null for
+     * "(none)"), and [isConnected] (whether the External Button slot
+     * is currently connected — i.e. whether there IS a live reader
+     * to touch).
+     *
+     * MAC comparison is case-insensitive to match the rest of XV's
+     * MAC-comparison surface (adapter.getRemoteDevice normalises to
+     * uppercase; picker input can be either case; the collision
+     * check against the primary in
+     * XvMapComponent.setSelectedExternalButtonInternal is
+     * case-insensitive).
+     *
+     * If [isConnected] is false, the decision is always
+     * [PttReaderRespawnDecision.Decision.NO_OP]: the persistence
+     * write is the only side effect, and the next connect edge
+     * (autoConnectExternalButton on plugin start) will pick up the
+     * new value.
+     */
+    fun shouldRespawnReader(
+        currentMac: String?,
+        newMac: String?,
+        isConnected: Boolean,
+    ): PttReaderRespawnDecision.Decision =
+        PttReaderRespawnDecision.decide(
+            currentHasReader = hasReader(currentMac),
+            newHasReader = hasReader(newMac),
+            currentEqualsNew = macsEqual(currentMac, newMac),
+            isConnected = isConnected,
+        )
+
+    /**
+     * True iff the given MAC represents a live external-button
+     * reader — i.e. it's non-null and non-blank. Blank / null both
+     * mean "operator picked (none)" — no reader.
+     */
+    private fun hasReader(mac: String?): Boolean = !mac.isNullOrBlank()
+
+    /**
+     * Case-insensitive MAC equality, tolerant of null/blank on either
+     * side. Blank strings are treated as null for this comparison so
+     * `"" == null` is true (both mean "no MAC").
+     */
+    private fun macsEqual(
+        a: String?,
+        b: String?,
+    ): Boolean {
+        val na = a?.takeIf { it.isNotBlank() }
+        val nb = b?.takeIf { it.isNotBlank() }
+        if (na == null && nb == null) return true
+        if (na == null || nb == null) return false
+        return na.equals(nb, ignoreCase = true)
+    }
+}

--- a/app/src/main/java/com/atakmap/android/xv/aina/PttReaderRespawnDecision.kt
+++ b/app/src/main/java/com/atakmap/android/xv/aina/PttReaderRespawnDecision.kt
@@ -1,0 +1,104 @@
+package com.atakmap.android.xv.aina
+
+/**
+ * Shared, slot-agnostic decision matrix for "operator changed the
+ * configuration of a PTT reader slot — what should the caller do with
+ * the currently-running reader?" Same NO_OP / TEARDOWN_ONLY / RESPAWN
+ * shape as the primary-AINA path added in PR #35, extracted so the
+ * External Button slot can reuse it verbatim rather than duplicating
+ * the decision table.
+ *
+ * The inputs are intentionally reduced to two booleans plus the
+ * connection state so callers with different "current" / "new" domain
+ * types (AINA button-protocol enum, external-button MAC string, some
+ * future third slot) can all funnel through the same pure logic. The
+ * domain-specific collapse (e.g. "AUDIO_ONLY / UNKNOWN / null all mean
+ * no reader" for the AINA slot; "null / blank MAC means no reader" for
+ * the external button slot) happens at the caller boundary.
+ *
+ * Callers should pass:
+ *  - [currentHasReader]: true iff a reader is currently constructed
+ *    under the caller's "current" value. For the primary AINA slot
+ *    this is `hasReader(currentKind)`; for the external button slot
+ *    this is `!currentMac.isNullOrBlank()`.
+ *  - [newHasReader]: same as above but for the "new" (operator-picked)
+ *    value.
+ *  - [currentEqualsNew]: true iff the "new" value is functionally
+ *    identical to the "current" value — same enum entry for AINA,
+ *    same MAC (case-insensitively) for external button. Used to
+ *    short-circuit `A → A` idempotently so a rapid toggle
+ *    `A → B → A` doesn't churn the reader mid-tap.
+ *  - [isConnected]: true iff there IS a live reader to touch. When
+ *    false, the decision is always [Decision.NO_OP] because the
+ *    persistence write is the only side effect and the next connect
+ *    edge will pick up the new value via the existing per-slot connect
+ *    path.
+ *
+ * See [AinaReaderKindResolver] for the primary-AINA specialization and
+ * [XvMapComponent.setSelectedExternalButtonInternal] for the external-
+ * button specialization.
+ */
+object PttReaderRespawnDecision {
+    /**
+     * What the caller should do with the currently-running reader in
+     * response to an operator config change on the slot.
+     */
+    enum class Decision {
+        /**
+         * Nothing to do. Either the slot isn't connected (so there's
+         * no live reader to worry about — the change is persist-only
+         * and takes effect on the next connect edge), or the new
+         * value is functionally equivalent to the old value (both
+         * "no reader" or both the same real reader value).
+         */
+        NO_OP,
+
+        /**
+         * Tear the reader down but keep any audio route hint. Used
+         * when the operator flips from "has reader" to "no reader"
+         * without disconnecting the device — for the AINA slot this
+         * is "SPP / BLE / BLE_HID → AUDIO_ONLY / UNKNOWN / null";
+         * for the external button slot this is "picked MAC → (none)"
+         * (the external button has no audio path, but the caller
+         * still models it as TEARDOWN_ONLY for symmetry).
+         */
+        TEARDOWN_ONLY,
+
+        /**
+         * Tear the current reader down AND spin up a new one under
+         * the new configuration. Used for real-reader → real-reader
+         * flips (kind changes on the AINA slot, MAC changes on the
+         * external button slot) and for "no reader" → real-reader
+         * transitions on an already-connected device.
+         */
+        RESPAWN,
+    }
+
+    /**
+     * Decide what the caller should do given the slot-agnostic
+     * booleans above. Pure — no Android runtime, no BT stack, no
+     * service AIDL.
+     */
+    fun decide(
+        currentHasReader: Boolean,
+        newHasReader: Boolean,
+        currentEqualsNew: Boolean,
+        isConnected: Boolean,
+    ): Decision {
+        if (!isConnected) return Decision.NO_OP
+        // "no reader → no reader" is a no-op even when connected;
+        // this is the "operator was on (none) and picked (none) again"
+        // or "AUDIO_ONLY → UNKNOWN" branch.
+        if (!currentHasReader && !newHasReader) return Decision.NO_OP
+        // Identical live configuration is a no-op — idempotent so
+        // a rapid A → B → A toggle doesn't churn the reader mid-tap.
+        if (currentEqualsNew) return Decision.NO_OP
+        // Live reader → "no reader": drop the reader, keep any audio
+        // route hint the caller layer wants to preserve.
+        if (currentHasReader && !newHasReader) return Decision.TEARDOWN_ONLY
+        // Everything else (no reader → live, or live → different
+        // live) needs a fresh connect path so any probe, retry logic,
+        // and callback wiring get re-invoked under the new config.
+        return Decision.RESPAWN
+    }
+}

--- a/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
+++ b/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
@@ -151,6 +151,18 @@ class XvMapComponent : AbstractMapComponent() {
     @Volatile
     private var reInitingReaderKind: Boolean = false
 
+    // Re-entry guard for [setSelectedExternalButtonInternal]. Same
+    // rationale as [reInitingReaderKind] but scoped to the External
+    // Button slot: the RESPAWN branch tears the old reader down
+    // (via voiceClient.disconnectExternalButton) and immediately
+    // re-attaches under the new MAC (via voiceClient.connectExternalButton),
+    // and we don't want a concurrent picker tap racing that sequence
+    // to double-teardown or leave a stale reader stitched to a
+    // disposed GATT client. Reset in a finally so an exception in
+    // the tear-down / respawn path doesn't wedge the guard on.
+    @Volatile
+    private var reInitingExternalButtonReader: Boolean = false
+
     // V2-AINA SDP-cache-gap probe — see [AinaProtocolProbe]. Lazily
     // constructed against the held plugin context.
     @Volatile
@@ -3065,36 +3077,167 @@ class XvMapComponent : AbstractMapComponent() {
     private fun ainaProbeFor(ctx: Context): com.atakmap.android.xv.aina.AinaProtocolProbe =
         ainaProbe ?: com.atakmap.android.xv.aina.AinaProtocolProbe(ctx).also { ainaProbe = it }
 
+    // Operator-driven External Button slot change (picker on-select,
+    // debug-intent MAC set, future automation). Persists the pick,
+    // then dispatches through [ExternalButtonReaderResolver] to decide
+    // whether the currently-running reader (if any) needs to be torn
+    // down and / or respawned under the new MAC.
+    //
+    // Field bug this closes: on 2026-07-11 (Pixel 9 Pro, Pryme
+    // BT-PTT-Z puck) the picker showed the puck as "Connected" but
+    // physical button presses did NOT reach XvVoicePlant — no
+    // `external button PTT down=true` events. Only after toggling
+    // the picker to "(none)" and then re-assigning the puck did
+    // events start dispatching. Same class of reader-lifecycle race
+    // PR #35 fixed for the primary AINA (button-protocol change on
+    // a connected device did not respawn the reader). Mirrors that
+    // fix by routing every operator-driven MAC change through the
+    // shared [PttReaderRespawnDecision] matrix and calling the same
+    // teardown → connect sequence the primary AINA path uses. See
+    // [ExternalButtonReaderResolver] for the pure decision.
+    //
+    // Reentry guarded because the tear-down + respawn is not atomic
+    // across the AIDL boundary — a concurrent picker tap racing the
+    // sequence could double-teardown or leave a stale reader stitched
+    // to a disposed GATT client.
     @SuppressWarnings("MissingPermission")
     private fun setSelectedExternalButtonInternal(mac: String?) {
-        settings.persistExternalButtonMac(mac)
-        if (mac.isNullOrBlank()) {
-            voiceClient?.ifBound { it.disconnectExternalButton() }
-            lastExternalButtonMac = null
-            lastExternalButtonConnected = false
-            settings.persistExternalButtonKind(null)
+        // Guarded against reentry from a picker tap racing an
+        // in-flight tear-down + respawn on the External Button slot.
+        // Same shape as [setAinaButtonProtocolInternal]'s
+        // [reInitingReaderKind] guard.
+        if (reInitingExternalButtonReader) {
+            Log.i(
+                TAG,
+                "setSelectedExternalButtonInternal: reader re-init already in flight — dropping " +
+                    "request for mac=${com.atakmap.android.xv.aina.redactMac(mac)}",
+            )
             return
         }
-        // Refuse silently if it collides with the primary — picker
-        // already filters it out, but defend in depth.
-        val primary = settings.persistedAinaMac()
-        if (primary != null && primary.equals(mac, ignoreCase = true)) {
-            Log.w(TAG, "setSelectedExternalButtonInternal: $mac collides with primary — ignored")
-            settings.persistExternalButtonMac(null)
-            return
+        // Normalise inputs before persist so the primary-collision
+        // check and the resolver's MAC comparison see the same
+        // string the picker offered up.
+        val normalizedNewMac = mac?.trim()?.takeIf { it.isNotBlank() }
+        // Refuse silently if the picked MAC collides with the
+        // primary — picker already filters it out, but defend in
+        // depth. Do this BEFORE persisting so we don't clobber a
+        // valid external-button pick with a bad one.
+        if (normalizedNewMac != null) {
+            val primary = settings.persistedAinaMac()
+            if (primary != null && primary.equals(normalizedNewMac, ignoreCase = true)) {
+                Log.w(
+                    TAG,
+                    "setSelectedExternalButtonInternal: ${com.atakmap.android.xv.aina.redactMac(normalizedNewMac)} " +
+                        "collides with primary — ignored",
+                )
+                // Clear any prior external-button pick to avoid a
+                // stale MAC pointing at the primary.
+                settings.persistExternalButtonMac(null)
+                return
+            }
         }
-        val kind = resolveConnectKind(mac)
-        Log.i(TAG, "setSelectedExternalButtonInternal: connecting $mac as kind=$kind")
-        settings.persistExternalButtonKind(kind)
-        lastExternalButtonMac = mac
-        voiceClient?.ifBound { it.connectExternalButton(mac, null, kind) }
-        // No service-side state-edge callback for the external button
-        // yet — optimistically cache "connected" so the UI shows
-        // progress. A future commit could thread an
-        // onExternalButtonConnectionChanged through the AIDL listener;
-        // for now the operator sees the picker status flip green on
-        // successful connect.
-        lastExternalButtonConnected = true
+        // Persist the pick. If the resolver decides NO_OP below, this
+        // is the only side effect — the next connect edge picks it up.
+        settings.persistExternalButtonMac(normalizedNewMac)
+
+        // Resolver inputs: [lastExternalButtonMac] is the MAC the
+        // plugin last handed to the service (source of truth for
+        // "what reader is currently running"), [normalizedNewMac] is
+        // the operator's new pick, and [isConnected] is
+        // [lastExternalButtonConnected] — the optimistic-cache flag
+        // set on connectExternalButton and cleared on disconnect.
+        val currentMac = lastExternalButtonMac
+        val isConnected = lastExternalButtonConnected
+        val decision =
+            com.atakmap.android.xv.aina.ExternalButtonReaderResolver.shouldRespawnReader(
+                currentMac = currentMac,
+                newMac = normalizedNewMac,
+                isConnected = isConnected,
+            )
+        Log.i(
+            TAG,
+            "setSelectedExternalButtonInternal: currentMac=${com.atakmap.android.xv.aina.redactMac(currentMac)} " +
+                "newMac=${com.atakmap.android.xv.aina.redactMac(normalizedNewMac)} " +
+                "isConnected=$isConnected → $decision",
+        )
+        when (decision) {
+            com.atakmap.android.xv.aina.PttReaderRespawnDecision.Decision.NO_OP -> {
+                // Persist-only path. If the operator picked (none) on
+                // an already-disconnected slot, still clear the kind
+                // so the next auto-connect doesn't try to reuse a
+                // stale kind string. If the operator picked the SAME
+                // MAC as the running reader, leave the kind persistence
+                // alone.
+                if (normalizedNewMac == null) {
+                    settings.persistExternalButtonKind(null)
+                }
+                return
+            }
+            com.atakmap.android.xv.aina.PttReaderRespawnDecision.Decision.TEARDOWN_ONLY -> {
+                // Operator picked (none) on a live reader. Tear down
+                // the reader and clear plugin-side bookkeeping. The
+                // External Button slot has no audio path, so unlike
+                // the primary AINA's TEARDOWN_ONLY there's nothing
+                // to preserve — a full [disconnectExternalButton] on
+                // the service is exactly right.
+                reInitingExternalButtonReader = true
+                try {
+                    voiceClient?.ifBound { it.disconnectExternalButton() }
+                    lastExternalButtonMac = null
+                    lastExternalButtonConnected = false
+                    settings.persistExternalButtonKind(null)
+                } finally {
+                    reInitingExternalButtonReader = false
+                }
+                return
+            }
+            com.atakmap.android.xv.aina.PttReaderRespawnDecision.Decision.RESPAWN -> {
+                // New MAC OR "no reader → live reader" transition on
+                // an already-connected slot. Resolve kind fresh (in
+                // case the operator scanned in a new BLE PTT device
+                // between config edits) and re-attach. VoicePlant's
+                // [connectExternalButton] already calls
+                // [disconnectExternalButton] at its entry point so
+                // we don't need a manual teardown here — one AIDL
+                // round-trip handles both edges. Guard covers the
+                // window between the plugin's persistExternalButtonKind
+                // and the service's reader flip so a concurrent
+                // config change can't race it.
+                //
+                // Precondition: RESPAWN implies newMac is non-null
+                // (the "live → no reader" flip lands in TEARDOWN_ONLY
+                // above; the "no reader → no reader" flip lands in
+                // NO_OP). Guarding with !! to make the contract
+                // explicit; a null here would be a decision-matrix
+                // bug worth surfacing loudly.
+                val newMac = requireNotNull(normalizedNewMac) {
+                    "ExternalButtonReaderResolver returned RESPAWN with null newMac"
+                }
+                val kind = resolveConnectKind(newMac)
+                reInitingExternalButtonReader = true
+                try {
+                    Log.i(
+                        TAG,
+                        "setSelectedExternalButtonInternal: connecting ${com.atakmap.android.xv.aina.redactMac(newMac)} " +
+                            "as kind=$kind",
+                    )
+                    settings.persistExternalButtonKind(kind)
+                    lastExternalButtonMac = newMac
+                    voiceClient?.ifBound { it.connectExternalButton(newMac, null, kind) }
+                    // No service-side state-edge callback for the
+                    // external button yet — optimistically cache
+                    // "connected" so the UI shows progress. A future
+                    // commit could thread an
+                    // onExternalButtonConnectionChanged through the
+                    // AIDL listener; for now the operator sees the
+                    // picker status flip green on successful connect.
+                    lastExternalButtonConnected = true
+                } finally {
+                    reInitingExternalButtonReader = false
+                }
+                return
+            }
+        }
     }
 
     // Shared MAC-format check for the scan-and-pick flow's primary /

--- a/app/src/test/java/com/atakmap/android/xv/aina/ExternalButtonReaderResolverTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/aina/ExternalButtonReaderResolverTest.kt
@@ -1,0 +1,202 @@
+package com.atakmap.android.xv.aina
+
+import com.atakmap.android.xv.aina.PttReaderRespawnDecision.Decision
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Coverage for the External Button reader-lifecycle decision matrix.
+ * Mirror of [AinaReaderKindResolverTest] but with MAC-based inputs
+ * because the External Button slot's kind is auto-derived at connect
+ * time rather than operator-configurable.
+ *
+ * Pins the field-bug fix from 2026-07-11 (Pixel 9 Pro, Pryme
+ * BT-PTT-Z puck): the picker showed "Connected" but button presses
+ * did not reach XvVoicePlant until the operator toggled the picker
+ * to "(none)" and re-selected the puck. Same class as PR #35's
+ * primary-AINA config-toggle bug — mirroring the fix here.
+ *
+ * Uses placeholder MACs per CLAUDE.md sensitive-content policy.
+ */
+class ExternalButtonReaderResolverTest {
+    private companion object {
+        const val PUCK_A = "AA:BB:CC:DD:EE:FF"
+        const val PUCK_B = "11:22:33:44:55:66"
+        const val PUCK_A_LOWER = "aa:bb:cc:dd:ee:ff"
+    }
+
+    // ---- Not-connected: every change is persist-only ----
+
+    @Test
+    fun `not connected — MAC change is a no-op`() {
+        assertEquals(
+            "picking a new MAC while the slot is idle is persist-only",
+            Decision.NO_OP,
+            ExternalButtonReaderResolver.shouldRespawnReader(
+                currentMac = null,
+                newMac = PUCK_A,
+                isConnected = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `not connected — MAC clear is a no-op`() {
+        assertEquals(
+            Decision.NO_OP,
+            ExternalButtonReaderResolver.shouldRespawnReader(
+                currentMac = PUCK_A,
+                newMac = null,
+                isConnected = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `not connected — same MAC pick is a no-op`() {
+        assertEquals(
+            Decision.NO_OP,
+            ExternalButtonReaderResolver.shouldRespawnReader(
+                currentMac = PUCK_A,
+                newMac = PUCK_A,
+                isConnected = false,
+            ),
+        )
+    }
+
+    // ---- Connected + no-op paths ----
+
+    @Test
+    fun `connected + same MAC same kind is a no-op (idempotent under rapid re-pick)`() {
+        // The 2026-07-11 field bug's happy-path variant: operator
+        // re-picks the currently-attached puck. Idempotent — no
+        // churn, no reader flap mid-transmission.
+        assertEquals(
+            Decision.NO_OP,
+            ExternalButtonReaderResolver.shouldRespawnReader(
+                currentMac = PUCK_A,
+                newMac = PUCK_A,
+                isConnected = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `connected + same MAC case-insensitive is a no-op`() {
+        // BluetoothAdapter.getRemoteDevice normalises to uppercase;
+        // the picker can hand back either case. The decision has to
+        // treat them as equivalent so a case-only "change" doesn't
+        // trigger a spurious respawn.
+        assertEquals(
+            Decision.NO_OP,
+            ExternalButtonReaderResolver.shouldRespawnReader(
+                currentMac = PUCK_A,
+                newMac = PUCK_A_LOWER,
+                isConnected = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `connected + blank MAC on both sides is a no-op`() {
+        // Rare: operator re-picks (none) when already on (none).
+        // No reader running, no change to make.
+        assertEquals(
+            Decision.NO_OP,
+            ExternalButtonReaderResolver.shouldRespawnReader(
+                currentMac = null,
+                newMac = null,
+                isConnected = true,
+            ),
+        )
+        assertEquals(
+            Decision.NO_OP,
+            ExternalButtonReaderResolver.shouldRespawnReader(
+                currentMac = "",
+                newMac = null,
+                isConnected = true,
+            ),
+        )
+        assertEquals(
+            Decision.NO_OP,
+            ExternalButtonReaderResolver.shouldRespawnReader(
+                currentMac = null,
+                newMac = "  ",
+                isConnected = true,
+            ),
+        )
+    }
+
+    // ---- Connected + TEARDOWN_ONLY ----
+
+    @Test
+    fun `connected + MAC cleared to null tears down`() {
+        // Operator picked (none) on a live external button. The
+        // existing workaround path — before this fix, the ONLY way
+        // to re-attach a stuck reader.
+        assertEquals(
+            Decision.TEARDOWN_ONLY,
+            ExternalButtonReaderResolver.shouldRespawnReader(
+                currentMac = PUCK_A,
+                newMac = null,
+                isConnected = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `connected + MAC cleared to blank tears down`() {
+        assertEquals(
+            Decision.TEARDOWN_ONLY,
+            ExternalButtonReaderResolver.shouldRespawnReader(
+                currentMac = PUCK_A,
+                newMac = "",
+                isConnected = true,
+            ),
+        )
+    }
+
+    // ---- Connected + RESPAWN ----
+
+    @Test
+    fun `connected + MAC swap respawns`() {
+        // Operator swapped from Puck A to Puck B on a live slot.
+        // Full teardown + reconnect so the new device gets its
+        // classification / connect flow re-run under the new MAC.
+        assertEquals(
+            Decision.RESPAWN,
+            ExternalButtonReaderResolver.shouldRespawnReader(
+                currentMac = PUCK_A,
+                newMac = PUCK_B,
+                isConnected = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `connected + null to MAC respawns`() {
+        // Operator was on (none) with the slot still marked connected
+        // (rare — probably a stale flag, but the resolver handles
+        // it: since new mac is real, we need to attach a reader).
+        assertEquals(
+            Decision.RESPAWN,
+            ExternalButtonReaderResolver.shouldRespawnReader(
+                currentMac = null,
+                newMac = PUCK_A,
+                isConnected = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `connected + blank to MAC respawns`() {
+        assertEquals(
+            Decision.RESPAWN,
+            ExternalButtonReaderResolver.shouldRespawnReader(
+                currentMac = "",
+                newMac = PUCK_A,
+                isConnected = true,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/atakmap/android/xv/aina/PttReaderRespawnDecisionTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/aina/PttReaderRespawnDecisionTest.kt
@@ -1,0 +1,141 @@
+package com.atakmap.android.xv.aina
+
+import com.atakmap.android.xv.aina.PttReaderRespawnDecision.Decision
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Coverage for the slot-agnostic decision matrix shared between
+ * [AinaReaderKindResolver] (primary AINA button-protocol slot) and
+ * [ExternalButtonReaderResolver] (External Button MAC slot). Both
+ * slots collapse their domain input (enum vs. MAC) to the same
+ * `(currentHasReader, newHasReader, currentEqualsNew)` triple and
+ * feed it here, so this test pins the truth table both specialisations
+ * inherit from.
+ *
+ * Same semantic contract as the old
+ * [AinaReaderKindResolverTest] — see that file for the
+ * enum-specialised cases the primary AINA path exercises.
+ */
+class PttReaderRespawnDecisionTest {
+    // ---- Not-connected: every change is persist-only ----
+
+    @Test
+    fun `not connected — all inputs collapse to NO_OP`() {
+        // Persist-only writes happen at the caller regardless; the
+        // reader decision is "there is no reader to touch."
+        for (currentHasReader in listOf(false, true)) {
+            for (newHasReader in listOf(false, true)) {
+                for (currentEqualsNew in listOf(false, true)) {
+                    assertEquals(
+                        "not connected: current=$currentHasReader new=$newHasReader " +
+                            "eq=$currentEqualsNew should be NO_OP",
+                        Decision.NO_OP,
+                        PttReaderRespawnDecision.decide(
+                            currentHasReader = currentHasReader,
+                            newHasReader = newHasReader,
+                            currentEqualsNew = currentEqualsNew,
+                            isConnected = false,
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    // ---- Connected, both "no reader" ----
+
+    @Test
+    fun `connected + no reader on either side is NO_OP regardless of equality`() {
+        // Both AinaReaderKindResolver's "AUDIO_ONLY → UNKNOWN" branch
+        // and ExternalButtonReaderResolver's "(none) → (none)" branch
+        // land here.
+        assertEquals(
+            Decision.NO_OP,
+            PttReaderRespawnDecision.decide(
+                currentHasReader = false,
+                newHasReader = false,
+                currentEqualsNew = false,
+                isConnected = true,
+            ),
+        )
+        assertEquals(
+            Decision.NO_OP,
+            PttReaderRespawnDecision.decide(
+                currentHasReader = false,
+                newHasReader = false,
+                currentEqualsNew = true,
+                isConnected = true,
+            ),
+        )
+    }
+
+    // ---- Connected, same live config ----
+
+    @Test
+    fun `connected + identical live config is NO_OP (idempotent under rapid A → A toggle)`() {
+        // Rapid picker double-tap or programmatic re-pick of the
+        // currently-attached MAC / kind. Idempotent so the reader
+        // doesn't churn mid-transmission.
+        assertEquals(
+            Decision.NO_OP,
+            PttReaderRespawnDecision.decide(
+                currentHasReader = true,
+                newHasReader = true,
+                currentEqualsNew = true,
+                isConnected = true,
+            ),
+        )
+    }
+
+    // ---- Connected, live → no reader → TEARDOWN_ONLY ----
+
+    @Test
+    fun `connected + live to no reader tears down`() {
+        // Operator flipped from a real reader to (none) / AUDIO_ONLY.
+        assertEquals(
+            Decision.TEARDOWN_ONLY,
+            PttReaderRespawnDecision.decide(
+                currentHasReader = true,
+                newHasReader = false,
+                currentEqualsNew = false,
+                isConnected = true,
+            ),
+        )
+    }
+
+    // ---- Connected, no reader → live → RESPAWN ----
+
+    @Test
+    fun `connected + no reader to live respawns`() {
+        // Operator was on (none) / AUDIO_ONLY and just picked a real
+        // reader on a slot that's already "connected" (audio route
+        // pinned but reader not attached).
+        assertEquals(
+            Decision.RESPAWN,
+            PttReaderRespawnDecision.decide(
+                currentHasReader = false,
+                newHasReader = true,
+                currentEqualsNew = false,
+                isConnected = true,
+            ),
+        )
+    }
+
+    // ---- Connected, live → different live → RESPAWN ----
+
+    @Test
+    fun `connected + live to different live respawns`() {
+        // Operator swapped MAC / flipped kind on an already-attached
+        // reader — need the full connect path to re-run.
+        assertEquals(
+            Decision.RESPAWN,
+            PttReaderRespawnDecision.decide(
+                currentHasReader = true,
+                newHasReader = true,
+                currentEqualsNew = false,
+                isConnected = true,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Mirror of #35's primary-AINA fix, applied to the External Button PTT slot.

### Field observation
Pixel 9 Pro, bonded BLE PTT puck picked in Settings -> External Button.
Picker showed the puck as "Connected" but physical button presses did
NOT reach XvVoicePlant -- no `external button PTT down=true` events.
Operator toggled the picker to "(none)" and re-assigned the puck; only
then did events start dispatching. Same reader-lifecycle race class
that #35 fixed for the primary AINA slot -- the External Button slot
was left with the pre-existing pre-#35 behaviour and now exhibits the
same bug shape on a same-MAC re-select or a persist-only path.

### Root cause pattern
Persist-only config change on a live slot did not tear down + respawn
the reader. Same reader-lifecycle gap #35 closed for the primary AINA
button-protocol change, adapted to the External Button slot where the
operator input is a MAC rather than a button-protocol enum.

## Decision matrix

Shared truth table extracted into `PttReaderRespawnDecision` (slot-
agnostic). Both `AinaReaderKindResolver` (primary AINA) and the new
`ExternalButtonReaderResolver` collapse their domain input to
`(currentHasReader, newHasReader, currentEqualsNew, isConnected)` and
funnel through the shared `decide()`.

| current | new | isConnected | Decision |
| --- | --- | --- | --- |
| any | any | false | NO_OP (persist-only) |
| no reader | no reader | true | NO_OP |
| live | same live | true | NO_OP (idempotent) |
| live | no reader | true | TEARDOWN_ONLY |
| no reader | live | true | RESPAWN |
| live | different live | true | RESPAWN |

For the External Button slot:
- "no reader" = null / blank MAC
- "live" = non-blank MAC
- currentEqualsNew = case-insensitive MAC equality (matches how
  `BluetoothAdapter.getRemoteDevice` normalises)

## Shared or separate?

**Shared.** `PttReaderRespawnDecision` is the pure truth table; both
slots' specialisations (`AinaReaderKindResolver` for the button-
protocol enum, `ExternalButtonReaderResolver` for the MAC string)
delegate to it. `AinaReaderKindResolver.Decision` is preserved as a
`typealias` to `PttReaderRespawnDecision.Decision` so #35's existing
call sites and 14 tests compile unchanged.

## Reader-lifecycle wiring

- `XvMapComponent.setSelectedExternalButtonInternal` rewritten to
  dispatch through `ExternalButtonReaderResolver`.
  - `NO_OP` -> persist-only (same-MAC re-pick on a live slot, or
    (none) re-pick on an already-empty slot).
  - `TEARDOWN_ONLY` -> `voiceClient.disconnectExternalButton()`
    (which `dispose()`s the underlying `BitmaskGattPttReader` per
    #39). No double-dispose because `VoicePlant.connectExternalButton`
    already calls `disconnectExternalButton` at its entry point, so
    a subsequent connect handles both edges in one AIDL round-trip.
  - `RESPAWN` -> re-resolve kind via existing `resolveConnectKind` +
    `voiceClient.connectExternalButton(mac, null, kind)`.
- Reentry guard `reInitingExternalButtonReader` (Volatile, `finally`-
  reset) mirrors `reInitingReaderKind` from #35.
- Primary-MAC collision check moved BEFORE the persist so a bad
  pick can't clobber a valid prior External Button pick.
- MAC normalisation (trim + blank-collapse to null) happens once at
  the top of the setter so the resolver sees canonical inputs.

## Config-change entry points

Only one plugin-side entry point mutates the External Button slot
at runtime: `setSelectedExternalButtonInternal`, called by the
Controller's `setSelectedExternalButton` from the picker on-select
handler and from `showBlePttScanDialog`'s assign-to-slot callback.
`autoConnectExternalButton` and `connectSavedExternalButton` are
plugin-start-only paths and NOT re-entered on config change, so
they don't need the decision guard -- their initial-attach path is
unchanged. Grep-verified in the diff.

## Tests

- `PttReaderRespawnDecisionTest` (6 cases): pins the shared truth
  table both specialisations inherit from.
- `ExternalButtonReaderResolverTest` (11 cases): MAC-specialised
  matrix including case-insensitive equality, blank/whitespace
  MACs, not-connected persist-only, connected clear-to-null
  teardown, connected MAC-swap respawn, connected null-to-MAC
  respawn.
- `AinaReaderKindResolverTest` (14 cases from #35): continues to
  pass against the shared decision via the typealias -- no
  behavioural drift for the primary AINA slot.

Ordering / scope guarantees: no primary-AINA path changes, no AIDL
bumps, no new permissions, no picker-UI change, no auto-connect
behaviour change, no reader-status indicator.

## Reference

Design template: #35 (primary AINA button-protocol change on a
connected device respawns the reader).

## Expected behaviour (not fixed here)

The ~2-4 s delay between picking a fresh BLE PTT puck and button
events starting to flow is EXPECTED: GATT connect + service
discovery + notify-characteristic subscribe over BLE takes that
long. Not a bug. A picker-side "Attaching..." status is UX polish
tracked separately.

## Test plan

- [ ] Bond a BLE PTT puck (Pryme BT-PTT-Z or similar).
- [ ] Open Settings -> External Button, pick the puck. Verify
      picker shows the device selected.
- [ ] Wait 3-5 s for GATT + service discovery + notify subscribe.
- [ ] Press physical button. Confirm logcat shows
      `external button PTT down=true`.
- [ ] Re-open Settings, re-select the SAME puck (same-MAC re-pick).
      Confirm logcat shows `currentMac=... newMac=... isConnected=true
      -> NO_OP` and the reader does NOT churn / re-attach.
- [ ] Toggle picker to (none). Confirm logcat shows
      `... -> TEARDOWN_ONLY` and button presses stop dispatching.
- [ ] Re-select the puck. Confirm logcat shows `... -> RESPAWN`,
      wait for GATT re-attach, confirm button events flow again.
- [ ] Pair a second bonded BLE PTT device (or use two pucks).
      Select puck A, wait for attach, then swap to puck B.
      Confirm logcat shows `... -> RESPAWN`, puck A's events stop,
      puck B's events start.
- [ ] Reproduce the field bug: cold-start the plugin with a puck
      already persisted to the External Button slot. Wait for
      auto-connect. If a picker interaction lands on the puck's
      current MAC (which the pre-fix path would have needed
      toggle-to-none-then-back to recover from), verify the fix
      now handles it via NO_OP (if reader is running) or RESPAWN
      (if reader failed to attach on the auto-connect edge).
- [ ] `./gradlew ktlintCheck` green.
- [ ] `./gradlew assembleCivDebug` green.
- [ ] `./gradlew testCivDebugUnitTest` green (new resolver suites
      pass; #35's 14-case AinaReaderKindResolverTest still passes
      through the typealias).

Generated with [Claude Code](https://claude.com/claude-code)