### PR TITLE
fix(ptt): cellular gate treats MODE_IN_COMMUNICATION as external call when XV has no own call (Pixel VoLTE)

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/service/PttCellularGate.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/PttCellularGate.kt
@@ -126,21 +126,75 @@ const val CELLULAR_BLOCK_TOAST_THROTTLE_MS: Long = 3_000L
  *
  * Correspondence:
  * - [AudioManager.MODE_IN_CALL] → [TelephonyManager.CALL_STATE_OFFHOOK]:
- *   the telephony stack sets MODE_IN_CALL whenever a cellular call is
- *   in the OFFHOOK (connected) state.
+ *   the telephony stack sets MODE_IN_CALL whenever a legacy CSFB /
+ *   circuit-switched cellular call is in the OFFHOOK (connected)
+ *   state. Pre-VoLTE handsets and VoLTE-disabled carrier profiles
+ *   still land here.
  * - [AudioManager.MODE_RINGTONE] → [TelephonyManager.CALL_STATE_RINGING]:
  *   set while an inbound call is ringing.
- * - Everything else → [TelephonyManager.CALL_STATE_IDLE]. In particular
- *   [AudioManager.MODE_IN_COMMUNICATION] is what XV's OWN self-managed
- *   Telecom call uses (see AudioControllerImpl.enterTx) — mapping it
- *   to OFFHOOK here would gate ourselves out of every subsequent PTT
- *   press. MODE_NORMAL, MODE_CURRENT, and MODE_INVALID all fall to
- *   IDLE for the same fail-open rationale as
+ * - [AudioManager.MODE_IN_COMMUNICATION]: **ambiguous on modern
+ *   Android.** Two independent things put the device into
+ *   MODE_IN_COMMUNICATION:
+ *     1. XV's OWN self-managed Telecom call (see
+ *        AudioControllerImpl.enterTx and
+ *        XvVoiceService.placeTelecomCallInternal). Mapping this to
+ *        OFFHOOK would self-gate every PTT during an active burst.
+ *     2. On modern (API ≥ 30) Pixel/Samsung/etc. handsets with
+ *        VoLTE-enabled cellular — which is the default on every
+ *        major US carrier now — the telephony stack ALSO uses
+ *        MODE_IN_COMMUNICATION for the real cellular call instead
+ *        of the legacy MODE_IN_CALL. Same audio mode as any other
+ *        VoIP app (Signal, WhatsApp, Discord, Meet, etc.). Field
+ *        evidence from Pixel 9 Pro / API 35 (2026-07-11): the OS
+ *        reported "OnAudioModeChanged: update mode from
+ *        IN_COMMUNICATION to NORMAL" as a live VoLTE voicemail
+ *        call hung up. The old MODE_IN_COMMUNICATION → IDLE
+ *        mapping incorrectly treated that as "not a phone call",
+ *        allowed the on-screen PTT, and let XV's self-managed
+ *        Telecom call auto-hold the operator's live call.
+ *   Disambiguate at the call site: if XV already has an active
+ *   self-managed Telecom call ([xvHasActiveTelecomCall] = true),
+ *   MODE_IN_COMMUNICATION is OURS → IDLE (do not self-gate).
+ *   Otherwise MODE_IN_COMMUNICATION is somebody else's call
+ *   (VoLTE cellular, or another VoIP app) → OFFHOOK (block the
+ *   on-screen PTT so we do not auto-hold their call).
+ * - Everything else → [TelephonyManager.CALL_STATE_IDLE].
+ *   MODE_NORMAL, MODE_CURRENT, and MODE_INVALID all fall to IDLE
+ *   for the same fail-open rationale as
  *   [shouldGateForCellularCall].
+ *
+ * [xvHasActiveTelecomCall] is sampled at the moment the gate runs
+ * — supplied by the caller from
+ * [com.atakmap.android.xv.telecom.ActiveCallRegistry.hasActiveCall].
+ * The registration and unregistration lifecycle is driven by
+ * XvConnection.onDestroy / teardownLocal, which is invoked by the
+ * TELECOM_END_DEBOUNCE_MS runnable in XvVoiceService — so the
+ * "our own call" flag stays true across the 8 s post-activity
+ * wind-down and drops only after Telecom has actually torn our
+ * connection down.
  */
