### PR TITLE
fix(bt): skip A2DP-forbid on BLE_HID pucks + dedup adapter STATE_TURNING_OFF cascade

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/audio/AinaA2dpWiring.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/AinaA2dpWiring.kt
@@ -13,6 +13,7 @@ import android.os.Build
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.atakmap.android.xv.aina.AinaDeviceClassifier
+import com.atakmap.android.xv.aina.AinaDeviceInfo
 
 /**
  * Wires [AinaA2dpController] into the BT-device lifecycle so AINA-class
@@ -46,8 +47,23 @@ import com.atakmap.android.xv.aina.AinaDeviceClassifier
 class AinaA2dpWiring(
     private val context: Context,
     private val controller: AinaA2dpController,
+    // Whether this device is a plausible speakermic (broad AINA-class
+    // filter used to gate the forbid path). Kept as an injected predicate
+    // so unit tests can stub the classifier.
     private val isAina: (BluetoothDevice) -> Boolean =
         { AinaDeviceClassifier.isPlausibleSpeakermic(it) },
+    // Button-protocol classifier used to narrow the forbid path further.
+    // BLE_HID pucks (Pryme BT-PTT-Z et al.) match the broad plausible-
+    // speakermic name/UUID filter but have NO A2DP profile at all —
+    // firing the reflective setConnectionPolicy(FORBIDDEN) against them
+    // is a no-op on the OK path and, on the Pixel 14+ platform-refused
+    // path, posts an "AINA media routing not blocked. Disable 'Media
+    // audio'" operator notification for a device that has no media
+    // routing to begin with. Injected for the same testability reason
+    // as [isAina]. Reported by operator 2026-07-11 against a Pryme
+    // BT-PTT-Z on a Pixel 9 Pro.
+    private val buttonProtocolOf: (BluetoothDevice) -> AinaDeviceInfo.ButtonProtocol =
+        { AinaDeviceClassifier.classifyButtonProtocol(it) },
     private val notificationManager: NotificationManager? =
         context.getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager,
     private val audioManager: AudioManager? =
@@ -76,6 +92,25 @@ class AinaA2dpWiring(
     override fun onDeviceConnected(device: BluetoothDevice) {
         val mac = device.address ?: return
         if (!isAina(device)) return
+        // BLE_HID short-circuit — see [buttonProtocolOf] KDoc for why.
+        // Any classifier throw is treated as UNKNOWN so the forbid path
+        // is preserved on the safe side (better a spurious no-op forbid
+        // on a UNKNOWN device than a missed forbid on a real AINA whose
+        // UUID cache momentarily errored out).
+        val protocol =
+            try {
+                buttonProtocolOf(device)
+            } catch (t: Throwable) {
+                Log.w(TAG, "buttonProtocolOf threw for $mac — treating as UNKNOWN", t)
+                AinaDeviceInfo.ButtonProtocol.UNKNOWN
+            }
+        if (protocol == AinaDeviceInfo.ButtonProtocol.BLE_HID) {
+            Log.d(
+                TAG,
+                "onDeviceConnected: $mac is BLE_HID (no A2DP profile) — skipping forbid path",
+            )
+            return
+        }
         if (!forbiddenOnce.add(mac)) {
             Log.d(TAG, "onDeviceConnected: $mac already forbidden this lifetime — skipping")
             return

--- a/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
@@ -175,10 +175,42 @@ class XvVoiceService : Service() {
         }
     }
 
+    // Dedup guard state for the adapter-state broadcast — see
+    // [shouldReactToAdapterState] for the mapping. Updated only from
+    // [btAdapterStateReceiver.onReceive] which runs on the main thread,
+    // but marked @Volatile as belt-and-suspenders so a hypothetical
+    // OEM stack that dispatches the broadcast on a worker thread does
+    // not race on the read.
+    @Volatile
+    private var lastAdapterStateSeen: Int = android.bluetooth.BluetoothAdapter.ERROR
+
+    @Volatile
+    private var lastAdapterStateReactedAtMs: Long = 0L
+
     // Fires on `BluetoothAdapter.ACTION_STATE_CHANGED`. On
     // `STATE_TURNING_OFF` we cascade a PTT release across all BT-sourced
     // inputs — see the registration site in onCreate for the field bug
     // this closes.
+    //
+    // Field bug 2026-07-11 (Samsung Tab5): the same STATE_TURNING_OFF
+    // broadcast arrived twice ~116 ms apart, driving two identical
+    // releaseAllBtSourcedPtt() calls and two identical WARN lines in
+    // logcat (12:44:03.888 and 12:44:04.004). The underlying cause is
+    // Samsung's BT stack double-firing ACTION_STATE_CHANGED for
+    // STATE_TURNING_OFF — a known behavior on some OEM builds. The
+    // cascade itself is idempotent (forgetSource on an already-forgotten
+    // slot is a no-op), so this is not a correctness bug, but it is
+    // log noise the operator has to filter through when triaging a
+    // BT-off cascade.
+    //
+    // We dedup by remembering the last observed state + the last time
+    // we reacted to it, and short-circuiting when the same state arrives
+    // inside [ADAPTER_STATE_DEDUP_WINDOW_MS]. We deliberately do NOT try
+    // to prevent the double registration itself — there is only one
+    // registration in this service; the double-fire is an OS behavior
+    // outside our control. Dedupping the response makes us resilient to
+    // future OEM builds that add or remove the double-fire behavior
+    // without needing to change the receiver plumbing.
     private val btAdapterStateReceiver =
         object : android.content.BroadcastReceiver() {
             override fun onReceive(
@@ -196,6 +228,26 @@ class XvVoiceService : Service() {
                 ) {
                     return
                 }
+                val nowMs = android.os.SystemClock.elapsedRealtime()
+                val prevState = lastAdapterStateSeen
+                val prevReactedMs = lastAdapterStateReactedAtMs
+                if (!shouldReactToAdapterState(
+                        newState = state,
+                        lastState = prevState,
+                        nowMs = nowMs,
+                        lastReactedMs = prevReactedMs,
+                        thresholdMs = ADAPTER_STATE_DEDUP_WINDOW_MS,
+                    )
+                ) {
+                    Log.d(
+                        TAG,
+                        "BluetoothAdapter state=$state repeated within " +
+                            "${nowMs - prevReactedMs}ms — dedupped",
+                    )
+                    return
+                }
+                lastAdapterStateSeen = state
+                lastAdapterStateReactedAtMs = nowMs
                 Log.w(
                     TAG,
                     "BluetoothAdapter state=$state — cascading BT-sourced PTT release",
@@ -1935,5 +1987,49 @@ class XvVoiceService : Service() {
         // onBind/onRebind cancels the timer; onDestroy also cancels
         // (the timer's own stopSelf is what got us there).
         private const val ORPHAN_GRACE_MS: Long = 30_000L
+
+        // Dedup window for the BluetoothAdapter ACTION_STATE_CHANGED
+        // broadcast — see [btAdapterStateReceiver] KDoc for the field
+        // bug. 500 ms comfortably brackets the observed 116 ms
+        // double-fire gap on Samsung Tab5 without swallowing a genuine
+        // re-fire from a real second BT-off event (operators do not
+        // toggle BT off twice inside half a second).
+        internal const val ADAPTER_STATE_DEDUP_WINDOW_MS: Long = 500L
+
+        /**
+         * Pure decision function for the STATE_TURNING_OFF / STATE_OFF
+         * dedup guard. Extracted from [btAdapterStateReceiver] so it can
+         * be unit-tested without standing up a Robolectric BroadcastReceiver.
+         *
+         * @param newState the state just extracted from the broadcast.
+         * @param lastState the previously-observed state, or
+         *     [android.bluetooth.BluetoothAdapter.ERROR] on first call.
+         * @param nowMs elapsed-realtime clock at the moment of receipt.
+         * @param lastReactedMs elapsed-realtime clock at the moment we
+         *     last reacted (0 on first call).
+         * @param thresholdMs dedup window in ms; identical repeats within
+         *     this window are ignored.
+         *
+         * Behavior:
+         *  - First observation of any state (lastState is ERROR) - react.
+         *  - Different state than last - react (real state transition,
+         *    e.g. STATE_TURNING_OFF followed by STATE_OFF is normal and
+         *    both deserve their own cascade attempt).
+         *  - Same state observed after threshold - react (probably a
+         *    genuine re-fire from a real second BT-off event).
+         *  - Same state observed within threshold - do NOT react (the
+         *    OS double-fire case we are guarding against).
+         */
+        internal fun shouldReactToAdapterState(
+            newState: Int,
+            lastState: Int,
+            nowMs: Long,
+            lastReactedMs: Long,
+            thresholdMs: Long,
+        ): Boolean {
+            if (lastState == android.bluetooth.BluetoothAdapter.ERROR) return true
+            if (newState != lastState) return true
+            return (nowMs - lastReactedMs) >= thresholdMs
+        }
     }
 }

