### PR TITLE
fix(ptt): cellular gate blocks ALL sources — phone calls are #1 priority

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/service/PttCellularGate.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/PttCellularGate.kt
@@ -55,44 +55,42 @@ enum class PttGate {
  * auto-hold bug this gate exists to fix; XV is a tactical voice tool
  * and unexplained mute is the more dangerous failure mode.
  *
- * Source-scoped policy (2026-07-10 revision): the cellular-call gate
- * only applies to [PttSource.ON_SCREEN] — the on-screen PTT button.
- * Every non-screen source (AINA V1/V2, Pryme MFB, any future
- * BT-HID / gpio hardware button, and the DEBUG intent path) bypasses
- * the gate entirely and returns [PttGate.ALLOW] even during OFFHOOK
- * or RINGING.
+ * Policy (2026-07-11 revision — supersedes both the original
+ * "block everything" (2026-07-10 21:00) and the source-scoped
+ * "on-screen only" (2026-07-10 22:00) positions): **every PTT source
+ * blocks during an active cellular call.** Phone calls are the #1
+ * priority on the device — nothing XV does should silently interrupt
+ * or auto-hold a live call regardless of which button initiated the
+ * PTT.
  *
  * Rationale:
- *  - On-screen PTT taps are accident-prone. A wayward finger during a
- *    phone call should not silently auto-hold the operator's call by
- *    placing XV's self-managed Telecom call. The toast + block is the
- *    right response for that path.
- *  - A hardware button press represents deliberate operator intent.
- *    Tactical scenarios routinely require an operator to key up
- *    mid-call (call-of-record on the phone, but the incident lives on
- *    XV). Blocking a hardware press would surprise-block a
- *    deliberate transmission attempt — a worse failure than the
- *    auto-hold it would prevent. The operator gets what they asked
- *    for; XV's Telecom call still auto-holds the cellular call as a
- *    side effect, but that side effect is now intentional.
- *  - DEBUG intents originate from adb / dev tooling, never from a
- *    stray touch. Treating them as bypass keeps the debug path
- *    usable while a cellular call is up.
- *
- * Future hardware sources added to [PttSource] inherit the ALLOW
- * behavior automatically — the gate only ever blocks the one
- * accident-prone input (ON_SCREEN).
+ *  - Field observation 2026-07-11: a hardware AINA button press
+ *    during a cellular voicemail call auto-held the call (Android's
+ *    Telecom framework parks the first self-managed call when a
+ *    second one is placed). The operator had NOT intended to
+ *    interrupt the call; the button was pressed as part of an
+ *    unrelated test motion. That failure mode is the same
+ *    "accident-prone" concern the on-screen tap has — and it turns
+ *    out the "hardware = intentional" assumption in the earlier
+ *    source-scoped policy was too generous.
+ *  - Blocking every source keeps the invariant simple, testable, and
+ *    matches operator intent: XV does not compete with a live phone
+ *    call. The toast tells the operator what happened.
+ *  - The [source] parameter is retained (rather than removed) so
+ *    logging can still name the actual button that would have fired,
+ *    and so a future need to re-introduce per-source behaviour does
+ *    not have to reshape the API.
  */
 fun shouldGateForCellularCall(
     callState: Int,
-    source: PttSource,
+    @Suppress("UNUSED_PARAMETER") source: PttSource,
 ): PttGate =
-    when {
-        // Only the on-screen PTT tap is accident-prone enough to gate.
-        // Every hardware button and the debug intent path bypass.
-        source != PttSource.ON_SCREEN -> PttGate.ALLOW
-        callState == TelephonyManager.CALL_STATE_OFFHOOK -> PttGate.BLOCK_CELLULAR_CALL
-        callState == TelephonyManager.CALL_STATE_RINGING -> PttGate.BLOCK_CELLULAR_RINGING
+    when (callState) {
+        // All PTT sources get blocked — phone calls are #1 priority.
+        // Hardware AINA button, Pryme puck, Samsung Active Key, Sonim
+        // PTT / Emergency, on-screen, DEBUG intent — every one of them.
+        TelephonyManager.CALL_STATE_OFFHOOK -> PttGate.BLOCK_CELLULAR_CALL
+        TelephonyManager.CALL_STATE_RINGING -> PttGate.BLOCK_CELLULAR_RINGING
         else -> PttGate.ALLOW
     }
 

--- a/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
@@ -865,16 +865,16 @@ class VoicePlant(
         // placement below — the whole point is to avoid placing that
         // call while the cellular stack is busy.
         //
-        // Source-scoped (2026-07-10): the gate only fires for
-        // [PttSource.ON_SCREEN] taps. Hardware button sources
-        // (AINA V1/V2, Pryme MFB, and any future BT-HID hardware
-        // input) represent deliberate operator intent — a mid-call
-        // hardware key-up must not be surprise-blocked. The pure
-        // decision in [shouldGateForCellularCall] returns ALLOW for
-        // every non-screen source unconditionally; the fetch of
-        // cellState is still cheap and worth keeping outside the
-        // branch so the INFO log below can name the actual telephony
-        // state that was bypassed.
+        // Blocks EVERY source (2026-07-11 revision — supersedes
+        // both the original "block everything" (2026-07-10 21:00)
+        // and the source-scoped "on-screen only" (2026-07-10 22:00)
+        // positions). Phone calls are the #1 priority on the device
+        // regardless of which button initiated the PTT. Field
+        // observation 2026-07-11: a hardware AINA press during a
+        // cellular voicemail call auto-held the call because the
+        // source-scoped policy allowed hardware through. The
+        // "hardware = intentional" assumption was too generous.
+        // See [shouldGateForCellularCall] for the pure decision.
         val cellState = cellularCallStateProvider()
         val gate = shouldGateForCellularCall(cellState, source)
         if (gate != PttGate.ALLOW) {
@@ -894,20 +894,6 @@ class VoicePlant(
                 )
             }
             return
-        } else {
-            // Log at INFO so an operator reading a post-mortem logcat
-            // understands why the "cellular call active" toast did NOT
-            // fire for a hardware press during a call. Expected
-            // behavior — deliberate hardware intent bypasses the
-            // fidget-guard. Only log when the cellular stack actually
-            // was in one of the states we would have gated on for an
-            // on-screen tap; the IDLE case is not interesting.
-            val cellActive =
-                cellState == android.telephony.TelephonyManager.CALL_STATE_OFFHOOK ||
-                    cellState == android.telephony.TelephonyManager.CALL_STATE_RINGING
-            if (source != PttSource.ON_SCREEN && cellActive) {
-                Log.i(TAG, "cellular call active but source=$source is hardware — allowing PTT")
-            }
         }
         // Pre-set the comm device for our route preference BEFORE
         // anything else. Two consumers need this assertion:

--- a/app/src/test/java/com/atakmap/android/xv/service/PttCellularGateTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/service/PttCellularGateTest.kt
@@ -18,13 +18,24 @@ class PttCellularGateTest {
     // ============================================================
     // shouldGateForCellularCall — decision function
     //
-    // Source-scoped policy (2026-07-10 revision): the gate ONLY
-    // applies to PttSource.ON_SCREEN. Every other source — every
-    // hardware button (AINA V1/V2, Pryme MFB, and any future
-    // BT-HID / gpio input) and the DEBUG intent path — bypasses
-    // the gate and returns ALLOW even during OFFHOOK / RINGING.
-    // The screen-tap path stays blocked because a stray finger
-    // during a phone call should not auto-hold the call.
+    // Block-all-sources policy (2026-07-11 revision — supersedes
+    // both the original "block everything" position from
+    // 2026-07-10 21:00 and the source-scoped "on-screen only"
+    // position from 2026-07-10 22:00): EVERY PttSource blocks
+    // during an active cellular call (OFFHOOK / RINGING). Phone
+    // calls are the #1 priority on the device — nothing XV does
+    // should silently interrupt or auto-hold a live call
+    // regardless of which button fired the PTT.
+    //
+    // Field observation 2026-07-11 that drove the revision: a
+    // hardware AINA button press during a cellular voicemail call
+    // auto-held the call via Android's Telecom second-self-managed-
+    // call arbitration. The press was unintentional — the previous
+    // "hardware = deliberate intent" assumption was too generous.
+    // The [source] parameter is retained (rather than removed) so
+    // logging can still name the button that would have fired, and
+    // so a future need to reintroduce per-source behaviour does not
+    // have to reshape the gate API.
     // ============================================================
 
     @Test
@@ -63,74 +74,78 @@ class PttCellularGateTest {
         assertEquals(PttGate.ALLOW, shouldGateForCellularCall(Int.MAX_VALUE, PttSource.ON_SCREEN))
     }
 
-    // --- Hardware sources bypass the gate entirely ---------------
+    // --- Hardware sources are ALSO blocked (block-all-sources policy) ---
 
     @Test
-    fun `AINA V1 hardware bypasses gate during OFFHOOK`() {
-        // Hardware button presses represent deliberate operator
-        // intent. Tactical scenarios may require an operator to
-        // key up mid-call; blocking a hardware press would
-        // surprise-block a deliberate transmission attempt.
+    fun `AINA V1 hardware blocks during OFFHOOK`() {
+        // 2026-07-11 revision: hardware presses no longer bypass the
+        // gate. A live cellular call is authoritative; every PTT
+        // source — including the operator's BT speakermic button —
+        // must be blocked so XV does not auto-hold the call by
+        // placing its own self-managed Telecom call on top.
         assertEquals(
-            PttGate.ALLOW,
+            PttGate.BLOCK_CELLULAR_CALL,
             shouldGateForCellularCall(TelephonyManager.CALL_STATE_OFFHOOK, PttSource.AINA_V1),
         )
     }
 
     @Test
-    fun `AINA V1 hardware bypasses gate during RINGING`() {
+    fun `AINA V1 hardware blocks during RINGING`() {
         assertEquals(
-            PttGate.ALLOW,
+            PttGate.BLOCK_CELLULAR_RINGING,
             shouldGateForCellularCall(TelephonyManager.CALL_STATE_RINGING, PttSource.AINA_V1),
         )
     }
 
     @Test
-    fun `AINA V2 hardware bypasses gate during OFFHOOK`() {
+    fun `AINA V2 hardware blocks during OFFHOOK`() {
         assertEquals(
-            PttGate.ALLOW,
+            PttGate.BLOCK_CELLULAR_CALL,
             shouldGateForCellularCall(TelephonyManager.CALL_STATE_OFFHOOK, PttSource.AINA_V2),
         )
     }
 
     @Test
-    fun `AINA V2 hardware bypasses gate during RINGING`() {
+    fun `AINA V2 hardware blocks during RINGING`() {
         assertEquals(
-            PttGate.ALLOW,
+            PttGate.BLOCK_CELLULAR_RINGING,
             shouldGateForCellularCall(TelephonyManager.CALL_STATE_RINGING, PttSource.AINA_V2),
         )
     }
 
     @Test
-    fun `Pryme BLE hardware bypasses gate during OFFHOOK`() {
+    fun `Pryme BLE hardware blocks during OFFHOOK`() {
         assertEquals(
-            PttGate.ALLOW,
+            PttGate.BLOCK_CELLULAR_CALL,
             shouldGateForCellularCall(TelephonyManager.CALL_STATE_OFFHOOK, PttSource.PRYME_BLE),
         )
     }
 
     @Test
-    fun `Pryme BLE hardware bypasses gate during RINGING`() {
+    fun `Pryme BLE hardware blocks during RINGING`() {
         assertEquals(
-            PttGate.ALLOW,
+            PttGate.BLOCK_CELLULAR_RINGING,
             shouldGateForCellularCall(TelephonyManager.CALL_STATE_RINGING, PttSource.PRYME_BLE),
         )
     }
 
     @Test
-    fun `DEBUG source bypasses gate during OFFHOOK`() {
-        // DEBUG originates from adb / dev tooling, not from a
-        // stray touch. Keep the debug path usable during a call.
+    fun `DEBUG source blocks during OFFHOOK`() {
+        // DEBUG originates from adb / dev tooling. Under the
+        // block-all-sources policy it is blocked too so unit /
+        // integration tests observe the same behavior operators
+        // see in the field — no accidental "works from adb, fails
+        // from a button" divergence.
         assertEquals(
-            PttGate.ALLOW,
+            PttGate.BLOCK_CELLULAR_CALL,
             shouldGateForCellularCall(TelephonyManager.CALL_STATE_OFFHOOK, PttSource.DEBUG),
         )
     }
 
     @Test
-    fun `DEBUG source bypasses gate during RINGING`() {
+    fun `DEBUG source blocks during RINGING`() {
         assertEquals(
-            PttGate.ALLOW,
+            PttGate.BLOCK_CELLULAR_RINGING,
             shouldGateForCellularCall(TelephonyManager.CALL_STATE_RINGING, PttSource.DEBUG),
         )
     }
@@ -153,29 +168,50 @@ class PttCellularGateTest {
     }
 
     @Test
-    fun `every non-screen source bypasses gate during OFFHOOK`() {
+    fun `every source blocks during OFFHOOK`() {
         // Data-driven complement to the enum-by-enum tests above.
-        // Any hardware source added in the future automatically
-        // gets the ALLOW-during-call treatment; the only source
-        // that stays blocked is ON_SCREEN.
+        // Under the block-all-sources policy EVERY PttSource —
+        // including any future BT-HID / gpio / vendor-specific
+        // input — must return BLOCK_CELLULAR_CALL during an
+        // active cellular call. No ON_SCREEN skip: the on-screen
+        // path is blocked the same way as everything else.
         for (src in PttSource.values()) {
-            if (src == PttSource.ON_SCREEN) continue
             assertEquals(
-                "$src must bypass OFFHOOK gate",
-                PttGate.ALLOW,
+                "$src must BLOCK during OFFHOOK",
+                PttGate.BLOCK_CELLULAR_CALL,
                 shouldGateForCellularCall(TelephonyManager.CALL_STATE_OFFHOOK, src),
             )
         }
     }
 
     @Test
-    fun `every non-screen source bypasses gate during RINGING`() {
+    fun `every source blocks during RINGING`() {
         for (src in PttSource.values()) {
-            if (src == PttSource.ON_SCREEN) continue
             assertEquals(
-                "$src must bypass RINGING gate",
-                PttGate.ALLOW,
+                "$src must BLOCK during RINGING",
+                PttGate.BLOCK_CELLULAR_RINGING,
                 shouldGateForCellularCall(TelephonyManager.CALL_STATE_RINGING, src),
+            )
+        }
+    }
+
+    @Test
+    fun `unknown call-state fails open to ALLOW for every source`() {
+        // Fail-open policy applies uniformly across sources: any
+        // unrecognized call-state value must ALLOW regardless of
+        // which button fired the PTT. Silent lockouts on
+        // unrecognized state codes are worse than the auto-hold
+        // bug the gate exists to fix.
+        for (src in PttSource.values()) {
+            assertEquals(
+                "-1 + $src must ALLOW (fail-open)",
+                PttGate.ALLOW,
+                shouldGateForCellularCall(-1, src),
+            )
+            assertEquals(
+                "Int.MAX_VALUE + $src must ALLOW (fail-open)",
+                PttGate.ALLOW,
+                shouldGateForCellularCall(Int.MAX_VALUE, src),
             )
         }
     }
@@ -476,15 +512,17 @@ class PttCellularGateTest {
     }
 
     @Test
-    fun `AudioManager MODE_IN_CALL does not gate an AINA hardware press`() {
-        // Full-pipeline complement of the source-scope policy: even
-        // when the cellular stack has claimed MODE_IN_CALL, a
-        // hardware button press is deliberate operator intent and
-        // must transmit. XV's Telecom call will still auto-hold the
-        // cellular call as a side effect — but that side effect is
-        // now the operator's choice, not an accident.
+    fun `AudioManager MODE_IN_CALL blocks an AINA hardware press`() {
+        // Full-pipeline complement of the block-all-sources policy
+        // (2026-07-11 revision): even a hardware AINA button press
+        // is blocked when the cellular stack has claimed
+        // MODE_IN_CALL. The prior "hardware = deliberate intent"
+        // carve-out was retired after a field observation showed
+        // an unintentional hardware press auto-holding a live
+        // voicemail call. Phone calls are the #1 priority; every
+        // PTT source defers to them.
         assertEquals(
-            PttGate.ALLOW,
+            PttGate.BLOCK_CELLULAR_CALL,
             shouldGateForCellularCall(
                 cellularCallStateFromAudioMode(
                     audioMode = AudioManager.MODE_IN_CALL,
@@ -496,15 +534,15 @@ class PttCellularGateTest {
     }
 
     @Test
-    fun `AudioManager MODE_IN_COMMUNICATION VoLTE does not gate an AINA hardware press`() {
-        // Same source-scope policy but for the VoLTE case: a hardware
-        // key-up during an active VoLTE call is deliberate operator
-        // intent (tactical scenarios routinely require key-up during
-        // an active phone call). The hardware source bypasses the
-        // gate even though the state resolution correctly identifies
-        // the call as external.
+    fun `AudioManager MODE_IN_COMMUNICATION VoLTE blocks an AINA hardware press`() {
+        // Same block-all-sources policy but for the VoLTE case: a
+        // hardware key-up during an active VoLTE call is blocked
+        // for the same reason as MODE_IN_CALL — the state
+        // resolution correctly identifies the call as external,
+        // and every PTT source (including hardware) defers to a
+        // live cellular call.
         assertEquals(
-            PttGate.ALLOW,
+            PttGate.BLOCK_CELLULAR_CALL,
             shouldGateForCellularCall(
                 cellularCallStateFromAudioMode(
                     audioMode = AudioManager.MODE_IN_COMMUNICATION,


### PR DESCRIPTION
Reverts the source-scoped policy from PR #37's 2026-07-10 22:00 revision. Phone calls are the #1 priority on the device — no PTT source should silently interrupt or auto-hold a live call.

## Field observation 2026-07-11

Operator on Pixel 9 Pro placed a voicemail call, then pressed the AINA hardware button while ATAK was in the foreground. The hardware press bypassed the source-scoped gate (because it wasn't ON_SCREEN), placed XV's self-managed Telecom call, and Android auto-held the cellular voicemail call. Operator did NOT intend to interrupt the call — the button was pressed as part of an unrelated test motion.

That failure mode is the same "accident-prone" concern the on-screen tap has. The "hardware = intentional operator action" assumption in the earlier revision was too generous.

## Policy history

- 2026-07-10 21:00 — original Option A: block everything. Right instinct.
- 2026-07-10 22:00 — source-scoped: on-screen only, hardware bypass. **Wrong** per field evidence.
- 2026-07-11 11:44 — this PR: restores block-everything. Every source blocks.

## What changed

- `PttCellularGate.shouldGateForCellularCall(callState, source)` — the source-scoped short-circuit is removed. Every source blocks during OFFHOOK / RINGING.
- The `source` parameter is retained (marked \`@Suppress(\"UNUSED_PARAMETER\")\`) so log strings and future extension stay possible without an API reshape.
- \`VoicePlant.pttDown\` — the \`else\` branch that logged \"cellular call active but source=X is hardware — allowing PTT\" is removed. Dead code under the new policy.
- The VoLTE-aware mode mapping from PR #45 (\`cellularCallStateFromAudioMode(audioMode, xvHasActiveTelecomCall)\`) is unchanged — that decision is orthogonal to source.

## Tests

Test-file sync ships in a follow-up commit on this branch (agent in flight).

## Test plan

- [x] \`ktlintCheck\` — green on the code changes
- [x] \`assembleCivDebug\` — green
- [ ] \`testCivDebugUnitTest\` — pending the test-file sync
- [ ] On-device Pixel 9 Pro:
  - Place cellular call → press AINA hardware → **expected: toast fires, no TX, cellular call stays live**
  - Same with Pryme puck press
  - Same with on-screen PTT
  - Hang up call → all sources resume normal TX