-fun cellularCallStateFromAudioMode(audioMode: Int): Int =
+fun cellularCallStateFromAudioMode(
+    audioMode: Int,
+    xvHasActiveTelecomCall: Boolean,
+): Int =
     when (audioMode) {
         AudioManager.MODE_IN_CALL -> TelephonyManager.CALL_STATE_OFFHOOK
         AudioManager.MODE_RINGTONE -> TelephonyManager.CALL_STATE_RINGING
+        AudioManager.MODE_IN_COMMUNICATION ->
+            if (xvHasActiveTelecomCall) {
+                // OUR own Telecom call is holding MODE_IN_COMMUNICATION.
+                // Do not gate the operator out of their own follow-up
+                // presses inside a burst / the end-debounce window.
+                TelephonyManager.CALL_STATE_IDLE
+            } else {
+                // Nobody in XV placed a call, yet the device is in
+                // MODE_IN_COMMUNICATION. Somebody else did — VoLTE
+                // cellular is the field-observed case, but any other
+                // VoIP app in the foreground would land here too.
+                // Treat as an active external call: block the
+                // accident-prone on-screen PTT so we do not
+                // auto-hold their call by placing our own.
+                TelephonyManager.CALL_STATE_OFFHOOK
+            }
         else -> TelephonyManager.CALL_STATE_IDLE
     }