--- a/app/src/test/java/com/atakmap/android/xv/audio/AinaA2dpWiringTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/audio/AinaA2dpWiringTest.kt
@@ -4,6 +4,7 @@ import android.app.NotificationManager
 import android.bluetooth.BluetoothDevice
 import android.content.Context
 import android.media.AudioManager
+import com.atakmap.android.xv.aina.AinaDeviceInfo
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -134,5 +135,77 @@ class AinaA2dpWiringTest {
         wiring.onDeviceConnected(ainaDevice)
 
         verify(exactly = 1) { controller.forbid(ainaDevice) }
+    }
+
+    /**
+     * Field bug 2026-07-11 (Pixel 9 Pro + Pryme BT-PTT-Z): the wiring
+     * classified a Pryme BLE_HID puck as a "plausible speakermic" — its
+     * name contains "BT-PTT" — and fired the reflective A2DP forbid
+     * against it. On the Pixel 14+ platform-refused path this posted a
+     * "disable Media audio" operator notification for a device that has
+     * NO A2DP profile at all (BLE HID-over-GATT only). The narrow fix
+     * is to skip the forbid path entirely when the button-protocol
+     * classifier reports BLE_HID.
+     */
+    @Test
+    fun `BLE_HID device bypasses the forbid path`() {
+        val ctx = mockk<Context>(relaxed = true)
+        val controller = mockk<AinaA2dpController>(relaxed = true)
+        val pryme =
+            mockk<BluetoothDevice>(relaxed = true).also {
+                every { it.address } returns "AA:BB:CC:DD:EE:FF"
+            }
+        val wiring =
+            AinaA2dpWiring(
+                context = ctx,
+                controller = controller,
+                // Pryme's name pattern historically hit the plausible-
+                // speakermic filter — that path caused the field bug.
+                // The button-protocol classifier is what should short-
+                // circuit the forbid.
+                isAina = { true },
+                buttonProtocolOf = { AinaDeviceInfo.ButtonProtocol.BLE_HID },
+                notificationManager = null as NotificationManager?,
+                audioManager = null as AudioManager?,
+            )
+
+        wiring.onDeviceConnected(pryme)
+
+        verify(exactly = 0) { controller.forbid(any()) }
+    }
+
+    /**
+     * Every non-BLE_HID button protocol still exercises the forbid
+     * path. Guards against Fix 1 over-narrowing — an SPP AINA V1, a
+     * BLE AINA V2, an AUDIO_ONLY headset that happens to also match
+     * the plausible-speakermic filter, and an UNKNOWN device that
+     * squeaked through name matching all still get A2DP forbidden as
+     * before.
+     */
+    @Test
+    fun `non-BLE_HID protocols still fire the forbid path`() {
+        for (protocol in AinaDeviceInfo.ButtonProtocol.values()) {
+            if (protocol == AinaDeviceInfo.ButtonProtocol.BLE_HID) continue
+            val ctx = mockk<Context>(relaxed = true)
+            val controller = mockk<AinaA2dpController>(relaxed = true)
+            every { controller.forbid(any()) } returns AinaA2dpController.ForbidResult.OK
+            val dev =
+                mockk<BluetoothDevice>(relaxed = true).also {
+                    every { it.address } returns "AA:BB:CC:DD:EE:FF"
+                }
+            val wiring =
+                AinaA2dpWiring(
+                    context = ctx,
+                    controller = controller,
+                    isAina = { true },
+                    buttonProtocolOf = { protocol },
+                    notificationManager = null as NotificationManager?,
+                    audioManager = null as AudioManager?,
+                )
+
+            wiring.onDeviceConnected(dev)
+
+            verify(exactly = 1) { controller.forbid(dev) }
+        }
     }
 }

