### PR TITLE
fix(ptt): External Button resolver spawns reader when picker sets a MAC with no live reader

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/aina/ExternalButtonReaderResolver.kt
+++ b/app/src/main/java/com/atakmap/android/xv/aina/ExternalButtonReaderResolver.kt
@@ -59,23 +59,58 @@ object ExternalButtonReaderResolver {
      * XvMapComponent.setSelectedExternalButtonInternal is
      * case-insensitive).
      *
-     * If [isConnected] is false, the decision is always
-     * [PttReaderRespawnDecision.Decision.NO_OP]: the persistence
-     * write is the only side effect, and the next connect edge
-     * (autoConnectExternalButton on plugin start) will pick up the
-     * new value.
+     * External Button vs. primary AINA — connection-edge semantics
+     * diverge:
+     *
+     * The primary AINA slot binds to devices that Android's headset
+     * profile service brokers: the OS pushes a connect edge when the
+     * peer powers on, and only then does the reader spin up. There
+     * the "no live reader + new MAC" case correctly maps to NO_OP —
+     * persist the pick, wait for the OS.
+     *
+     * The External Button slot binds to BLE peripherals that DO NOT
+     * push a connect edge to the phone. BLE PTT pucks (Pryme,
+     * PTT-Z-family, generic HM10 buttons, third-party Amazon buttons)
+     * advertise passively; XV has to open the GATT connection itself.
+     * If we return NO_OP when no reader exists yet, we never open the
+     * GATT connection, no button events ever arrive, and the picker
+     * status stays "Connected" (from the OS bond state) while
+     * physical presses do nothing.
+     *
+     * Field-observed 2026-07-11 on Pixel 9 Pro (Pryme puck +
+     * separate Amazon BLE button, neither reader-attached at
+     * pick time): setSelectedExternalButtonInternal fired with
+     * currentMac=null / isConnected=false, the shared
+     * PttReaderRespawnDecision returned NO_OP on the !isConnected
+     * short-circuit, and the reader was never spawned. Toggling
+     * the picker to (none) and back to the same puck did not help
+     * because the same NO_OP path fired again.
+     *
+     * Fix: for the External Button slot specifically, when the
+     * operator picks a real MAC and there is no live reader, always
+     * RESPAWN — that spawns the reader whose GATT connect attempt
+     * is how the BLE peripheral becomes reachable in the first
+     * place. All other transitions continue to delegate to the
+     * shared decision matrix. Primary AINA behaviour is unchanged
+     * because that resolver still uses the plain shared decision.
      */
     fun shouldRespawnReader(
         currentMac: String?,
         newMac: String?,
         isConnected: Boolean,
-    ): PttReaderRespawnDecision.Decision =
-        PttReaderRespawnDecision.decide(
+    ): PttReaderRespawnDecision.Decision {
+        // BLE peripherals need XV to initiate GATT connect — no
+        // external connect edge is coming to trigger auto-spawn.
+        // If the operator picked a real MAC and there is no reader
+        // yet, spawn one so the connection can be attempted.
+        if (!isConnected && hasReader(newMac)) return PttReaderRespawnDecision.Decision.RESPAWN
+        return PttReaderRespawnDecision.decide(
             currentHasReader = hasReader(currentMac),
             newHasReader = hasReader(newMac),
             currentEqualsNew = macsEqual(currentMac, newMac),
             isConnected = isConnected,
         )
+    }
 
     /**
      * True iff the given MAC represents a live external-button

--- a/app/src/test/java/com/atakmap/android/xv/aina/ExternalButtonReaderResolverTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/aina/ExternalButtonReaderResolverTest.kt
@@ -25,13 +25,26 @@ class ExternalButtonReaderResolverTest {
         const val PUCK_A_LOWER = "aa:bb:cc:dd:ee:ff"
     }
 
-    // ---- Not-connected: every change is persist-only ----
+    // ---- Not-connected: BLE peripherals need XV-initiated spawn ----
+    //
+    // Divergence from the primary AINA slot: External Button binds
+    // to BLE peripherals that never push a connect edge — XV opens
+    // GATT itself, so picking a new MAC while no reader exists is
+    // exactly the situation where we MUST spawn. Field bug 2026-07-11:
+    // pickers logged NO_OP for both a Pryme and a third-party Amazon
+    // BLE button because the shared decision short-circuited on
+    // !isConnected. This resolver overrides that specifically.
 
     @Test
-    fun `not connected — MAC change is a no-op`() {
+    fun `not connected — new MAC picked spawns the reader`() {
+        // The 2026-07-11 field bug's canonical case: no reader alive
+        // yet, operator picks a puck for the first time, GATT must
+        // be initiated. Blocking on !isConnected here traps the
+        // operator forever — no connect edge is coming to unblock.
         assertEquals(
-            "picking a new MAC while the slot is idle is persist-only",
-            Decision.NO_OP,
+            "picking a new MAC while the slot is idle must spawn a reader — " +
+                "BLE peripherals don't push a connect edge",
+            Decision.RESPAWN,
             ExternalButtonReaderResolver.shouldRespawnReader(
                 currentMac = null,
                 newMac = PUCK_A,
@@ -41,7 +54,42 @@ class ExternalButtonReaderResolverTest {
     }
 
     @Test
+    fun `not connected — same MAC re-pick spawns the reader`() {
+        // Operator re-picks the currently-configured MAC while no
+        // reader is alive (post-restart, post-crash, or the field
+        // scenario where a previous NO_OP left the slot stuck). The
+        // re-pick is the operator's way of asking XV to try again;
+        // honour it by spawning the reader.
+        assertEquals(
+            Decision.RESPAWN,
+            ExternalButtonReaderResolver.shouldRespawnReader(
+                currentMac = PUCK_A,
+                newMac = PUCK_A,
+                isConnected = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `not connected — different MAC pick spawns the new reader`() {
+        // Operator has a puck configured but no reader alive, then
+        // picks a different puck. Spawn a reader for the new MAC —
+        // nothing to tear down since nothing was live.
+        assertEquals(
+            Decision.RESPAWN,
+            ExternalButtonReaderResolver.shouldRespawnReader(
+                currentMac = PUCK_A,
+                newMac = PUCK_B,
+                isConnected = false,
+            ),
+        )
+    }
+
+    @Test
     fun `not connected — MAC clear is a no-op`() {
+        // Operator picks "(none)" while no reader is alive. Nothing
+        // to spawn (no MAC), nothing to tear down (no reader). Just
+        // persist the clear.
         assertEquals(
             Decision.NO_OP,
             ExternalButtonReaderResolver.shouldRespawnReader(
@@ -53,12 +101,15 @@ class ExternalButtonReaderResolverTest {
     }
 
     @Test
-    fun `not connected — same MAC pick is a no-op`() {
+    fun `not connected — blank MAC clear is a no-op`() {
+        // Same as above but with "" instead of null — some callers
+        // pass empty strings for "(none)". Should be equivalent to
+        // null under hasReader's isNullOrBlank check.
         assertEquals(
             Decision.NO_OP,
             ExternalButtonReaderResolver.shouldRespawnReader(
                 currentMac = PUCK_A,
-                newMac = PUCK_A,
+                newMac = "",
                 isConnected = false,
             ),
         )


### PR DESCRIPTION
Field observation 2026-07-11 on Pixel 9 Pro: two BLE PTT buttons (Pryme BT-PTT-Z + a third-party Amazon BLE button) both picked from the External Button picker but neither started dispatching events.

Log evidence:
```
Controller.setSelectedExternalButton('E3:57:D4:4F:DC:5F')
setSelectedExternalButtonInternal: currentMac=?? newMac=E3:XX:...:5F 
    isConnected=false → NO_OP
```

## Root cause

PR #44's shared `PttReaderRespawnDecision` short-circuits to NO_OP on `!isConnected`. That's correct for the primary AINA (SPP over RFCOMM, brokered by Android's headset profile service — an external OS connect edge drives spawn). Wrong for External Button (BLE peripherals advertise passively; XV must initiate GATT). Under the shared decision, the flow trapped forever: no reader spawned → no GATT connect → peripheral never reachable → NO_OP forever.

## Fix

Override in `ExternalButtonReaderResolver`: when `!isConnected && newMac` is non-blank, return RESPAWN. Spawns the reader so its GATT connect makes the peripheral reachable. All other transitions delegate to the shared decision unchanged.

Primary AINA behaviour is untouched — `AinaReaderKindResolver` still uses the plain `PttReaderRespawnDecision.decide` path so the SPP-brokered-by-OS assumption stays valid.

## Test plan

- [x] `ktlintCheck` — green
- [x] `assembleCivDebug` — green
- [x] `testCivDebugUnitTest` — green with 3 flipped cases (NO_OP → RESPAWN) + 2 new (none)-picker preservation cases
- [ ] On-device: pick a fresh BLE PTT button in External Button picker → reader spawns within ~2 s → button presses reach XvVoicePlant
- [ ] Regression: pick primary AINA config with device off → NO_OP (unchanged)