### PR TITLE
fix(ptt): External Button lifecycle — startup attach timing + kind staleness

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/aina/ExternalButtonKindResolver.kt
+++ b/app/src/main/java/com/atakmap/android/xv/aina/ExternalButtonKindResolver.kt
@@ -1,0 +1,106 @@
+package com.atakmap.android.xv.aina
+
+/**
+ * Pure decision logic for the reader "kind" string XV assigns to the
+ * External Button slot at connect time. Extracted from
+ * XvMapComponent.resolveConnectKind so the precedence rules can be
+ * covered by ordinary JUnit — the live [resolveConnectKind] wraps a
+ * BluetoothAdapter call and isn't unit-testable on its own.
+ *
+ * Precedence — highest wins:
+ *
+ * 1. **Known-BLE-PTT membership.** If the MAC appears in
+ *    [XvSettings.knownBlePttDevices] (the set of pucks the operator
+ *    scanned in via "Scan for BLE PTT device"), the reader kind is
+ *    always `"ble-hid"`. This wins over any Bluetooth classification
+ *    result because HM-10 / PTT-Z-family pucks don't expose their
+ *    vendor UUID over BR/EDR SDP, so the classifier can misclassify
+ *    them (or return "auto" for unbonded devices) even when the
+ *    operator has explicitly declared them as BLE PTT buttons.
+ *
+ * 2. **Classifier result.** Whatever the SDP-based classifier
+ *    produced from the BluetoothDevice at bond time — `"v1"` (SPP),
+ *    `"v2"` (BLE GATT vendor UUID), or `"ble-hid"` (BLE HID puck).
+ *    Blank/null classifier result means the device wasn't
+ *    classifiable (adapter unavailable, MAC not bonded, SDP threw).
+ *
+ * 3. **Persisted hint** (last-known kind for this MAC, if any). A
+ *    stale hint is better than falling through to `"auto"` because
+ *    `"auto"` at connect time on the External Button slot resolves
+ *    to "no reader" — the operator's puck presses would be silently
+ *    dropped. The hint acts as a "last resort" recovery for devices
+ *    the classifier can no longer see (e.g. a bonded puck that
+ *    Android has forgotten how to enumerate over SDP after a system
+ *    update).
+ *
+ * 4. `"auto"` — the caller signals "no known reader kind." Whether
+ *    the reader-lifecycle logic upstream treats that as no-reader or
+ *    as a retry hint is its problem, not this resolver's.
+ *
+ * Field bug 2026-07-11 (Pixel 9 Pro, Pryme BT-PTT-Z puck): operator
+ * added a puck via BOTH the Android BT Settings bond dialog AND
+ * XV Settings → "Scan for BLE PTT device". Picker (correctly)
+ * showed the bonded entry only. Operator picked the bonded entry
+ * BEFORE the scan-and-add. Persisted kind was whatever the
+ * classifier derived. Operator then scanned the same MAC into
+ * knownBlePtt; the persisted kind was NOT refreshed. On next cold
+ * launch, `connectSavedExternalButton` used the stale persisted
+ * kind, not `"ble-hid"`, and physical presses silently dropped.
+ *
+ * The fix: `connectSavedExternalButton` computes the kind fresh via
+ * this resolver every time instead of reading a cached
+ * `persistedExternalButtonKind()`. Cache staleness surface goes to
+ * zero because there is no cache in the connect path — the
+ * knownBlePtt list IS the source of truth.
+ *
+ * Persisted kind is retained as a hint only; it seeds the "last
+ * resort" fallback above for the case where the classifier can no
+ * longer see the device.
+ */
+object ExternalButtonKindResolver {
+    /**
+     * Compute the reader kind string for a MAC given the current
+     * knownBlePtt membership + a classifier result + an optional
+     * persisted hint. Returns one of `"ble-hid"` / `"v1"` / `"v2"` /
+     * or the persisted hint (if any and no better answer is
+     * available), falling back to `"auto"`.
+     *
+     * All inputs are treated case-insensitively where applicable —
+     * the caller is expected to pass MAC-based membership already
+     * computed against a case-insensitive comparison; this function
+     * does not re-check MAC equality.
+     *
+     * @param isInKnownBlePtt True iff the target MAC is present in
+     *   the operator's known-BLE-PTT set. When true, the answer is
+     *   always `"ble-hid"`.
+     * @param classifierResult The SDP-based classifier's answer for
+     *   this MAC — `"v1"`, `"v2"`, `"ble-hid"`, `"auto"`, or null /
+     *   blank if the classifier could not run at all (adapter null,
+     *   device not bonded, threw).
+     * @param persistedHint The last-known kind string persisted for
+     *   this MAC (from XvSettings.persistedExternalButtonKind), or
+     *   null / blank if none. Used only as a last-resort fallback so
+     *   we don't collapse to `"auto"` (which means "no reader") on a
+     *   device the classifier can no longer see.
+     */
+    fun resolve(
+        isInKnownBlePtt: Boolean,
+        classifierResult: String?,
+        persistedHint: String?,
+    ): String {
+        if (isInKnownBlePtt) return "ble-hid"
+        val classifier = classifierResult?.trim()?.takeIf { it.isNotBlank() }
+        // "auto" from the classifier is a punt — treat it like a
+        // classifier miss so the persisted hint gets a chance to
+        // recover the reader. A concrete "v1" / "v2" / "ble-hid"
+        // wins over any hint.
+        if (classifier != null && !classifier.equals("auto", ignoreCase = true)) {
+            return classifier
+        }
+        val hint = persistedHint?.trim()?.takeIf { it.isNotBlank() }
+        if (hint != null && !hint.equals("auto", ignoreCase = true)) {
+            return hint
+        }
+        return "auto"
+    }
+}