--- a/app/src/test/java/com/atakmap/android/xv/service/AdapterStateDedupTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/service/AdapterStateDedupTest.kt
@@ -1,0 +1,129 @@
+package com.atakmap.android.xv.service
+
+import android.bluetooth.BluetoothAdapter
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-function coverage for the STATE_TURNING_OFF / STATE_OFF dedup
+ * guard extracted from [XvVoiceService.btAdapterStateReceiver].
+ *
+ * Field bug 2026-07-11 (Samsung Tab5): the same
+ * BluetoothAdapter STATE_TURNING_OFF broadcast arrived twice ~116 ms
+ * apart, driving two identical releaseAllBtSourcedPtt() calls and two
+ * identical WARN lines. Samsung's BT stack is known to double-fire
+ * ACTION_STATE_CHANGED for STATE_TURNING_OFF on some builds. The
+ * cascade itself is idempotent, so this is a log-noise / operator-
+ * triage bug rather than a correctness bug — but the guard is worth
+ * pinning so the log surface stays clean.
+ *
+ * The receiver stores the last observed state + the last time it
+ * reacted, and asks [XvVoiceService.shouldReactToAdapterState] whether
+ * the new event deserves another cascade. This test exercises the
+ * four documented cases from the KDoc.
+ */
+class AdapterStateDedupTest {
+    // Chosen to comfortably bracket the observed 116 ms double-fire
+    // gap on Samsung Tab5 while not swallowing a genuine second BT-off
+    // event (operators do not toggle BT off twice inside half a second).
+    private val thresholdMs: Long = 500L
+
+    /**
+     * First observation of any state after service start — no prior
+     * state is remembered (sentinel is [BluetoothAdapter.ERROR]). The
+     * cascade MUST fire so the initial BT-off is handled.
+     */
+    @Test
+    fun `first observation of any state — react`() {
+        val decision =
+            XvVoiceService.shouldReactToAdapterState(
+                newState = BluetoothAdapter.STATE_TURNING_OFF,
+                lastState = BluetoothAdapter.ERROR,
+                nowMs = 10_000L,
+                lastReactedMs = 0L,
+                thresholdMs = thresholdMs,
+            )
+        assertTrue("first observation must react", decision)
+    }
+
+    /**
+     * The 2026-07-11 Samsung Tab5 field case in miniature: the same
+     * STATE_TURNING_OFF broadcast arrives again 116 ms after the first.
+     * The dedup guard must suppress the second reaction so the
+     * operator sees exactly one WARN log line and the cascade runs
+     * exactly once.
+     */
+    @Test
+    fun `same state within threshold — dedup`() {
+        val decision =
+            XvVoiceService.shouldReactToAdapterState(
+                newState = BluetoothAdapter.STATE_TURNING_OFF,
+                lastState = BluetoothAdapter.STATE_TURNING_OFF,
+                nowMs = 10_116L,
+                lastReactedMs = 10_000L,
+                thresholdMs = thresholdMs,
+            )
+        assertFalse("duplicate within threshold must be dedupped", decision)
+    }
+
+    /**
+     * A genuinely separate STATE_TURNING_OFF (operator toggled BT off,
+     * back on, then off again several seconds later) should NOT be
+     * dedupped. Threshold-exceeded repeats are treated as real re-fires.
+     */
+    @Test
+    fun `same state after threshold — react`() {
+        val decision =
+            XvVoiceService.shouldReactToAdapterState(
+                newState = BluetoothAdapter.STATE_TURNING_OFF,
+                lastState = BluetoothAdapter.STATE_TURNING_OFF,
+                nowMs = 15_000L,
+                lastReactedMs = 10_000L,
+                thresholdMs = thresholdMs,
+            )
+        assertTrue("threshold-exceeded re-fire must react", decision)
+    }
+
+    /**
+     * A real state transition (STATE_TURNING_OFF → STATE_OFF is the
+     * normal case) must always react regardless of timing. The two
+     * states carry different semantics for downstream cleanup and
+     * both deserve their own cascade attempt — the cascade is
+     * idempotent, so a redundant call across the transition is
+     * harmless while a missed one on the transition edge is not.
+     */
+    @Test
+    fun `different state within threshold — react`() {
+        val decision =
+            XvVoiceService.shouldReactToAdapterState(
+                newState = BluetoothAdapter.STATE_OFF,
+                lastState = BluetoothAdapter.STATE_TURNING_OFF,
+                nowMs = 10_050L,
+                lastReactedMs = 10_000L,
+                thresholdMs = thresholdMs,
+            )
+        assertTrue("state transition must always react", decision)
+    }
+
+    /**
+     * Boundary case: the delta is exactly the threshold. The guard is
+     * inclusive on "after threshold" so an event landing right at the
+     * boundary is treated as a real re-fire. Matters for platforms
+     * whose double-fire gap could drift close to whatever value we
+     * chose — the boundary must land on the safe side (react rather
+     * than dedup, so a real event is not silently dropped).
+     */
+    @Test
+    fun `same state at threshold boundary — react`() {
+        val decision =
+            XvVoiceService.shouldReactToAdapterState(
+                newState = BluetoothAdapter.STATE_TURNING_OFF,
+                lastState = BluetoothAdapter.STATE_TURNING_OFF,
+                nowMs = 10_500L,
+                lastReactedMs = 10_000L,
+                thresholdMs = thresholdMs,
+            )
+        assertTrue("delta == threshold must react (react rather than drop)", decision)
+    }
+}


