### PR TITLE
fix(ptt): cellular gate grace window after XV own-call teardown fixes false-positive block

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
@@ -142,9 +142,33 @@ class VoicePlant(
             val am =
                 context.getSystemService(Context.AUDIO_SERVICE)
                     as? AudioManager
+            // Post-teardown grace: after our own Telecom call
+            // unregisters, AudioManager.getMode() can lag on the
+            // MODE_IN_COMMUNICATION → MODE_NORMAL transition for up
+            // to ~1.4 s on Pixel 9 Pro / API 35 (field observation
+            // 2026-07-11 14:47). In that window
+            // xvHasActiveTelecomCallProvider() returns false but
+            // the mode still reads IN_COMMUNICATION, which without
+            // this grace would resolve to CALL_STATE_OFFHOOK and
+            // block the operator's legitimate follow-up press with
+            // a spurious "Cellular call active" toast. OR the grace
+            // check into the own-call signal so the disambiguation
+            // stays "ours" for RECENT_OWN_CALL_GRACE_MS after our
+            // registry entry drops. External calls still resolve
+            // correctly because they never registered — the grace
+            // stamp only advances on our OWN teardown.
+            val nowMs = android.os.SystemClock.elapsedRealtime()
+            val xvOwnCallOrGrace =
+                xvHasActiveTelecomCallProvider() ||
+                    com.atakmap.android.xv.telecom.ActiveCallRegistry
+                        .withinRecentCallGrace(
+                            nowMs = nowMs,
+                            graceMs = com.atakmap.android.xv.telecom.ActiveCallRegistry
+                                .RECENT_OWN_CALL_GRACE_MS,
+                        )
             cellularCallStateFromAudioMode(
                 audioMode = am?.mode ?: AudioManager.MODE_NORMAL,
-                xvHasActiveTelecomCall = xvHasActiveTelecomCallProvider(),
+                xvHasActiveTelecomCall = xvOwnCallOrGrace,
             )
         } catch (t: Throwable) {
             android.util.Log.w(

--- a/app/src/main/java/com/atakmap/android/xv/telecom/ActiveCallRegistry.kt
+++ b/app/src/main/java/com/atakmap/android/xv/telecom/ActiveCallRegistry.kt
@@ -3,6 +3,7 @@ package com.atakmap.android.xv.telecom
 import android.content.Context
 import android.telecom.CallAudioState
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 
 // Per-process holder for the live XvConnection. The plugin and the
 // XvConnectionService run in DIFFERENT processes (different UIDs), so
@@ -19,8 +20,39 @@ import android.util.Log
 internal object ActiveCallRegistry {
     private const val TAG = "XvCallReg"
 
+    /**
+     * Post-teardown grace window (milliseconds) after our own Telecom
+     * call is unregistered — see [withinRecentCallGrace] for the full
+     * rationale. Sized to cover the observed ~1.4 s window on Pixel 9
+     * Pro / API 35 during which `AudioManager.getMode()` still reports
+     * `MODE_IN_COMMUNICATION` after the call ends, plus a safety
+     * margin for slower devices (Samsung Tab5, Sonim ruggedized).
+     */
+    const val RECENT_OWN_CALL_GRACE_MS: Long = 3_000L
+
     @Volatile
     private var activeConnection: XvConnection? = null
+
+    // Wall-clock (elapsedRealtime) timestamp of the most recent
+    // transition from "own call active" → "own call ended". Zero
+    // means we have never had an own call in this process lifetime
+    // (or the registry has never been unregistered from). Read by
+    // [withinRecentCallGrace] to paper over a race between our own
+    // call ending and AudioManager.getMode() catching up.
+    //
+    // Field observation 2026-07-11 (Pixel 9 Pro / API 35): after
+    // XvVoiceService tore down its self-managed Telecom call, the
+    // registry unregistered synchronously (hasActiveCall() → false)
+    // but AudioManager.getMode() kept reporting MODE_IN_COMMUNICATION
+    // for ~1.4 s while the audio HAL wound down to MODE_NORMAL. In
+    // that window, PttCellularGate saw IN_COMMUNICATION + no own
+    // call → CALL_STATE_OFFHOOK → BLOCK_CELLULAR_CALL and blocked
+    // legitimate operator PTT presses with the "Cellular call
+    // active" toast. The grace window causes the gate to treat that
+    // stale IN_COMMUNICATION reading as still-ours for a bounded
+    // interval after teardown, restoring correct behavior.
+    @Volatile
+    private var lastOwnCallEndedAtMs: Long = 0L
 
     // Application context, set by XvVoiceService.onCreate. Used by
     // XvConnection to broadcast ANSWER/DECLINE/HANGUP intents from the
@@ -86,12 +118,78 @@ internal object ActiveCallRegistry {
     fun unregister(connection: XvConnection) {
         if (activeConnection === connection) {
             activeConnection = null
+            // Stamp the moment our own call transitioned to ended so
+            // [withinRecentCallGrace] can hide the ~1.4 s
+            // MODE_IN_COMMUNICATION tail from the cellular gate. Use
+            // elapsedRealtime for monotonicity; PttCellularGate reads
+            // the same clock via [VoicePlant.nowMsProvider], so the
+            // two are directly comparable.
+            lastOwnCallEndedAtMs = android.os.SystemClock.elapsedRealtime()
         }
     }
 
     fun activeConnection(): XvConnection? = activeConnection
 
     fun hasActiveCall(): Boolean = activeConnection != null
+
+    /**
+     * True when the caller's [nowMs] is within [graceMs] of the last
+     * own-call teardown timestamp — i.e. we recently had a self-
+     * managed Telecom call and the audio HAL's `MODE_IN_COMMUNICATION`
+     * → `MODE_NORMAL` transition may still be in flight. The
+     * `PttCellularGate` provider ORs this into its `hasActiveCall`
+     * signal so a stale `MODE_IN_COMMUNICATION` reading during that
+     * tail is still resolved as OUR call (IDLE) rather than
+     * misclassified as an external cellular call (OFFHOOK).
+     *
+     * Returns false if we have never had an own call in this process
+     * lifetime (sentinel zero — no prior teardown to base the grace
+     * on). This preserves the block-all-sources policy for external
+     * calls that come in before XV has ever placed its own call.
+     *
+     * Comparison is inclusive at both boundaries — exactly-at-
+     * teardown and exactly-at-grace-expiry both count as "within" —
+     * so a caller passing `nowMs == lastOwnCallEndedAtMs + graceMs`
+     * still sees `true`. Wallclock skew is not a concern because
+     * both endpoints come from `SystemClock.elapsedRealtime()`.
+     */
+    fun withinRecentCallGrace(
+        nowMs: Long,
+        graceMs: Long,
+    ): Boolean {
+        val endedAt = lastOwnCallEndedAtMs
+        if (endedAt <= 0L) return false
+        val elapsed = nowMs - endedAt
+        // elapsed < 0 can happen if a caller passes a nowMs sample
+        // taken before the unregister() stamp landed (thread ordering
+        // on the volatile field). Treat as "within" — we know a
+        // teardown occurred and the caller's read raced it.
+        if (elapsed < 0L) return true
+        return elapsed <= graceMs
+    }
+
+    /**
+     * Test-only: force the "last own-call ended at" timestamp to a
+     * deterministic value so the grace-window unit test can drive
+     * boundary cases without instantiating a real
+     * [android.telecom.Connection] (which requires Robolectric).
+     * Zero clears the stamp — restoring the "never had an own call"
+     * state.
+     */
+    @VisibleForTesting
+    fun setLastOwnCallEndedAtMsForTest(value: Long) {
+        lastOwnCallEndedAtMs = value
+    }
+
+    /**
+     * Test-only: read the last-teardown timestamp so tests can
+     * assert the [unregister] side effect landed. Kept separate from
+     * the setter so production callers cannot accidentally reach
+     * for it — the grace decision must go through
+     * [withinRecentCallGrace].
+     */
+    @VisibleForTesting
+    fun lastOwnCallEndedAtMsForTest(): Long = lastOwnCallEndedAtMs
 
     fun fanOutRouteChange(state: CallAudioState?) {
         for (l in routeListeners) {

--- a/app/src/test/java/com/atakmap/android/xv/service/PttCellularGateTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/service/PttCellularGateTest.kt
@@ -552,4 +552,149 @@ class PttCellularGateTest {
             ),
         )
     }
+
+    // ============================================================
+    // Post-teardown grace window — VoicePlant closure semantics
+    //
+    // These tests model the OR that the `cellularCallStateProvider`
+    // closure in VoicePlant performs before calling
+    // [cellularCallStateFromAudioMode]:
+    //
+    //   val xvOwnCallOrGrace =
+    //       registry.hasActiveCall() ||
+    //       registry.withinRecentCallGrace(nowMs, RECENT_OWN_CALL_GRACE_MS)
+    //
+    // The pure gate function's contract does not change — it still
+    // receives a single Boolean "own call?" input. The disambiguation
+    // between "call is literally active" and "call was recently
+    // active" happens at the caller level. The tests here lock in
+    // the round-trip through the pure functions so a future refactor
+    // that alters the pure gate's Boolean contract does not silently
+    // regress the grace path.
+    //
+    // Field trace 2026-07-11 14:47 (Pixel 9 Pro / API 35):
+    //   14:47:14.722 XV Telecom externally torn down → registry
+    //                unregister → hasActiveCall = false
+    //   14:47:14.765 AudioManager.getMode() still IN_COMMUNICATION
+    //   14:47:16.126 AudioManager.getMode() finally NORMAL
+    // The ~1.4 s window between 14.722 and 16.126 is where operator
+    // PTT presses were being falsely blocked.
+    // ============================================================
+
+    @Test
+    fun `IN_COMMUNICATION during post-teardown grace resolves as own call — ALLOW`() {
+        // hasActiveCall=false (registry already unregistered), but
+        // withinGrace=true (audio mode still catching up). The
+        // provider closure ORs them; the pure gate sees "own call =
+        // true", maps IN_COMMUNICATION → IDLE, and the gate ALLOWs.
+        // This is the scenario the fix restores from the field
+        // regression.
+        val withinGrace = true
+        val hasActiveCall = false
+        val xvOwnCallOrGrace = hasActiveCall || withinGrace
+        assertEquals(
+            PttGate.ALLOW,
+            shouldGateForCellularCall(
+                cellularCallStateFromAudioMode(
+                    audioMode = AudioManager.MODE_IN_COMMUNICATION,
+                    xvHasActiveTelecomCall = xvOwnCallOrGrace,
+                ),
+                PttSource.ON_SCREEN,
+            ),
+        )
+    }
+
+    @Test
+    fun `IN_COMMUNICATION after grace expired still blocks external call — BLOCK`() {
+        // Both hasActiveCall and withinGrace are false — grace
+        // window has elapsed and no fresh own call exists. This is
+        // an actual external call (VoLTE cellular, other VoIP app)
+        // and the block-all-sources policy must still fire.
+        val withinGrace = false
+        val hasActiveCall = false
+        val xvOwnCallOrGrace = hasActiveCall || withinGrace
+        assertEquals(
+            PttGate.BLOCK_CELLULAR_CALL,
+            shouldGateForCellularCall(
+                cellularCallStateFromAudioMode(
+                    audioMode = AudioManager.MODE_IN_COMMUNICATION,
+                    xvHasActiveTelecomCall = xvOwnCallOrGrace,
+                ),
+                PttSource.ON_SCREEN,
+            ),
+        )
+    }
+
+    @Test
+    fun `grace window covers every PTT source during audio-HAL tail`() {
+        // The grace does not carve out per-source behaviour — if the
+        // OR resolves to "still ours" the whole gate treats the mode
+        // as IDLE for every source. A hardware AINA press, on-screen
+        // tap, Pryme puck, and DEBUG intent all ALLOW during the
+        // tail, matching operator intent that mid-burst / just-
+        // -after-burst presses should not lock out.
+        val withinGrace = true
+        val hasActiveCall = false
+        val xvOwnCallOrGrace = hasActiveCall || withinGrace
+        for (src in PttSource.values()) {
+            assertEquals(
+                "$src must ALLOW during post-teardown grace",
+                PttGate.ALLOW,
+                shouldGateForCellularCall(
+                    cellularCallStateFromAudioMode(
+                        audioMode = AudioManager.MODE_IN_COMMUNICATION,
+                        xvHasActiveTelecomCall = xvOwnCallOrGrace,
+                    ),
+                    src,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `grace window does not unlock a legacy MODE_IN_CALL cellular call`() {
+        // Belt-and-suspenders: the grace only papers over the
+        // MODE_IN_COMMUNICATION ambiguity. If the audio HAL reports
+        // MODE_IN_CALL — the legacy CSFB / non-VoLTE path that XV
+        // NEVER enters itself — the gate must still block regardless
+        // of the grace, because MODE_IN_CALL is unambiguously an
+        // external cellular call. The pure mapping already handles
+        // this (MODE_IN_CALL → OFFHOOK independent of the own-call
+        // flag), but locking it in here defends against a future
+        // refactor that might route the flag through more broadly.
+        val withinGrace = true
+        val hasActiveCall = false
+        val xvOwnCallOrGrace = hasActiveCall || withinGrace
+        assertEquals(
+            PttGate.BLOCK_CELLULAR_CALL,
+            shouldGateForCellularCall(
+                cellularCallStateFromAudioMode(
+                    audioMode = AudioManager.MODE_IN_CALL,
+                    xvHasActiveTelecomCall = xvOwnCallOrGrace,
+                ),
+                PttSource.ON_SCREEN,
+            ),
+        )
+    }
+
+    @Test
+    fun `grace window does not unlock MODE_RINGTONE`() {
+        // Same rationale as MODE_IN_CALL — MODE_RINGTONE is
+        // unambiguously an incoming external call. The grace only
+        // exists to hide the IN_COMMUNICATION tail from misclassifying
+        // an own-call teardown as external.
+        val withinGrace = true
+        val hasActiveCall = false
+        val xvOwnCallOrGrace = hasActiveCall || withinGrace
+        assertEquals(
+            PttGate.BLOCK_CELLULAR_RINGING,
+            shouldGateForCellularCall(
+                cellularCallStateFromAudioMode(
+                    audioMode = AudioManager.MODE_RINGTONE,
+                    xvHasActiveTelecomCall = xvOwnCallOrGrace,
+                ),
+                PttSource.ON_SCREEN,
+            ),
+        )
+    }
 }

--- a/app/src/test/java/com/atakmap/android/xv/telecom/ActiveCallRegistryGraceTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/telecom/ActiveCallRegistryGraceTest.kt
@@ -1,0 +1,162 @@
+package com.atakmap.android.xv.telecom
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Coverage for the post-teardown grace window on [ActiveCallRegistry].
+ * The grace exists to paper over a race between XV's self-managed
+ * Telecom call unregistering (synchronous, drops
+ * [ActiveCallRegistry.hasActiveCall] immediately) and the Android
+ * audio HAL winding `AudioManager.getMode()` back from
+ * `MODE_IN_COMMUNICATION` to `MODE_NORMAL` (asynchronous, ~1.4 s
+ * observed on Pixel 9 Pro / API 35 on 2026-07-11 14:47). Without
+ * this grace the cellular gate saw a stale IN_COMMUNICATION + no
+ * own call and blocked legitimate operator PTT presses with a
+ * spurious "Cellular call active" toast.
+ *
+ * The tests here drive [ActiveCallRegistry.withinRecentCallGrace]
+ * directly via the [ActiveCallRegistry.setLastOwnCallEndedAtMsForTest]
+ * hook so the boundary cases are hermetic — no need to instantiate a
+ * real [android.telecom.Connection] and route it through
+ * [ActiveCallRegistry.unregister] (which would require Robolectric).
+ */
+class ActiveCallRegistryGraceTest {
+    @Before
+    fun resetRegistry() {
+        // Registry is a process-wide singleton (Kotlin object). Clear
+        // the timestamp between tests so ordering is irrelevant.
+        ActiveCallRegistry.setLastOwnCallEndedAtMsForTest(0L)
+    }
+
+    @After
+    fun cleanUpRegistry() {
+        ActiveCallRegistry.setLastOwnCallEndedAtMsForTest(0L)
+    }
+
+    // ============================================================
+    // withinRecentCallGrace — pure decision function
+    // ============================================================
+
+    @Test
+    fun `never had an own call — grace always false`() {
+        // Sentinel-zero state (fresh process, or explicit reset).
+        // The grace must not fire without a prior teardown to base
+        // it on; otherwise it would hide the block-all-sources
+        // policy for external cellular calls arriving before XV
+        // has ever placed its own call.
+        assertFalse(ActiveCallRegistry.withinRecentCallGrace(nowMs = 0L, graceMs = 3_000L))
+        assertFalse(ActiveCallRegistry.withinRecentCallGrace(nowMs = 1_000L, graceMs = 3_000L))
+        assertFalse(ActiveCallRegistry.withinRecentCallGrace(nowMs = Long.MAX_VALUE, graceMs = 3_000L))
+    }
+
+    @Test
+    fun `never had an own call — grace false for any graceMs value`() {
+        // Belt-and-suspenders: the "no prior teardown" short-circuit
+        // must dominate over an unusual [graceMs] argument. A caller
+        // passing an absurd grace should not accidentally unlock the
+        // gate when there is no basis for the grace.
+        assertFalse(ActiveCallRegistry.withinRecentCallGrace(nowMs = 500L, graceMs = 0L))
+        assertFalse(ActiveCallRegistry.withinRecentCallGrace(nowMs = 500L, graceMs = Long.MAX_VALUE))
+    }
+
+    @Test
+    fun `just torn down — grace true within window`() {
+        // 500 ms after teardown, still well inside the 3 s window —
+        // this is the exact scenario from the 2026-07-11 14:47 field
+        // trace where AudioManager.getMode() lagged ~1.4 s.
+        ActiveCallRegistry.setLastOwnCallEndedAtMsForTest(1_000L)
+        assertTrue(
+            ActiveCallRegistry.withinRecentCallGrace(nowMs = 1_500L, graceMs = 3_000L),
+        )
+    }
+
+    @Test
+    fun `past grace boundary — grace false`() {
+        // 3500 ms after teardown, past the 3 s window. The
+        // AudioManager mode has certainly caught up by now; a
+        // MODE_IN_COMMUNICATION reading at this point is somebody
+        // ELSE's call and must be blocked.
+        ActiveCallRegistry.setLastOwnCallEndedAtMsForTest(1_000L)
+        assertFalse(
+            ActiveCallRegistry.withinRecentCallGrace(nowMs = 4_500L, graceMs = 3_000L),
+        )
+    }
+
+    @Test
+    fun `exactly at teardown instant — grace true`() {
+        // Zero-elapsed sample. Not a physically possible ordering in
+        // production (the caller reads nowMs strictly after
+        // unregister stamps the field) but the boundary matters —
+        // if a caller ever passes a nowMs equal to the stamp, we
+        // must treat it as within.
+        ActiveCallRegistry.setLastOwnCallEndedAtMsForTest(1_000L)
+        assertTrue(
+            ActiveCallRegistry.withinRecentCallGrace(nowMs = 1_000L, graceMs = 3_000L),
+        )
+    }
+
+    @Test
+    fun `exactly at grace boundary — grace true`() {
+        // Inclusive boundary: elapsed == graceMs must return true.
+        // Choosing exclusive at this edge would introduce a
+        // one-millisecond flaky window; inclusive is unambiguous
+        // and matches the fail-safe direction (favor "still ours").
+        ActiveCallRegistry.setLastOwnCallEndedAtMsForTest(1_000L)
+        assertTrue(
+            ActiveCallRegistry.withinRecentCallGrace(nowMs = 4_000L, graceMs = 3_000L),
+        )
+    }
+
+    @Test
+    fun `nowMs before teardown — grace true (thread-race fail-safe)`() {
+        // Negative elapsed can happen if the caller samples nowMs
+        // from a stale local variable before the unregister
+        // stamp landed on the volatile field. We know a teardown
+        // occurred (endedAt is non-zero); treat as within so the
+        // race resolves as "still ours" — the same direction the
+        // whole grace exists to protect.
+        ActiveCallRegistry.setLastOwnCallEndedAtMsForTest(2_000L)
+        assertTrue(
+            ActiveCallRegistry.withinRecentCallGrace(nowMs = 1_000L, graceMs = 3_000L),
+        )
+    }
+
+    @Test
+    fun `re-registered after grace expired — grace still orthogonal`() {
+        // When a fresh own call comes up after the grace expired,
+        // hasActiveCall becomes true again. The grace field only
+        // updates on unregister — it does NOT reset on register —
+        // but that is fine, because the [hasActiveCall] check in
+        // the provider already dominates the OR before
+        // withinRecentCallGrace is even consulted. The invariant
+        // this test locks: the grace reader is a pure function of
+        // (nowMs, graceMs, lastOwnCallEndedAtMs) — it does not
+        // consult activeConnection state, so a re-register does
+        // not alter its output.
+        ActiveCallRegistry.setLastOwnCallEndedAtMsForTest(1_000L)
+        // 4500 ms > 3000 ms grace → false regardless of any
+        // register/unregister motion elsewhere.
+        assertFalse(
+            ActiveCallRegistry.withinRecentCallGrace(nowMs = 4_500L, graceMs = 3_000L),
+        )
+    }
+
+    // ============================================================
+    // RECENT_OWN_CALL_GRACE_MS — constant contract
+    // ============================================================
+
+    @Test
+    fun `grace constant is 3 seconds`() {
+        // Sized on the 2026-07-11 field observation: Pixel 9 Pro /
+        // API 35 held MODE_IN_COMMUNICATION for ~1.4 s after XV's
+        // Telecom teardown. 3000 ms gives ~2x headroom for slower
+        // devices while staying well under any operator-noticeable
+        // "why is this still blocked?" threshold.
+        assertEquals(3_000L, ActiveCallRegistry.RECENT_OWN_CALL_GRACE_MS)
+    }
+}


### PR DESCRIPTION
## Field evidence — 2026-07-11 14:47 (Pixel 9 Pro / API 35)

Operator PTT presses were intermittently blocked with the "Cellular call active" toast even when no cellular call was active. The trace shows a race between three signals when XV's own self-managed Telecom call is torn down:

```
14:47:14.722  XvVoiceSvc  Telecom externally tore down our call — unwinding voice plant
14:47:14.765  switchAudioMode: IN_COMMUNICATION   (audio HAL still catching up)
14:47:16.126  switchAudioMode: NORMAL             (audio HAL finally settled)
```

`ActiveCallRegistry.hasActiveCall()` flips to `false` synchronously with the 14.722 teardown, but `AudioManager.getMode()` keeps reporting `MODE_IN_COMMUNICATION` for ~1.4 seconds while the audio HAL winds down. Any operator press landing in that window sees `IN_COMMUNICATION + hasActiveCall=false`, which `cellularCallStateFromAudioMode` correctly (per PR #45) resolves to `CALL_STATE_OFFHOOK` — treating our own tail as an external call — and the block-all-sources policy from PR #46 blocks the press with the spurious toast.

## Root cause

The pure gate cannot distinguish "MODE_IN_COMMUNICATION because our own call just ended and the HAL hasn't caught up" from "MODE_IN_COMMUNICATION because a real external cellular call is active" using only the point-in-time `hasActiveCall()` snapshot. The tail after an own-call teardown is the same shape as an external-call arrival.

## Fix — post-teardown grace window

`ActiveCallRegistry` now records `lastOwnCallEndedAtMs = SystemClock.elapsedRealtime()` on `unregister()`. A new pure reader `withinRecentCallGrace(nowMs, graceMs)` returns true when the caller's `nowMs` is within `graceMs` of that stamp. `RECENT_OWN_CALL_GRACE_MS = 3000` — sized to comfortably cover the observed ~1.4 s Pixel tail, with headroom for slower devices (Samsung, Sonim ruggedized), while staying well under any operator-noticeable "why is this still blocked?" threshold.

`VoicePlant.cellularCallStateProvider` extends its own-call boolean:

```kotlin
val xvOwnCallOrGrace = xvHasActiveTelecomCallProvider() ||
    ActiveCallRegistry.withinRecentCallGrace(nowMs, RECENT_OWN_CALL_GRACE_MS)
val callState = cellularCallStateFromAudioMode(audioMode, xvOwnCallOrGrace)
```

The pure `cellularCallStateFromAudioMode` contract is **unchanged** — it still takes a single Boolean "own call?" input. The disambiguation between "call is literally active" and "call was recently active" happens at the provider closure so the pure gate stays a single-input decision function.

## Invariant preserved

The gate still blocks correctly for external cellular calls (VoLTE, other VoIP apps). Those never register in `ActiveCallRegistry`, so both `hasActiveCall()` and `withinRecentCallGrace()` return false — `xvOwnCallOrGrace` stays false and the block-all-sources policy from PR #46 fires exactly as before.

## Trade-off

If the operator's XV call ends and a fresh external cellular call arrives within 3 s, the grace briefly hides the incoming state and lets a press through. This is a rare edge case and blocking a hardware press during a still-transitioning-in ring is not the "auto-hold a live call" harm the block-all-sources policy exists to prevent. Acceptable trade.

## Explicitly not in scope

- No change to the block-all-sources policy (PR #46).
- No change to the `AudioManager.getMode` provider.
- No change to the `MODE_IN_CALL` → `OFFHOOK` mapping.
- No change to the toast throttle.
- No new AndroidManifest permissions, no AIDL bumps.

## Test plan

- [x] `./gradlew ktlintCheck` — green
- [x] `./gradlew assembleCivDebug` — green
- [x] `./gradlew testCivDebugUnitTest` — green
- [x] `ActiveCallRegistryGraceTest` (new) covers `withinRecentCallGrace` boundaries: never-had-call → false; just-torn-down (500 ms in) → true; past 3 s → false; exactly at teardown → true; exactly at grace boundary → true; negative elapsed (thread-race fail-safe) → true; `RECENT_OWN_CALL_GRACE_MS` constant contract.
- [x] `PttCellularGateTest` gains five integration cases modelling the provider closure's OR: `IN_COMMUNICATION + withinGrace=true` → ALLOW; `IN_COMMUNICATION + withinGrace=false` → BLOCK; grace covers every `PttSource` uniformly; grace does NOT unlock `MODE_IN_CALL` or `MODE_RINGTONE` (those are unambiguously external).
- [ ] Field: keep the trace-observed device pattern (place an XV call, tear it down, press PTT again within 2 s) — verify no false-positive toast and the follow-up press succeeds.
- [ ] Field: verify a real VoLTE cellular call still blocks XV PTT (both hardware and on-screen) exactly as before — the grace must not leak into the external-call path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)