--- a/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
+++ b/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
@@ -3251,90 +3251,215 @@ class XvMapComponent : AbstractMapComponent() {
         return if (macRegex.matches(normalized)) normalized else null
     }
 
+    // Guard against the AIDL-bound path and the fallback timer both
+    // firing autoConnectExternalButton (rare but possible if the bind
+    // races the 3s fallback). At-most-once semantics protect the
+    // service from a duplicate connectExternalButton call.
+    @Volatile
+    private var externalButtonAutoConnectFired: Boolean = false
+
     @SuppressWarnings("MissingPermission")
     private fun autoConnectExternalButton() {
-        // Slight delay to match autoConnectAina + give the BT adapter
-        // time to settle.
+        // Previously fired unconditionally on a 1400 ms postDelayed
+        // handler. Field-observed 2026-07-11 on Pixel 9 Pro: force-stop
+        // → cold relaunch left the External Button reader unspawned
+        // for ~10 s until the operator manually poked the picker.
+        // Root cause: the postDelayed runnable at 1400 ms could fire
+        // BEFORE the voice service AIDL bind completed, at which
+        // point voiceClient?.ifBound queued the connectExternalButton
+        // call for later — but the plugin-side state
+        // (lastExternalButtonMac / lastExternalButtonConnected) was
+        // set immediately, so subsequent picker reads showed the slot
+        // as "connected" while no reader existed. The connectExternalButton
+        // call did eventually run once the binder came up, so the
+        // reader would spawn a bit later — hence the 10 s recovery
+        // window.
+        //
+        // Fix: wire off the AIDL bind callback via
+        // [XvVoiceClient.whenBound]. When the binder is ready, run
+        // the auto-connect. If already bound (subsequent plugin
+        // reloads or hot restart against a still-running service),
+        // it runs synchronously. A belt-and-suspenders 3000 ms
+        // fallback runs the auto-connect anyway with a WARN log so a
+        // wedged bind doesn't leave the External Button slot dark
+        // forever. First-runner wins via [externalButtonAutoConnectFired].
+        //
+        // The primary AINA path ([autoConnectAina]) still uses its
+        // 1400 ms delay — that path relies on OS-brokered SPP
+        // auto-connect edges (BluetoothHeadset profile proxy) which
+        // are a different problem class, and rewiring it is out of
+        // scope for this fix (see PR body).
+        val client = voiceClient
+        if (client == null) {
+            Log.w(TAG, "autoConnectExternalButton: voiceClient is null at scheduling time — cannot arm auto-connect")
+            return
+        }
+        externalButtonAutoConnectFired = false
+        client.whenBound("autoConnectExternalButton") {
+            runAutoConnectExternalButton(source = "aidl-bound")
+        }
+        // Fallback so a wedged bind can't strand the External Button
+        // reader indefinitely. 3000 ms is well past the observed cold-
+        // launch bind latency on Pixel-class hardware (< 800 ms in
+        // captures) and past the old 1400 ms timer that the field
+        // still saw fire too early. If the bind DOES come in inside
+        // that window (the common path), whenBound will have run
+        // first and this handler no-ops.
         android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
-            val savedMac = settings.persistedExternalButtonMac()
-            if (savedMac != null) {
-                connectSavedExternalButton(savedMac)
-                return@postDelayed
-            }
-            if (!settings.persistedAutoConnectBtEnabled()) {
-                Log.i(TAG, "autoConnectExternalButton: no saved selection and auto-connect disabled — skipping")
-                return@postDelayed
-            }
-            // Auto-pick an EXTERNAL BUTTON: prefer a BLE_HID puck
-            // (typical motorcyclist handlebar button) over an
-            // additional speakermic, since the operator's primary is
-            // the audio path and a second audio device on slot 0 would
-            // compete for SCO. Filter out the primary's MAC so we
-            // don't pick the same device twice.
-            val primaryMac = settings.persistedAinaMac()
-            val candidates =
-                listBondedAinaDevices()
-                    .filterNot {
-                        primaryMac != null && it.mac.equals(primaryMac, ignoreCase = true)
-                    }
-            if (candidates.isEmpty()) {
-                Log.i(TAG, "autoConnectExternalButton: no compatible external-button candidate — skipping")
-                return@postDelayed
-            }
-            val picked =
-                candidates.firstOrNull {
-                    it.buttonProtocol == com.atakmap.android.xv.aina.AinaDeviceInfo.ButtonProtocol.BLE_HID
-                } ?: run {
-                    // No BLE_HID puck bonded — don't auto-pick a second
-                    // speakermic. Audio routing only sensibly engages
-                    // one BT speakermic, so picking another would
-                    // create operator-surprise side effects. Operator
-                    // can still manually pick a second AINA in the
-                    // Settings → Preferences picker if they want it.
-                    Log.i(TAG, "autoConnectExternalButton: no BLE PTT button bonded — leaving external-button slot empty")
-                    return@postDelayed
+            if (externalButtonAutoConnectFired) return@postDelayed
+            Log.w(
+                TAG,
+                "autoConnectExternalButton: AIDL bind still not up 3000 ms after schedule — " +
+                    "running fallback auto-connect (belt-and-suspenders); pending actions will queue " +
+                    "against the client until the bind lands",
+            )
+            runAutoConnectExternalButton(source = "fallback-timer")
+        }, 3000)
+    }
+
+    // Actual auto-connect body. Guarded so only the first caller
+    // (whenBound-triggered OR the 3 s fallback) runs it. Every branch
+    // logs at INFO so a future field logcat shows exactly which path
+    // was taken.
+    @SuppressWarnings("MissingPermission")
+    private fun runAutoConnectExternalButton(source: String) {
+        if (externalButtonAutoConnectFired) {
+            Log.i(TAG, "autoConnectExternalButton[$source]: already fired — skipping duplicate")
+            return
+        }
+        externalButtonAutoConnectFired = true
+        Log.i(TAG, "autoConnectExternalButton[$source]: entry")
+        val savedMac = settings.persistedExternalButtonMac()
+        if (savedMac != null) {
+            Log.i(
+                TAG,
+                "autoConnectExternalButton[$source]: restoring saved MAC " +
+                    com.atakmap.android.xv.aina.redactMac(savedMac),
+            )
+            connectSavedExternalButton(savedMac)
+            Log.i(TAG, "autoConnectExternalButton[$source]: complete (restore path)")
+            return
+        }
+        if (!settings.persistedAutoConnectBtEnabled()) {
+            Log.i(TAG, "autoConnectExternalButton[$source]: no saved selection and auto-connect disabled — skipping")
+            return
+        }
+        // Auto-pick an EXTERNAL BUTTON: prefer a BLE_HID puck
+        // (typical motorcyclist handlebar button) over an
+        // additional speakermic, since the operator's primary is
+        // the audio path and a second audio device on slot 0 would
+        // compete for SCO. Filter out the primary's MAC so we
+        // don't pick the same device twice.
+        val primaryMac = settings.persistedAinaMac()
+        val candidates =
+            listBondedAinaDevices()
+                .filterNot {
+                    primaryMac != null && it.mac.equals(primaryMac, ignoreCase = true)
                 }
-            val kind =
-                when (picked.buttonProtocol) {
-                    com.atakmap.android.xv.aina.AinaDeviceInfo.ButtonProtocol.BLE_HID -> "ble-hid"
-                    com.atakmap.android.xv.aina.AinaDeviceInfo.ButtonProtocol.SPP -> "v1"
-                    com.atakmap.android.xv.aina.AinaDeviceInfo.ButtonProtocol.BLE -> "v2"
-                    else -> "auto"
-                }
-            Log.i(TAG, "autoConnectExternalButton: auto-picked → ${picked.name} ${picked.mac} kind=$kind")
-            settings.persistExternalButtonMac(picked.mac)
-            settings.persistExternalButtonKind(kind)
-            lastExternalButtonMac = picked.mac
-            voiceClient?.ifBound { it.connectExternalButton(picked.mac, null, kind) }
-            lastExternalButtonConnected = true
-        }, 1400)
+        if (candidates.isEmpty()) {
+            Log.i(TAG, "autoConnectExternalButton[$source]: no compatible external-button candidate — skipping")
+            return
+        }
+        val picked =
+            candidates.firstOrNull {
+                it.buttonProtocol == com.atakmap.android.xv.aina.AinaDeviceInfo.ButtonProtocol.BLE_HID
+            } ?: run {
+                // No BLE_HID puck bonded — don't auto-pick a second
+                // speakermic. Audio routing only sensibly engages
+                // one BT speakermic, so picking another would
+                // create operator-surprise side effects. Operator
+                // can still manually pick a second AINA in the
+                // Settings → Preferences picker if they want it.
+                Log.i(
+                    TAG,
+                    "autoConnectExternalButton[$source]: no BLE PTT button bonded — leaving external-button slot empty",
+                )
+                return
+            }
+        val kind =
+            when (picked.buttonProtocol) {
+                com.atakmap.android.xv.aina.AinaDeviceInfo.ButtonProtocol.BLE_HID -> "ble-hid"
+                com.atakmap.android.xv.aina.AinaDeviceInfo.ButtonProtocol.SPP -> "v1"
+                com.atakmap.android.xv.aina.AinaDeviceInfo.ButtonProtocol.BLE -> "v2"
+                else -> "auto"
+            }
+        Log.i(
+            TAG,
+            "autoConnectExternalButton[$source]: auto-picked → ${picked.name} " +
+                "${com.atakmap.android.xv.aina.redactMac(picked.mac)} kind=$kind",
+        )
+        settings.persistExternalButtonMac(picked.mac)
+        settings.persistExternalButtonKind(kind)
+        lastExternalButtonMac = picked.mac
+        voiceClient?.ifBound { it.connectExternalButton(picked.mac, null, kind) }
+        lastExternalButtonConnected = true
+        Log.i(TAG, "autoConnectExternalButton[$source]: complete (auto-pick path)")
     }
 
     @SuppressWarnings("MissingPermission")
     private fun connectSavedExternalButton(savedMac: String) {
-        val adapter = BluetoothAdapter.getDefaultAdapter() ?: return
-        val bonded =
-            try {
-                adapter.bondedDevices ?: emptySet()
-            } catch (t: Throwable) {
-                Log.w(TAG, "connectSavedExternalButton: bondedDevices threw", t)
-                return
-            }
-        val device =
-            bonded.firstOrNull { it.address.equals(savedMac, ignoreCase = true) }
-                ?: run {
-                    Log.w(TAG, "connectSavedExternalButton: saved MAC $savedMac no longer bonded")
-                    return
-                }
-        val primary = settings.persistedAinaMac()
-        if (primary != null && primary.equals(savedMac, ignoreCase = true)) {
-            Log.w(TAG, "connectSavedExternalButton: collides with primary — skipping")
+        val redactedSaved = com.atakmap.android.xv.aina.redactMac(savedMac)
+        val adapter = BluetoothAdapter.getDefaultAdapter()
+        if (adapter == null) {
+            Log.w(TAG, "connectSavedExternalButton: no BT adapter — cannot restore $redactedSaved")
             return
         }
-        val kind = settings.persistedExternalButtonKind() ?: "auto"
-        Log.i(TAG, "connectSavedExternalButton: ${device.name} ${device.address} kind=$kind")
-        lastExternalButtonMac = device.address
-        voiceClient?.ifBound { it.connectExternalButton(device.address, null, kind) }
+        // Known-BLE-PTT devices can be picked without a system bond
+        // (PTT-Z01 in particular refuses to bond at all). If the saved
+        // MAC is in that list, skip the bonded-devices lookup entirely
+        // and drive the connect straight into the ble-hid reader path.
+        // Without this, a cold launch with only a knownBlePtt-only puck
+        // saved would take the "no longer bonded" WARN branch below
+        // and never spawn the reader.
+        val isKnownBlePtt =
+            settings.knownBlePttDevices().any { (m, _) -> m.equals(savedMac, ignoreCase = true) }
+        val bondedDevice: BluetoothDevice? =
+            try {
+                val bonded = adapter.bondedDevices ?: emptySet()
+                bonded.firstOrNull { it.address.equals(savedMac, ignoreCase = true) }
+            } catch (t: Throwable) {
+                Log.w(TAG, "connectSavedExternalButton: bondedDevices threw", t)
+                null
+            }
+        if (bondedDevice == null && !isKnownBlePtt) {
+            // Saved MAC has drifted: not in bond table and not in
+            // knownBlePtt. Log at WARN so field logcats surface the
+            // drift instead of silently dropping the reader attach.
+            // Deliberately don't clear the persisted MAC — the
+            // operator may be mid-repair (re-bonding the puck) and
+            // we don't want to forget for them. A follow-up UI hook
+            // could offer to clear it; not in this PR.
+            Log.w(
+                TAG,
+                "connectSavedExternalButton: saved MAC $redactedSaved no longer bonded and not in " +
+                    "knownBlePtt — reader will not spawn; persisted MAC left in place for operator repair",
+            )
+            return
+        }
+        val primary = settings.persistedAinaMac()
+        if (primary != null && primary.equals(savedMac, ignoreCase = true)) {
+            Log.w(TAG, "connectSavedExternalButton: $redactedSaved collides with primary — skipping")
+            return
+        }
+        // Live-resolve the kind on every connect. This closes the
+        // staleness surface identified 2026-07-11: previously the
+        // persisted kind was written once at pick time and never
+        // re-checked, so an operator who added the same MAC to
+        // knownBlePtt AFTER picking it wound up with a stale kind
+        // that misclassified the reader on next cold launch. Live
+        // resolve consults knownBlePtt first, then the SDP-based
+        // classifier, then the persisted hint — see
+        // [ExternalButtonKindResolver] for the precedence contract.
+        val kind = resolveConnectKind(savedMac)
+        val macForConnect = bondedDevice?.address ?: savedMac
+        val nameForConnect = bondedDevice?.name
+        Log.i(
+            TAG,
+            "connectSavedExternalButton: mac=$redactedSaved kind=$kind (knownBlePtt=$isKnownBlePtt, " +
+                "bonded=${bondedDevice != null})",
+        )
+        lastExternalButtonMac = macForConnect
+        voiceClient?.ifBound { it.connectExternalButton(macForConnect, nameForConnect, kind) }
         lastExternalButtonConnected = true
     }
 
@@ -3496,35 +3621,58 @@ class XvMapComponent : AbstractMapComponent() {
             else -> null
         }
 
-    // Resolve the reader "kind" string for a given MAC. Known BLE PTT
-    // devices (added via the settings Scan-for-BLE-PTT dialog) are
-    // always driven by the BLE-HID / HM-10 reader — the SDP-based
-    // classifier can't confirm this because HM-10 devices don't
-    // expose their vendor UUID over BR/EDR SDP (and PTT-Z01 doesn't
-    // bond at all), so we short-circuit before the classifier runs.
-    // Everything else falls through to the classifier: SPP → v1,
-    // BLE → v2, BLE_HID → ble-hid, unknown → auto.
+    // Resolve the reader "kind" string for a given MAC. Precedence:
+    //
+    //   1. If the MAC is in `knownBlePttDevices` (operator scanned it in
+    //      via "Scan for BLE PTT device"), always "ble-hid" — HM-10 /
+    //      PTT-Z pucks don't expose the BLE vendor UUID over BR/EDR SDP
+    //      so the classifier can miss it entirely.
+    //   2. Otherwise, whatever the SDP-based classifier says: SPP → v1,
+    //      BLE → v2, BLE_HID → ble-hid, unknown → falls through.
+    //   3. Otherwise, the last-persisted hint for this MAC (retained as
+    //      a "last resort" so a bonded device the classifier can no
+    //      longer see still spins up a reader instead of collapsing to
+    //      "auto" = no reader).
+    //   4. Otherwise "auto".
+    //
+    // Pure decision lives in [ExternalButtonKindResolver] so the
+    // precedence rules are unit-testable independent of the Bluetooth
+    // stack. This function is the live wrapper that runs the
+    // classifier + hint reads and hands the results to the resolver.
+    //
+    // Field bug 2026-07-11: operator added the same Pryme puck to
+    // knownBlePtt AFTER picking it as the External Button, and a
+    // stale persisted kind then survived the knownBlePtt add. Fix is
+    // in [connectSavedExternalButton] — call this method fresh at
+    // connect time instead of reading `persistedExternalButtonKind()`
+    // directly.
     private fun resolveConnectKind(mac: String): String {
-        if (settings.knownBlePttDevices().any { (m, _) -> m.equals(mac, ignoreCase = true) }) {
-            return "ble-hid"
-        }
-        return try {
-            val adapter = BluetoothAdapter.getDefaultAdapter()
-            val device = adapter?.getRemoteDevice(mac)
-            if (device == null) {
-                "auto"
-            } else {
-                when (com.atakmap.android.xv.aina.AinaDeviceClassifier.classifyButtonProtocol(device)) {
-                    com.atakmap.android.xv.aina.AinaDeviceInfo.ButtonProtocol.SPP -> "v1"
-                    com.atakmap.android.xv.aina.AinaDeviceInfo.ButtonProtocol.BLE -> "v2"
-                    com.atakmap.android.xv.aina.AinaDeviceInfo.ButtonProtocol.BLE_HID -> "ble-hid"
-                    else -> "auto"
+        val isInKnownBlePtt =
+            settings.knownBlePttDevices().any { (m, _) -> m.equals(mac, ignoreCase = true) }
+        val classifierResult: String? =
+            try {
+                val adapter = BluetoothAdapter.getDefaultAdapter()
+                val device = adapter?.getRemoteDevice(mac)
+                if (device == null) {
+                    null
+                } else {
+                    when (com.atakmap.android.xv.aina.AinaDeviceClassifier.classifyButtonProtocol(device)) {
+                        com.atakmap.android.xv.aina.AinaDeviceInfo.ButtonProtocol.SPP -> "v1"
+                        com.atakmap.android.xv.aina.AinaDeviceInfo.ButtonProtocol.BLE -> "v2"
+                        com.atakmap.android.xv.aina.AinaDeviceInfo.ButtonProtocol.BLE_HID -> "ble-hid"
+                        else -> null
+                    }
                 }
+            } catch (t: Throwable) {
+                Log.w(TAG, "could not classify $mac for kind, falling back to hint / auto", t)
+                null
             }
-        } catch (t: Throwable) {
-            Log.w(TAG, "could not classify $mac for kind, falling back to auto", t)
-            "auto"
-        }
+        val persistedHint = settings.persistedExternalButtonKind()
+        return com.atakmap.android.xv.aina.ExternalButtonKindResolver.resolve(
+            isInKnownBlePtt = isInKnownBlePtt,
+            classifierResult = classifierResult,
+            persistedHint = persistedHint,
+        )
     }
 
     private fun isAinaConnected(): Boolean = ainaBle != null || ainaSpp != null

--- a/app/src/main/java/com/atakmap/android/xv/service/XvVoiceClient.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/XvVoiceClient.kt
@@ -39,6 +39,22 @@ class XvVoiceClient(
     // sends ~20 setting writes); past that we drop oldest with a WARN.
     private val pendingActionsCap: Int = 256
 
+    // Plugin-side callbacks scheduled to run once the AIDL binder is
+    // ready. Distinct from [pendingActions] because these do NOT need
+    // the IXvVoice reference — they're plugin-only bookkeeping (e.g.
+    // starting an auto-connect flow that itself dispatches via
+    // ifBound). Draining runs on the ServiceConnection callback thread
+    // AFTER pendingActions have been replayed so any AIDL side effects
+    // they enqueue land after the persistent-settings replay. Each
+    // entry runs at most once; drained + cleared on bind. Callers that
+    // want repeat-on-rebind semantics use [setPersistent]. See
+    // [whenBound] for the entry point.
+    //
+    // Guarded by a synchronized block on itself so
+    // whenBound-inserts and onServiceConnected-drains can't race and
+    // leave a callback un-run or double-run.
+    private val onBindCallbacks: MutableList<Pair<String, () -> Unit>> = mutableListOf()
+
     // "Persistent" settings — last value the plugin pushed for a given
     // setting key. On binder reconnect after a service crash we replay
     // these so the new IXvVoice starts in the same state. Keyed by a
@@ -129,6 +145,26 @@ class XvVoiceClient(
                         a(v)
                     } catch (t: Throwable) {
                         Log.w(TAG, "pending action threw", t)
+                    }
+                }
+                // Drain plugin-side on-bind callbacks after all AIDL
+                // replay is done. These are typically startup flows
+                // that themselves dispatch through ifBound() — running
+                // them here guarantees the binder is live so those
+                // dispatches take the immediate-invoke path rather
+                // than re-queueing.
+                val callbacks =
+                    synchronized(onBindCallbacks) {
+                        val snapshot = onBindCallbacks.toList()
+                        onBindCallbacks.clear()
+                        snapshot
+                    }
+                for ((name, cb) in callbacks) {
+                    try {
+                        Log.i(TAG, "onServiceConnected: firing whenBound callback '$name'")
+                        cb()
+                    } catch (t: Throwable) {
+                        Log.w(TAG, "whenBound callback '$name' threw", t)
                     }
                 }
             }
@@ -240,6 +276,59 @@ class XvVoiceClient(
                 listener = l
             } catch (t: Throwable) {
                 Log.w(TAG, "setListener: register threw", t)
+            }
+        }
+    }
+
+    /**
+     * True iff the AIDL binder is currently bound (i.e. IXvVoice
+     * calls can be dispatched immediately without queueing). Callers
+     * that want to key off "is the voice plant actually reachable
+     * right now" — e.g. auto-connect flows that don't want to spin
+     * up a queued action against a service that hasn't finished
+     * binding yet — read this. Distinct from "has the client been
+     * started" which is a plugin-side lifecycle question.
+     */
+    fun isBound(): Boolean = voice != null
+
+    /**
+     * Run [action] once, on the AIDL bind. If the binder is already
+     * bound, [action] runs synchronously on the caller's thread. If
+     * not, it's queued and runs from [ServiceConnection.onServiceConnected]
+     * after the persistent-settings replay + pending-action drain.
+     *
+     * [name] is used only for log tagging so a wedged bind path
+     * shows which callback failed to fire.
+     *
+     * Unlike [ifBound] this does NOT receive an [IXvVoice] argument —
+     * it's for plugin-side flows (auto-connect, restoration) that
+     * themselves route AIDL work through the client's ifBound / other
+     * methods. Callers that want repeat-on-rebind semantics use
+     * [setPersistent] instead.
+     */
+    fun whenBound(
+        name: String,
+        action: () -> Unit,
+    ) {
+        // Snapshot bound state under the same lock we use to guard
+        // the callback list so a bind edge racing us can't lose the
+        // callback (edge fires → clears list; we then insert; nothing
+        // drains it). Under the lock: if already bound, run inline;
+        // else enqueue. Either way the callback executes exactly once.
+        val runNow =
+            synchronized(onBindCallbacks) {
+                if (voice != null) {
+                    true
+                } else {
+                    onBindCallbacks.add(name to action)
+                    false
+                }
+            }
+        if (runNow) {
+            try {
+                action()
+            } catch (t: Throwable) {
+                Log.w(TAG, "whenBound '$name' inline invoke threw", t)
             }
         }
     }