### PR DESCRIPTION
Two field-reported issues from 2026-07-11 smoke on Pixel 9 Pro + Samsung
Tab5. Both are BT adapter / device-classification lifecycle handling
that emits unnecessary operator-visible noise; bundled here since they
share the same problem class.

## Fix 1 - Skip A2DP-forbid on BLE_HID pucks

### Field evidence

Operator observation (Pixel 9 Pro + Pryme BT-PTT-Z): when the puck
connects via system BT, an unnecessary "AINA media routing not
blocked. Disable 'Media audio'" persistent notification fires against
a device that has NO A2DP profile at all - the puck is BLE HID-over-
GATT only, there is no media routing to forbid.

### Root cause

`AinaA2dpWiring.onDeviceConnected` gated the A2DP-forbid path on the
broad `AinaDeviceClassifier.isPlausibleSpeakermic` predicate. That
predicate answers "does XV know how to talk to this device's buttons
at all," not "is this device A2DP-capable." BLE_HID pucks pair as
HID-over-GATT only but pass the name/UUID filter (their name matches
"BT-PTT"), so the reflective `setConnectionPolicy(FORBIDDEN)` fires
against them on connect. On the Pixel 14+ platform-refused path this
posts the misleading operator notification described above.

### Fix

Refined the wiring's connect-time gate to also skip the forbid path
when `AinaDeviceClassifier.classifyButtonProtocol(device)` returns
BLE_HID. All other classifications (SPP / BLE / AUDIO_ONLY / UNKNOWN)
proceed as before. `isPlausibleSpeakermic` is left untouched - it is
used elsewhere (picker filter, sort) and has broader semantics. The
new button-protocol callback is injected the same way `isAina` already
is so the guard can be unit-tested without a live BluetoothAdapter.
`AinaA2dpController` is a pure mechanism (no classifier gate); no
parallel filter needed.

