### PR TITLE
refactor(log): PTT log prefix picks correct slot label per PttSource

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/audio/PttSource.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/PttSource.kt
@@ -60,3 +60,25 @@ enum class PttSource(val dropsTrailingClick: Boolean) {
         val DEFAULT: PttSource = ON_SCREEN
     }
 }
+
+// Human-readable log prefix per PTT source. Used by [VoicePlant]'s
+// primary-AINA and external-button handler factories so a Pryme puck
+// wired into the External Button slot doesn't get logged as
+// "primary AINA button" (which it isn't). Pure function — no state,
+// no side effects — so it can be unit-tested in isolation.
+//
+// The `when` is exhaustive over the enum today. If a future enum value
+// is added without a matching branch here, the Kotlin compiler will
+// flag it and the operator will pick a real label rather than
+// shipping a misleading default.
+fun logPrefixForPttSource(source: PttSource): String =
+    when (source) {
+        PttSource.ON_SCREEN -> "on-screen PTT"
+        PttSource.AINA_V1 -> "primary AINA V1 button"
+        PttSource.AINA_V2 -> "primary AINA V2 button"
+        PttSource.PRYME_BLE -> "external button"
+        PttSource.SAMSUNG_ACTIVE_KEY -> "Samsung Active Key"
+        PttSource.SONIM_PTT -> "Sonim PTT"
+        PttSource.SONIM_EMERGENCY -> "Sonim Emergency"
+        PttSource.DEBUG -> "debug PTT"
+    }

--- a/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
@@ -30,6 +30,7 @@ import com.atakmap.android.xv.audio.StatusTones
 import com.atakmap.android.xv.audio.TptPlayer
 import com.atakmap.android.xv.audio.TptTone
 import com.atakmap.android.xv.audio.TxController
+import com.atakmap.android.xv.audio.logPrefixForPttSource
 import com.atakmap.android.xv.ptt.SamsungActiveKeyReader
 import com.atakmap.android.xv.ptt.SonimEmergencyButtonReader
 import com.atakmap.android.xv.ptt.SonimPttButtonReader
@@ -1859,7 +1860,7 @@ class VoicePlant(
     // there's no risk of half-press accidental dispatch.
     private fun primaryAinaEvent(source: PttSource): (AinaButton, Boolean) -> Unit =
         { btn, down ->
-            Log.i(TAG, "primary AINA button $btn down=$down source=$source")
+            Log.i(TAG, "${logPrefixForPttSource(source)} $btn down=$down source=$source")
             when (btn) {
                 AinaButton.PTTE -> callbacks.onEmergencyButton(down)
                 AinaButton.PTT -> if (down) pttDown(0, source) else pttUp(0, source)
@@ -1879,7 +1880,7 @@ class VoicePlant(
     // the user asked for.
     private fun externalButtonEvent(source: PttSource): (AinaButton, Boolean) -> Unit =
         { btn, down ->
-            Log.i(TAG, "external button $btn down=$down source=$source")
+            Log.i(TAG, "${logPrefixForPttSource(source)} $btn down=$down source=$source")
             when (btn) {
                 AinaButton.PTT -> if (down) pttDown(0, source) else pttUp(0, source)
                 else -> { /* external button does not drive PTTS/PTTE/MFB */ }

--- a/app/src/test/java/com/atakmap/android/xv/audio/PttSourceLogPrefixTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/audio/PttSourceLogPrefixTest.kt
@@ -1,0 +1,53 @@
+package com.atakmap.android.xv.audio
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Coverage for [logPrefixForPttSource]. The helper feeds VoicePlant's
+ * primary-AINA and external-button log lines — one assertion per enum
+ * value so a rename in [PttSource] or a mislabelled branch is caught
+ * at test-time rather than in field logs. Pure function; no Robolectric
+ * shell needed.
+ */
+class PttSourceLogPrefixTest {
+    @Test
+    fun `on-screen source maps to on-screen PTT`() {
+        assertEquals("on-screen PTT", logPrefixForPttSource(PttSource.ON_SCREEN))
+    }
+
+    @Test
+    fun `AINA V1 source maps to primary AINA V1 button`() {
+        assertEquals("primary AINA V1 button", logPrefixForPttSource(PttSource.AINA_V1))
+    }
+
+    @Test
+    fun `AINA V2 source maps to primary AINA V2 button`() {
+        assertEquals("primary AINA V2 button", logPrefixForPttSource(PttSource.AINA_V2))
+    }
+
+    @Test
+    fun `Pryme BLE source maps to external button`() {
+        assertEquals("external button", logPrefixForPttSource(PttSource.PRYME_BLE))
+    }
+
+    @Test
+    fun `Samsung Active Key source maps to Samsung Active Key`() {
+        assertEquals("Samsung Active Key", logPrefixForPttSource(PttSource.SAMSUNG_ACTIVE_KEY))
+    }
+
+    @Test
+    fun `Sonim PTT source maps to Sonim PTT`() {
+        assertEquals("Sonim PTT", logPrefixForPttSource(PttSource.SONIM_PTT))
+    }
+
+    @Test
+    fun `Sonim Emergency source maps to Sonim Emergency`() {
+        assertEquals("Sonim Emergency", logPrefixForPttSource(PttSource.SONIM_EMERGENCY))
+    }
+
+    @Test
+    fun `debug source maps to debug PTT`() {
+        assertEquals("debug PTT", logPrefixForPttSource(PttSource.DEBUG))
+    }
+}


### PR DESCRIPTION
## Summary

Small, log-clarity-only refactor. VoicePlant's primary-AINA and
external-button handler factories both hardcoded their log prefix
regardless of which `PttSource` actually drove the edge, producing
lines like:

```
XvVoicePlant: primary AINA button PTT down=false source=PRYME_BLE
```

on a Samsung Tab Active5 with a Pryme puck wired into the External
Button slot. The prefix said `primary AINA button` but the source
was `PRYME_BLE` — misleading when reading field logs across
mixed-hardware operators.

## Fix

Introduce a pure top-level helper `logPrefixForPttSource(source)`
in the same file as `PttSource`, and route both call sites through
it:

```kotlin
Log.i(TAG, "${logPrefixForPttSource(source)} $btn down=$down source=$source")
```

- `ON_SCREEN` → `on-screen PTT`
- `AINA_V1` → `primary AINA V1 button`
- `AINA_V2` → `primary AINA V2 button`
- `PRYME_BLE` → `external button`
- `SAMSUNG_ACTIVE_KEY` → `Samsung Active Key`
- `SONIM_PTT` → `Sonim PTT`
- `SONIM_EMERGENCY` → `Sonim Emergency`
- `DEBUG` → `debug PTT`

The `when` is exhaustive over the enum; a future `PttSource`
addition will trip the Kotlin compiler rather than silently
regress to a wrong label. Trailing `source=$source` is preserved
so grep on the exact enum value still matches when the prefix is
generic (`debug PTT`).

## No behavior change

- State machine, TX/RX path, PTT dispatch, toast wording,
  AIDL surface, PttDispatcher OR-gate — all untouched.
- Log strings only.

## Test plan

- [x] `./gradlew ktlintCheck` — green
- [x] `./gradlew assembleCivDebug` — green
- [x] `./gradlew testCivDebugUnitTest` — green, includes new
      `PttSourceLogPrefixTest` covering all 8 enum values
- [ ] Field verify next mixed-hardware session that the External
      slot line reads `external button PTT down=... source=PRYME_BLE`
      (or the appropriate label if the External slot is populated
      with something other than a Pryme puck in the future).