### PR TITLE
chore(release): bump versionCode 18 → 19, versionName 0.1.17 → 0.1.18 for TPP submission

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -113,8 +113,8 @@ android {
         // TPP / portal listings can't tell the new APK from the
         // previous one, and devices may keep the cached old APK on
         // plugin sync.
-        versionCode = 18
-        versionName = "0.1.17"
+        versionCode = 19
+        versionName = "0.1.18"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Version bump for TPP submission to tak.gov. Reflects the 2026-07-11 weekend session's landed fixes on top of 0.1.17 (19 merged PRs #32 → #50). Per feedback_no_version_bumps_dev.md, version bumps are reserved for TPP / release submissions.