## Fix 2 - Dedup BluetoothAdapter STATE_TURNING_OFF cascade

### Field evidence

Samsung Tab5, 2026-07-11 12:44:03/04 - two identical WARN lines 116 ms
apart: `BluetoothAdapter state=... - cascading BT-sourced PTT release`
at 12:44:03.888 and 12:44:04.004.

### Root cause

Samsung's BT stack is known to double-fire `ACTION_STATE_CHANGED` for
STATE_TURNING_OFF on some builds. The cascade itself is idempotent
(`forgetSource` on an already-forgotten slot is a no-op), so this is a
log-noise / operator-triage bug rather than a correctness bug - but
the noise makes triaging a real BT-off cascade harder.

### Fix

Added a state-transition dedup guard in `XvVoiceService`: track the
last observed adapter state + the elapsed-realtime at which we last
reacted, and short-circuit if the same state repeats within
`ADAPTER_STATE_DEDUP_WINDOW_MS` (500 ms; comfortably brackets the
observed 116 ms double-fire gap without swallowing a genuine second
BT-off event). Different states always react - the normal
STATE_TURNING_OFF -> STATE_OFF transition each deserves its own
cascade attempt. First observation of any state (sentinel `ERROR`)
always reacts.

Deliberately did NOT try to prevent the double registration itself -
there is only one registration in this service; the double-fire is an
OS behavior outside our control. Dedupping the response makes the code
resilient to future OEM builds that add or remove the double-fire
behavior without needing to change the receiver plumbing.

The decision helper is extracted as a pure `shouldReactToAdapterState`
so the four documented cases are unit-tested without standing up a
Robolectric BroadcastReceiver.

## Scope discipline

- No AIDL bumps.
- No new AndroidManifest permissions.
- No changes to any picker, cellular gate, TxController, reader
  lifecycle, or auto-connect code.
- Log strings and their prefixes are unchanged (parallel PR territory).

## Tests

- `AinaA2dpWiringTest`
  - `BLE_HID device bypasses the forbid path` - new; guards Fix 1.
  - `non-BLE_HID protocols still fire the forbid path` - new; iterates
    over every `ButtonProtocol` except BLE_HID to prove Fix 1 did not
    over-narrow the guard.
- `AdapterStateDedupTest` (new file)
  - `first observation of any state - react`
  - `same state within threshold - dedup` (mirrors the 116 ms field case)
  - `same state after threshold - react`
  - `different state within threshold - react`
  - `same state at threshold boundary - react` (boundary is inclusive on
    the safe side)

## Local build gate

- `./gradlew ktlintCheck` - green
- `./gradlew assembleCivDebug` - green
- `./gradlew testCivDebugUnitTest` - green (new tests present in results)