--- a/app/src/test/java/com/atakmap/android/xv/aina/ExternalButtonKindResolverTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/aina/ExternalButtonKindResolverTest.kt
@@ -1,0 +1,296 @@
+package com.atakmap.android.xv.aina
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Coverage for the External Button kind-resolution precedence. Pins
+ * the semantic contract that
+ * [com.atakmap.android.xv.plugin.XvMapComponent.resolveConnectKind]
+ * and [com.atakmap.android.xv.plugin.XvMapComponent.connectSavedExternalButton]
+ * rely on:
+ *
+ *  - a known-BLE-PTT membership always beats the classifier and any
+ *    persisted hint — this is the invariant that closes the
+ *    2026-07-11 field bug where a MAC added to knownBlePtt AFTER
+ *    being picked as the External Button was surviving a stale
+ *    persisted kind across cold launches;
+ *  - the SDP-based classifier's answer wins over the persisted hint
+ *    when it's a concrete "v1" / "v2" / "ble-hid";
+ *  - a classifier "auto" result is treated as a punt so the hint
+ *    can recover the reader;
+ *  - the persisted hint is the last-resort fallback so a bonded
+ *    device the classifier can no longer see (e.g. a bonded puck
+ *    Android forgot how to enumerate over SDP) still spins up a
+ *    reader instead of collapsing to "auto" = no reader;
+ *  - "auto" is the terminal fallback when nothing else has an
+ *    opinion.
+ *
+ * Uses placeholder MACs implicitly via the parameter names — the
+ * resolver takes booleans / strings, not MACs, because the MAC
+ * lookup is a caller responsibility.
+ */
+class ExternalButtonKindResolverTest {
+    // ---- Known-BLE-PTT wins everything ----
+
+    @Test
+    fun `knownBlePtt beats classifier v1`() {
+        // The 2026-07-11 field bug's canonical case: MAC is in
+        // knownBlePtt but the SDP classifier said SPP. Without the
+        // knownBlePtt precedence rule, the stale classification wins
+        // and the operator's puck presses silently drop.
+        assertEquals(
+            "knownBlePtt membership must override an SPP classifier result",
+            "ble-hid",
+            ExternalButtonKindResolver.resolve(
+                isInKnownBlePtt = true,
+                classifierResult = "v1",
+                persistedHint = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `knownBlePtt beats classifier v2`() {
+        assertEquals(
+            "ble-hid",
+            ExternalButtonKindResolver.resolve(
+                isInKnownBlePtt = true,
+                classifierResult = "v2",
+                persistedHint = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `knownBlePtt beats stale persisted hint`() {
+        // The 2026-07-11 field-report second variant: operator picked
+        // the bonded MAC before adding it to knownBlePtt, persisted
+        // kind was written as "v1" from the classifier, then the
+        // scan-and-add wrote the MAC into knownBlePtt. The persisted
+        // hint on next cold launch must not win over the fresh
+        // knownBlePtt precedence.
+        assertEquals(
+            "ble-hid",
+            ExternalButtonKindResolver.resolve(
+                isInKnownBlePtt = true,
+                classifierResult = null,
+                persistedHint = "v1",
+            ),
+        )
+    }
+
+    @Test
+    fun `knownBlePtt with no other inputs still resolves to ble-hid`() {
+        assertEquals(
+            "ble-hid",
+            ExternalButtonKindResolver.resolve(
+                isInKnownBlePtt = true,
+                classifierResult = null,
+                persistedHint = null,
+            ),
+        )
+    }
+
+    // ---- Classifier wins when its result is concrete ----
+
+    @Test
+    fun `classifier v1 wins over persisted hint`() {
+        assertEquals(
+            "v1",
+            ExternalButtonKindResolver.resolve(
+                isInKnownBlePtt = false,
+                classifierResult = "v1",
+                persistedHint = "ble-hid",
+            ),
+        )
+    }
+
+    @Test
+    fun `classifier v2 wins over persisted hint`() {
+        assertEquals(
+            "v2",
+            ExternalButtonKindResolver.resolve(
+                isInKnownBlePtt = false,
+                classifierResult = "v2",
+                persistedHint = "v1",
+            ),
+        )
+    }
+
+    @Test
+    fun `classifier ble-hid wins over persisted hint`() {
+        assertEquals(
+            "ble-hid",
+            ExternalButtonKindResolver.resolve(
+                isInKnownBlePtt = false,
+                classifierResult = "ble-hid",
+                persistedHint = "v1",
+            ),
+        )
+    }
+
+    // ---- Classifier "auto" is a punt: hint gets a chance ----
+
+    @Test
+    fun `classifier auto lets persisted hint win`() {
+        // "auto" from the classifier is the "I don't know" answer —
+        // don't let it flatten a real hint. This is the recovery
+        // path for a device the classifier can no longer see.
+        assertEquals(
+            "v2",
+            ExternalButtonKindResolver.resolve(
+                isInKnownBlePtt = false,
+                classifierResult = "auto",
+                persistedHint = "v2",
+            ),
+        )
+    }
+
+    @Test
+    fun `classifier auto case-insensitive`() {
+        // Case-insensitive so a caller passing "AUTO" or "Auto"
+        // doesn't accidentally pin the reader to a bad kind.
+        assertEquals(
+            "ble-hid",
+            ExternalButtonKindResolver.resolve(
+                isInKnownBlePtt = false,
+                classifierResult = "AUTO",
+                persistedHint = "ble-hid",
+            ),
+        )
+    }
+
+    // ---- Persisted hint as last-resort ----
+
+    @Test
+    fun `null classifier lets persisted hint win`() {
+        // Classifier could not run (adapter null, device not bonded,
+        // SDP threw). Fall back to the hint so a bonded-but-
+        // unclassifiable puck still gets a reader.
+        assertEquals(
+            "ble-hid",
+            ExternalButtonKindResolver.resolve(
+                isInKnownBlePtt = false,
+                classifierResult = null,
+                persistedHint = "ble-hid",
+            ),
+        )
+    }
+
+    @Test
+    fun `blank classifier lets persisted hint win`() {
+        assertEquals(
+            "v1",
+            ExternalButtonKindResolver.resolve(
+                isInKnownBlePtt = false,
+                classifierResult = "",
+                persistedHint = "v1",
+            ),
+        )
+    }
+
+    @Test
+    fun `whitespace classifier lets persisted hint win`() {
+        assertEquals(
+            "v2",
+            ExternalButtonKindResolver.resolve(
+                isInKnownBlePtt = false,
+                classifierResult = "   ",
+                persistedHint = "v2",
+            ),
+        )
+    }
+
+    // ---- Terminal fallback: "auto" ----
+
+    @Test
+    fun `no inputs at all resolves to auto`() {
+        assertEquals(
+            "auto",
+            ExternalButtonKindResolver.resolve(
+                isInKnownBlePtt = false,
+                classifierResult = null,
+                persistedHint = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `classifier auto and no hint resolves to auto`() {
+        assertEquals(
+            "auto",
+            ExternalButtonKindResolver.resolve(
+                isInKnownBlePtt = false,
+                classifierResult = "auto",
+                persistedHint = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `classifier auto and hint auto resolves to auto`() {
+        assertEquals(
+            "auto",
+            ExternalButtonKindResolver.resolve(
+                isInKnownBlePtt = false,
+                classifierResult = "auto",
+                persistedHint = "auto",
+            ),
+        )
+    }
+
+    @Test
+    fun `blank hint falls through to auto`() {
+        assertEquals(
+            "auto",
+            ExternalButtonKindResolver.resolve(
+                isInKnownBlePtt = false,
+                classifierResult = null,
+                persistedHint = "",
+            ),
+        )
+    }
+
+    @Test
+    fun `whitespace hint falls through to auto`() {
+        assertEquals(
+            "auto",
+            ExternalButtonKindResolver.resolve(
+                isInKnownBlePtt = false,
+                classifierResult = null,
+                persistedHint = "   ",
+            ),
+        )
+    }
+
+    // ---- Trimming ----
+
+    @Test
+    fun `classifier result is trimmed`() {
+        // Defensive — no known caller passes untrimmed strings but
+        // the resolver's contract is to treat leading/trailing
+        // whitespace as insignificant, matching the rest of the XV
+        // string-handling surface.
+        assertEquals(
+            "v2",
+            ExternalButtonKindResolver.resolve(
+                isInKnownBlePtt = false,
+                classifierResult = "  v2  ",
+                persistedHint = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `persisted hint is trimmed`() {
+        assertEquals(
+            "ble-hid",
+            ExternalButtonKindResolver.resolve(
+                isInKnownBlePtt = false,
+                classifierResult = null,
+                persistedHint = "  ble-hid  ",
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Two field-reported External Button reader-lifecycle failures observed 2026-07-11 on Pixel 9 Pro. Same code area (`XvMapComponent.autoConnectExternalButton` / `connectSavedExternalButton` / `resolveConnectKind`), same problem class — ship as one PR per bundling preference.

Ready for review — do NOT self-merge.

---

## Bug 1 — Cold-launch attach timing

**Symptom:** operator force-stops ATAK, relaunches. Physical Pryme puck presses do not reach `XvVoicePlant` for ~10 s until the operator manually pokes the picker.

**Root cause:** `autoConnectExternalButton` scheduled a `postDelayed(1400 ms)` runnable at plugin load. On a cold launch the runnable could fire BEFORE the voice service AIDL bind completed. `voiceClient.ifBound` queued the `connectExternalButton` call for later, but plugin-side state (`lastExternalButtonMac` / `lastExternalButtonConnected`) was set immediately — so the picker showed the slot as "connected" while no reader existed. The queued action eventually drained when the binder came up, spawning the reader with a ~10 s recovery window instead of instantly.

**Fix:** rewire the auto-connect off a new `XvVoiceClient.whenBound(name, action)` hook that fires from `ServiceConnection.onServiceConnected` after the persistent-settings replay + pending-action drain. When the callback runs, the binder is definitely live — any `ifBound` dispatches the auto-connect makes take the immediate-invoke path, not the queue.

A belt-and-suspenders 3000 ms fallback runs the auto-connect anyway with a WARN log so a wedged bind can't strand the External Button slot dark forever. First-runner wins via a `@Volatile` `externalButtonAutoConnectFired` flag — the fallback no-ops when the AIDL bind fires first (the common path).

Every branch in `runAutoConnectExternalButton` now logs at INFO, including an entry/complete pair with the trigger source (`aidl-bound` or `fallback-timer`), so future field logcats show exactly which path fired without having to reproduce the bug.

Primary AINA path (`autoConnectAina`) is **deliberately unchanged** — it relies on OS-brokered SPP auto-connect edges via the `BluetoothHeadset` profile proxy, which is a different problem class and not in scope here.

---

## Bug 2 — Persisted kind staleness

**Symptom:** operator adds the same Pryme puck via BOTH Android BT Settings (system bond) AND XV Settings → "Scan for BLE PTT device" (adds to `knownBlePttDevices`). If the pick happened BEFORE the scan-and-add, the persisted kind sticks as whatever the SDP classifier derived from the bonded classification. On next cold startup, the stale kind — not `"ble-hid"` — is used to spawn the reader. Button presses silently drop.

**Root cause:** `connectSavedExternalButton` read `settings.persistedExternalButtonKind() ?: "auto"`. That cache was written once at pick time (`setSelectedExternalButtonInternal`) and never re-checked against a subsequent `knownBlePttDevices` add.

**Fix (live-resolve variant):** drop the read of `persistedExternalButtonKind()` from `connectSavedExternalButton` entirely. Compute the kind fresh via `resolveConnectKind(mac)` on every connect. `knownBlePttDevices` IS the source of truth at connect time — no cache in the connect path, no staleness surface.

To make the precedence rules unit-testable, the pure decision moved to a new `ExternalButtonKindResolver`:

1. `knownBlePtt` membership wins (always `"ble-hid"`) — HM-10 / PTT-Z pucks don't expose their vendor UUID over BR/EDR SDP, so the classifier can miss it entirely.
2. Concrete classifier result (`"v1"` / `"v2"` / `"ble-hid"`) wins next.
3. Classifier `"auto"` is treated as a punt so the persisted hint gets a chance.
4. Persisted hint is a last-resort so a bonded-but-unclassifiable device (e.g. a puck Android forgot how to enumerate over SDP after a system update) still spawns a reader instead of collapsing to `"auto"` (which resolves to "no reader" at connect time).
5. Terminal fallback: `"auto"`.

The persisted kind is retained as a hint only, seeding step 4. New 19-case JUnit suite in `ExternalButtonKindResolverTest` covers each precedence level plus trim / case-insensitivity edges. Uses non-MAC boolean/string inputs so it runs on the JVM without a BT adapter.

---

## Additional hardening in `connectSavedExternalButton`

- If the saved MAC is in `knownBlePttDevices` but not currently in the bond table (PTT-Z01 in particular refuses to bond at all), skip the bonded-devices lookup and drive the connect straight into the `ble-hid` reader path. Previously that case took the "no longer bonded" WARN branch and never spawned the reader.
- When neither `knownBlePttDevices` nor the bond table has the MAC, log at WARN so field logcats surface the drift, but leave the persisted MAC in place for operator repair (they may be mid-repair — re-bonding the puck — and we don't want to forget for them).

---

## Explicitly not in scope

- Primary AINA auto-connect timing (different problem class — OS-brokered SPP edges).
- No new `AndroidManifest` permissions.
- No AIDL bumps.
- No new Settings toggles.
- No UI changes beyond INFO logging.
- No changes to picker display / dedup.

## Test plan

- [x] `./gradlew ktlintCheck` — green
- [x] `./gradlew assembleCivDebug` — green
- [x] `./gradlew testCivDebugUnitTest` — green with 19 new tests in `ExternalButtonKindResolverTest`
- [ ] Field validation: on Pixel 9 Pro, force-stop ATAK, relaunch, verify Pryme puck presses reach `XvVoicePlant` immediately (no manual picker poke, no 10 s wait). Logcat should show `autoConnectExternalButton[aidl-bound]: entry` followed by `connectSavedExternalButton: mac=... kind=ble-hid`.
- [ ] Field validation: pair a puck via Android BT Settings, pick as External Button, then add via XV Settings → "Scan for BLE PTT device", force-stop, relaunch, verify reader spawns as `kind=ble-hid` (previously would spawn with stale classifier kind).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>