--- a/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
@@ -56,11 +56,66 @@ import com.atakmap.android.xv.ptt.SonimPttButtonReader
 class VoicePlant(
     private val context: Context,
     private val callbacks: Callbacks,
+    // Probe: does XV have a live self-managed Telecom Connection right
+    // now? Injected so unit tests can drive the "own call vs external
+    // call" branch of [cellularCallStateFromAudioMode] without a real
+    // Telecom registry or Robolectric. Defaults to reading
+    // [ActiveCallRegistry.hasActiveCall], which flips true the moment
+    // XvConnectionService registers a fresh XvConnection and flips
+    // back to false when XvConnection.onDestroy / teardownLocal fires
+    // — driven by the TELECOM_END_DEBOUNCE_MS runnable in
+    // XvVoiceService. That means the flag stays true across the whole
+    // 8 s post-activity wind-down of a burst (so mid-burst PTT
+    // presses do not self-gate) and only drops after Telecom has
+    // actually torn our connection down (so a fresh cellular call
+    // arriving after the debounce ends is correctly seen as
+    // external).
+    //
+    // Why we need this: on modern Pixel / Samsung / Motorola handsets
+    // with VoLTE cellular (the default on every major US carrier),
+    // the OS uses MODE_IN_COMMUNICATION for the *real* cellular call
+    // — the same audio mode XV's own self-managed Telecom call uses,
+    // and the same mode any other VoIP app (Signal, WhatsApp,
+    // Discord, Meet) uses. AudioManager.getMode() alone cannot tell
+    // "we placed this call" from "the cellular stack / another VoIP
+    // app placed this call". Combining getMode() with a lookup of
+    // our own connection state disambiguates: same MODE_IN_COMMUNICATION
+    // reading means IDLE when it's our call (do not self-gate) and
+    // OFFHOOK when it's theirs (block the accident-prone on-screen
+    // PTT so we do not auto-hold their call by placing our own on
+    // top). Field evidence for the ambiguity: Pixel 9 Pro / API 35,
+    // 2026-07-11 — a VoLTE voicemail call put the device in
+    // MODE_IN_COMMUNICATION; the old getMode()-only mapping treated
+    // that as IDLE, allowed the on-screen PTT, and let XV's Telecom
+    // call auto-hold the operator's live cellular call.
+    private val xvHasActiveTelecomCallProvider: () -> Boolean = {
+        try {
+            com.atakmap.android.xv.telecom.ActiveCallRegistry
+                .hasActiveCall()
+        } catch (t: Throwable) {
+            // Registry is a plain object with a volatile field read —
+            // it does not throw in practice. Belt-and-suspenders:
+            // treat "we don't know" as "we have no call", so a
+            // MODE_IN_COMMUNICATION reading maps to OFFHOOK and the
+            // on-screen PTT is blocked. That fails safe for the
+            // exact bug this gate exists to prevent — auto-holding
+            // an external call — at the cost of a spurious block on
+            // our own call, which is recoverable (release, press
+            // again, timing settles).
+            android.util.Log.w(
+                TAG,
+                "xvHasActiveTelecomCallProvider: unexpected throw — treating as no active call",
+                t,
+            )
+            false
+        }
+    },
     // Cellular-call state probe for the pttDown gate. Injected so unit
     // tests can drive OFFHOOK / RINGING / IDLE without touching a real
-    // AudioManager. Defaults to reading AudioManager.getMode() and
-    // mapping the audio-mode constant to a TelephonyManager call-state
-    // constant via [cellularCallStateFromAudioMode].
+    // AudioManager. Defaults to reading AudioManager.getMode() +
+    // [xvHasActiveTelecomCallProvider] and mapping the pair to a
+    // TelephonyManager call-state constant via
+    // [cellularCallStateFromAudioMode].
     //
     // Why AudioManager and not TelephonyManager: the original wire-up
     // used TelephonyManager.getCallState() on the assumption that the
@@ -72,9 +127,9 @@ class VoicePlant(
     // that itself throws + logs a stack trace on every press makes the
     // audio hot-path more expensive AND buys no benefit (we never see
     // OFFHOOK). AudioManager.getMode() requires no permission at any
-    // API level and returns MODE_IN_CALL / MODE_RINGTONE for the exact
-    // states we want to gate on. XV's own audio-plant code already
-    // reads audioManager.mode extensively (AudioControllerImpl,
+    // API level and returns MODE_IN_CALL / MODE_RINGTONE / MODE_IN_COMMUNICATION
+    // for the states we want to gate on. XV's own audio-plant code
+    // already reads audioManager.mode extensively (AudioControllerImpl,
     // ScoLink, TptPlayer) — this is just one more reader.
     //
     // Belt-and-suspenders: a defensive catch on Throwable still returns
@@ -87,7 +142,8 @@ class VoicePlant(
                 context.getSystemService(Context.AUDIO_SERVICE)
                     as? AudioManager
             cellularCallStateFromAudioMode(
-                am?.mode ?: AudioManager.MODE_NORMAL,
+                audioMode = am?.mode ?: AudioManager.MODE_NORMAL,
+                xvHasActiveTelecomCall = xvHasActiveTelecomCallProvider(),
             )
         } catch (t: Throwable) {
             android.util.Log.w(

--- a/app/src/test/java/com/atakmap/android/xv/service/PttCellularGateTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/service/PttCellularGateTest.kt
@@ -237,53 +237,136 @@ class PttCellularGateTest {
 
     // ============================================================
     // cellularCallStateFromAudioMode — permission-free state source
+    //
+    // Two-input pure function: (audioMode, xvHasActiveTelecomCall).
+    // The second input disambiguates MODE_IN_COMMUNICATION, which
+    // modern Android uses BOTH for XV's own self-managed Telecom
+    // call AND for a real VoLTE cellular call (as of API 30+ on
+    // every major US carrier's default VoLTE profile — field
+    // evidence: Pixel 9 Pro / API 35, 2026-07-11, voicemail call
+    // observed in MODE_IN_COMMUNICATION). Without the second
+    // input the gate cannot tell "we placed this call" from "the
+    // cellular stack placed this call" and either self-gates
+    // every PTT (map to OFFHOOK) or fails to block VoLTE (map to
+    // IDLE — the pre-fix behavior that PR #37 shipped and the
+    // field bug this test suite guards against).
     // ============================================================
 
     @Test
-    fun `MODE_IN_CALL maps to CALL_STATE_OFFHOOK`() {
+    fun `MODE_IN_CALL maps to CALL_STATE_OFFHOOK regardless of own-call state`() {
         // AudioManager.MODE_IN_CALL is set by the telephony framework
-        // whenever a cellular call is in the OFFHOOK (connected) state.
-        // This is the primary "block PTT" trigger — we do not want XV
-        // to place its self-managed Telecom call and auto-hold the
-        // active cellular call.
+        // whenever a legacy CSFB / circuit-switched cellular call is
+        // OFFHOOK. Pre-VoLTE handsets and VoLTE-disabled carrier
+        // profiles land here. XV never enters MODE_IN_CALL itself
+        // (our self-managed VoIP call uses MODE_IN_COMMUNICATION),
+        // so this branch is independent of xvHasActiveTelecomCall —
+        // real cellular always wins.
         assertEquals(
             TelephonyManager.CALL_STATE_OFFHOOK,
-            cellularCallStateFromAudioMode(AudioManager.MODE_IN_CALL),
+            cellularCallStateFromAudioMode(
+                audioMode = AudioManager.MODE_IN_CALL,
+                xvHasActiveTelecomCall = false,
+            ),
+        )
+        assertEquals(
+            "MODE_IN_CALL with our own call already up must still map to OFFHOOK — " +
+                "cellular MODE_IN_CALL is authoritative and XV never enters it",
+            TelephonyManager.CALL_STATE_OFFHOOK,
+            cellularCallStateFromAudioMode(
+                audioMode = AudioManager.MODE_IN_CALL,
+                xvHasActiveTelecomCall = true,
+            ),
         )
     }
 
     @Test
-    fun `MODE_RINGTONE maps to CALL_STATE_RINGING`() {
+    fun `MODE_RINGTONE maps to CALL_STATE_RINGING regardless of own-call state`() {
         assertEquals(
             TelephonyManager.CALL_STATE_RINGING,
-            cellularCallStateFromAudioMode(AudioManager.MODE_RINGTONE),
+            cellularCallStateFromAudioMode(
+                audioMode = AudioManager.MODE_RINGTONE,
+                xvHasActiveTelecomCall = false,
+            ),
+        )
+        assertEquals(
+            TelephonyManager.CALL_STATE_RINGING,
+            cellularCallStateFromAudioMode(
+                audioMode = AudioManager.MODE_RINGTONE,
+                xvHasActiveTelecomCall = true,
+            ),
         )
     }
 
     @Test
-    fun `MODE_NORMAL maps to CALL_STATE_IDLE`() {
+    fun `MODE_NORMAL maps to CALL_STATE_IDLE regardless of own-call state`() {
         assertEquals(
             TelephonyManager.CALL_STATE_IDLE,
-            cellularCallStateFromAudioMode(AudioManager.MODE_NORMAL),
+            cellularCallStateFromAudioMode(
+                audioMode = AudioManager.MODE_NORMAL,
+                xvHasActiveTelecomCall = false,
+            ),
+        )
+        assertEquals(
+            TelephonyManager.CALL_STATE_IDLE,
+            cellularCallStateFromAudioMode(
+                audioMode = AudioManager.MODE_NORMAL,
+                xvHasActiveTelecomCall = true,
+            ),
         )
     }
 
     @Test
-    fun `MODE_IN_COMMUNICATION maps to CALL_STATE_IDLE (not our own gate)`() {
+    fun `MODE_IN_COMMUNICATION with our own active call maps to IDLE`() {
         // XV's self-managed Telecom call sets MODE_IN_COMMUNICATION on
         // every TX (see AudioControllerImpl.enterTx). If we mapped that
         // to OFFHOOK the gate would fire on our OWN follow-up presses
-        // during a burst — a permanent PTT lockout. Explicitly assert
-        // the invariant "MODE_IN_CALL = cell, MODE_IN_COMMUNICATION =
-        // us, skip".
+        // during a burst — a permanent PTT lockout. The own-call flag
+        // is how we detect that we placed the call.
         assertEquals(
             TelephonyManager.CALL_STATE_IDLE,
-            cellularCallStateFromAudioMode(AudioManager.MODE_IN_COMMUNICATION),
+            cellularCallStateFromAudioMode(
+                audioMode = AudioManager.MODE_IN_COMMUNICATION,
+                xvHasActiveTelecomCall = true,
+            ),
         )
     }
 
     @Test
-    fun `unknown audio-mode fails open to CALL_STATE_IDLE`() {
+    fun `MODE_IN_COMMUNICATION with NO own active call maps to OFFHOOK (VoLTE cellular)`() {
+        // Field-critical case, 2026-07-11 regression fix. Modern
+        // Pixel / Samsung / Motorola handsets with VoLTE enabled
+        // (default on every major US carrier's plans) put the OS in
+        // MODE_IN_COMMUNICATION for the REAL cellular call — the
+        // same audio mode our self-managed VoIP call uses. Log
+        // evidence from Pixel 9 Pro / API 35 during a live
+        // voicemail call:
+        //
+        //   AHal::CrystalClearAudioWrapper: OnAudioModeChanged:
+        //   update mode from IN_COMMUNICATION to NORMAL
+        //
+        // Before this fix the mapping unconditionally returned IDLE
+        // for MODE_IN_COMMUNICATION on the theory that only XV
+        // could be responsible for that mode. That was wrong: any
+        // VoIP app (Signal, WhatsApp, Discord, Meet) can also
+        // claim MODE_IN_COMMUNICATION, and VoLTE cellular does too.
+        //
+        // The fix: if XV has no active self-managed Telecom call
+        // and the device is nonetheless in MODE_IN_COMMUNICATION,
+        // somebody else placed the call. Treat as OFFHOOK so the
+        // on-screen PTT gate blocks and XV does not auto-hold the
+        // operator's live call by placing our own self-managed
+        // call on top.
+        assertEquals(
+            TelephonyManager.CALL_STATE_OFFHOOK,
+            cellularCallStateFromAudioMode(
+                audioMode = AudioManager.MODE_IN_COMMUNICATION,
+                xvHasActiveTelecomCall = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `unknown audio-mode fails open to CALL_STATE_IDLE regardless of own-call state`() {
         // Same fail-open rationale as shouldGateForCellularCall — a
         // silent PTT lockout with no visible cause is worse than the
         // auto-hold bug this gate exists to fix. Any future audio-mode
@@ -291,16 +374,36 @@ class PttCellularGateTest {
         // must not gate PTT.
         assertEquals(
             TelephonyManager.CALL_STATE_IDLE,
-            cellularCallStateFromAudioMode(AudioManager.MODE_INVALID),
+            cellularCallStateFromAudioMode(
+                audioMode = AudioManager.MODE_INVALID,
+                xvHasActiveTelecomCall = false,
+            ),
         )
         assertEquals(
             TelephonyManager.CALL_STATE_IDLE,
-            cellularCallStateFromAudioMode(Int.MAX_VALUE),
+            cellularCallStateFromAudioMode(
+                audioMode = AudioManager.MODE_INVALID,
+                xvHasActiveTelecomCall = true,
+            ),
+        )
+        assertEquals(
+            TelephonyManager.CALL_STATE_IDLE,
+            cellularCallStateFromAudioMode(
+                audioMode = Int.MAX_VALUE,
+                xvHasActiveTelecomCall = false,
+            ),
+        )
+        assertEquals(
+            TelephonyManager.CALL_STATE_IDLE,
+            cellularCallStateFromAudioMode(
+                audioMode = Int.MAX_VALUE,
+                xvHasActiveTelecomCall = true,
+            ),
         )
     }
 
     @Test
-    fun `AudioManager mode round-trips through the full gate for cell OFFHOOK on-screen`() {
+    fun `AudioManager mode round-trips through the full gate for legacy cell OFFHOOK on-screen`() {
         // End-to-end sanity: getMode() returns MODE_IN_CALL during an
         // active cellular call → provider adapter maps to
         // CALL_STATE_OFFHOOK → gate returns BLOCK_CELLULAR_CALL for
@@ -308,7 +411,10 @@ class PttCellularGateTest {
         assertEquals(
             PttGate.BLOCK_CELLULAR_CALL,
             shouldGateForCellularCall(
-                cellularCallStateFromAudioMode(AudioManager.MODE_IN_CALL),
+                cellularCallStateFromAudioMode(
+                    audioMode = AudioManager.MODE_IN_CALL,
+                    xvHasActiveTelecomCall = false,
+                ),
                 PttSource.ON_SCREEN,
             ),
         )
@@ -319,7 +425,32 @@ class PttCellularGateTest {
         assertEquals(
             PttGate.BLOCK_CELLULAR_RINGING,
             shouldGateForCellularCall(
-                cellularCallStateFromAudioMode(AudioManager.MODE_RINGTONE),
+                cellularCallStateFromAudioMode(
+                    audioMode = AudioManager.MODE_RINGTONE,
+                    xvHasActiveTelecomCall = false,
+                ),
+                PttSource.ON_SCREEN,
+            ),
+        )
+    }
+
+    @Test
+    fun `AudioManager mode round-trips through the full gate for VoLTE cell on-screen`() {
+        // End-to-end sanity for the Pixel-VoLTE regression: getMode()
+        // returns MODE_IN_COMMUNICATION during an active VoLTE call,
+        // and XV has NOT placed its own Telecom call yet. Provider
+        // adapter must map to CALL_STATE_OFFHOOK and the gate must
+        // return BLOCK_CELLULAR_CALL for an on-screen tap. Before
+        // this fix the mapping was IDLE → ALLOW → XV placed its own
+        // call → Telecom auto-held the operator's VoLTE call. This
+        // test locks in the correct behavior.
+        assertEquals(
+            PttGate.BLOCK_CELLULAR_CALL,
+            shouldGateForCellularCall(
+                cellularCallStateFromAudioMode(
+                    audioMode = AudioManager.MODE_IN_COMMUNICATION,
+                    xvHasActiveTelecomCall = false,
+                ),
                 PttSource.ON_SCREEN,
             ),
         )
@@ -329,11 +460,16 @@ class PttCellularGateTest {
     fun `AudioManager MODE_IN_COMMUNICATION does not gate ourselves on-screen`() {
         // Full-pipeline complement to the mapping test: XV's own
         // Telecom call must never cause the gate to fire even on
-        // the on-screen path.
+        // the on-screen path. This is what keeps mid-burst PTT
+        // presses working — during a burst xvHasActiveTelecomCall
+        // is true (registry entry lives until end-debounce fires).
         assertEquals(
             PttGate.ALLOW,
             shouldGateForCellularCall(
-                cellularCallStateFromAudioMode(AudioManager.MODE_IN_COMMUNICATION),
+                cellularCallStateFromAudioMode(
+                    audioMode = AudioManager.MODE_IN_COMMUNICATION,
+                    xvHasActiveTelecomCall = true,
+                ),
                 PttSource.ON_SCREEN,
             ),
         )
@@ -350,7 +486,30 @@ class PttCellularGateTest {
         assertEquals(
             PttGate.ALLOW,
             shouldGateForCellularCall(
-                cellularCallStateFromAudioMode(AudioManager.MODE_IN_CALL),
+                cellularCallStateFromAudioMode(
+                    audioMode = AudioManager.MODE_IN_CALL,
+                    xvHasActiveTelecomCall = false,
+                ),
+                PttSource.AINA_V2,
+            ),
+        )
+    }
+
+    @Test
+    fun `AudioManager MODE_IN_COMMUNICATION VoLTE does not gate an AINA hardware press`() {
+        // Same source-scope policy but for the VoLTE case: a hardware
+        // key-up during an active VoLTE call is deliberate operator
+        // intent (tactical scenarios routinely require key-up during
+        // an active phone call). The hardware source bypasses the
+        // gate even though the state resolution correctly identifies
+        // the call as external.
+        assertEquals(
+            PttGate.ALLOW,
+            shouldGateForCellularCall(
+                cellularCallStateFromAudioMode(
+                    audioMode = AudioManager.MODE_IN_COMMUNICATION,
+                    xvHasActiveTelecomCall = false,
+                ),
                 PttSource.AINA_V2,
             ),
         )


### PR DESCRIPTION
## Summary

- PR #37 mapped `AudioManager.MODE_IN_COMMUNICATION` unconditionally to `CALL_STATE_IDLE` on the theory that only XV's own self-managed Telecom call uses that mode. On modern Android with VoLTE cellular (default on every major US carrier), the OS also uses `MODE_IN_COMMUNICATION` for the real cellular call. Result: on-screen PTT was ALLOWED during a live VoLTE call, XV's Telecom call landed on top, and Android auto-held the operator's cellular call.
- Fix: give the pure gate function a second input, `xvHasActiveTelecomCall`. `MODE_IN_COMMUNICATION` with our own call active resolves to `IDLE` (do not self-gate mid-burst). Same mode with NO own call resolves to `OFFHOOK` (block the accident-prone on-screen PTT). Every other audio mode is independent of the flag.
- The Rule 3 source scope (on-screen only) is preserved. Hardware sources (AINA V1/V2, Pryme MFB, Samsung Active Key, Sonim PTT/Emergency, DEBUG) still bypass the gate unconditionally.

## Reproducer (field-observed 2026-07-11, Pixel 9 Pro / API 35, VoLTE-enabled cellular)

1. Place or receive a cellular call (voicemail dial-out is easiest).
2. While the call is up, tap XV's on-screen PTT button.
3. Observed on the affected build (post PR #37, pre this fix):
   - No `cellular call active` toast fired.
   - XV placed its self-managed Telecom call.
   - Android auto-held the cellular call as its second-self-managed-call arbitration.
   - Operator lost their live call to a fidget-guard that was supposed to prevent exactly this.

Log evidence (Pixel 9 Pro, timestamps redacted to the second):

```
I/AHal::CrystalClearAudioWrapper: OnAudioModeChanged:
  update mode from IN_COMMUNICATION to NORMAL
```

The transition `IN_COMMUNICATION -> NORMAL` fired as the VoLTE call hung up — confirming the cellular call was in `MODE_IN_COMMUNICATION` throughout, not `MODE_IN_CALL`.

## Root cause

`AudioManager.getMode()` on modern Android is ambiguous: `MODE_IN_COMMUNICATION` means either
1. XV's own self-managed Telecom call is claiming the mode (via `AudioControllerImpl.enterTx` / `XvVoiceService.placeTelecomCallInternal`), OR
2. A VoLTE cellular call is claiming the mode (default on every major US carrier), OR
3. Another VoIP app (Signal, WhatsApp, Discord, Meet, etc.) is claiming the mode.

The old PR #37 mapping treated case 1 as the only possibility and returned `IDLE` for all three. `AudioManager.getMode()` alone cannot disambiguate. `TelephonyManager.getCallState()` would but was rejected in `fd1efb6` because it throws `SecurityException` without `READ_PHONE_STATE` on API 31+ — a permission we deliberately refuse to add.

## Fix

`cellularCallStateFromAudioMode()` becomes a two-argument pure function:

```kotlin
fun cellularCallStateFromAudioMode(
    audioMode: Int,
    xvHasActiveTelecomCall: Boolean,
): Int = when (audioMode) {
    AudioManager.MODE_IN_CALL -> TelephonyManager.CALL_STATE_OFFHOOK
    AudioManager.MODE_RINGTONE -> TelephonyManager.CALL_STATE_RINGING
    AudioManager.MODE_IN_COMMUNICATION ->
        if (xvHasActiveTelecomCall) TelephonyManager.CALL_STATE_IDLE
        else TelephonyManager.CALL_STATE_OFFHOOK
    else -> TelephonyManager.CALL_STATE_IDLE
}
```

Wiring in `VoicePlant`: a new `xvHasActiveTelecomCallProvider: () -> Boolean` constructor parameter defaults to `com.atakmap.android.xv.telecom.ActiveCallRegistry.hasActiveCall()`. The registry lives in the same process as `VoicePlant` (both inside `XvVoiceService`). Its `register` / `unregister` lifecycle is already driven by `XvConnection.onDestroy` / `teardownLocal`, which is triggered by `XvVoiceService.scheduleEndTelecomCall`'s `TELECOM_END_DEBOUNCE_MS` (8 s) runnable. So the flag stays `true` across a whole burst + wind-down and only drops after Telecom has actually torn our connection down.

Race handling for the end-debounce window: if the operator presses PTT with no cell call active but `xvHasActiveTelecomCall` is still `true` (a previous burst's teardown still pending), the mapping returns `IDLE` and the gate allows — their own recent PTT usage shouldn't self-block. Only the (own-call = false, `MODE_IN_COMMUNICATION` = true) shape routes through the new `OFFHOOK` branch, which is exactly the VoLTE / external-VoIP case.

## Explicitly NOT in scope

- No `READ_PHONE_STATE` re-add (that was the whole point of `fd1efb6`).
- No source-scope policy change — Rule 3 still holds, hardware still bypasses the gate.
- No toast throttle change.
- No AndroidManifest permission additions.
- No AIDL bumps.
- No `TxController` / `PttDispatcher` edits.

## Test plan

### Automated (green on this branch)

- `./gradlew ktlintCheck` — green.
- `./gradlew assembleCivDebug` — green.
- `./gradlew testCivDebugUnitTest` — green. `PttCellularGateTest` picks up new cases: `(MODE_IN_CALL x own-call true/false)` -> `OFFHOOK`, `(MODE_RINGTONE x own-call true/false)` -> `RINGING`, `(MODE_IN_COMMUNICATION x own-call true)` -> `IDLE` (mid-burst), `(MODE_IN_COMMUNICATION x own-call false)` -> `OFFHOOK` (the Pixel-VoLTE regression), `(MODE_NORMAL x both)` -> `IDLE`, `(MODE_INVALID x both)` -> `IDLE`, plus round-trip pipeline coverage for VoLTE-cellular OFFHOOK on both on-screen and hardware sources. All 32 gate tests green; existing `shouldGateForCellularCall` decision-logic tests unchanged.

### On-device (Pixel 9 Pro, API 35, VoLTE-enabled cellular carrier)

- [ ] With no cellular call active, tap on-screen PTT -> TX proceeds normally, no toast.
- [ ] Place a voicemail cellular call. While the call is up, tap on-screen PTT -> expect `cellular call active — hang up before XV PTT` toast, no TX, cellular call stays live (not auto-held).
- [ ] With the same cellular call still up, press a hardware PTT button (AINA V2 / Pryme MFB / Samsung Active Key / Sonim PTT) -> expect deliberate TX (Rule 3 bypass); cellular call may auto-hold as the intended side effect.
- [ ] Start an XV burst normally, release PTT, wait <8 s (still in end-debounce), press on-screen PTT again -> mid-burst press MUST allow (own-call still registered).
- [ ] Start an XV burst, release, wait >8 s (past end-debounce), verify no cellular call is active, press on-screen PTT again -> allow.
- [ ] Receive an incoming cellular call (ringing), press on-screen PTT -> expect toast + block (`MODE_RINGTONE` path is unchanged).

### On-device (legacy CSFB / VoLTE-disabled carrier profile — Rule 3 baseline)

- [ ] Cellular call active -> device in `MODE_IN_CALL`, on-screen PTT blocked with toast, hardware bypasses. No regression from PR #37 baseline.

## Notes

- Field-observed only on the on-screen path. Rule 3 (hardware bypasses) is preserved end-to-end — a mid-VoLTE-call hardware key-up is still deliberate operator intent and transmits.
- The Pixel 9 Pro log excerpt in the commit body cites only the `AHal::CrystalClearAudioWrapper` OS line (no operator identifiers, MACs, callsigns, or coordinates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)