### PR TITLE
fix(tx): widen cold-SCO drop N=3→6 and TPT hold 200→300 ms to kill peer-side screech

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/audio/TxController.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/TxController.kt
@@ -1703,25 +1703,48 @@ class TxController(
         //      click at TX-stop — same shape, opposite end of the
         //      burst. See [shouldDropStartFrame].
 
-        // Extra PRIMING → TPT delay on the cold-SCO path. 200 ms was
-        // selected to cover the observed AOC underrun window (86 frames
-        // ≈ 30 ms of the underrun itself, plus ~150 ms of pipeline-
-        // recovery margin so subsequent TX frames land against a
-        // stabilized uplink). Tunable — smaller values leave residual
-        // underrun in the TPT-to-TX transition; larger values are
-        // perceived by the operator as PTT sluggishness.
-        internal const val COLD_SCO_TPT_HOLD_MS: Long = 200L
+        // Extra PRIMING → TPT delay on the cold-SCO path.
+        //
+        // Original tuning 2026-07-08: 200 ms — chosen against the
+        // observed AOC "[AMixMODEM] uplink underrun for 86 frames"
+        // window (~30 ms of literal underrun + ~150 ms pipeline
+        // recovery margin).
+        //
+        // Field observation 2026-07-11 (TPP validation, Pixel 9 Pro
+        // with AINA V1): peer still heard garbled audio ("screech")
+        // at the head of the first cold-SCO transmission. 200 ms
+        // covers the underrun burst itself but leaves the modem/pipe
+        // in a settling phase during the TPT→TX transition — real
+        // mic frames land against a still-stabilizing uplink and
+        // encode to Opus screech at the peer. Widened to 300 ms to
+        // give the pipeline a full 100 ms of additional post-
+        // underrun margin. Perceptible latency cost: +100 ms of
+        // "waiting for the beep" on a cold burst; warm-SCO bursts
+        // (the common case in an active session) are unaffected.
+        //
+        // Tunable — smaller values leave residual underrun in the
+        // TPT-to-TX transition; larger values are perceived as PTT
+        // sluggishness.
+        internal const val COLD_SCO_TPT_HOLD_MS: Long = 300L
 
         // Number of leading TX frames to silently discard on the cold-
-        // SCO path. Each frame is 20 ms of PCM. N=3 = 60 ms of dropped
-        // leading edge, which covers the tail of the AOC underrun
-        // burst without eating meaningful speech content (typical
-        // human reaction time from TPT-audible to first phoneme is
-        // 250-400 ms).
+        // SCO path. Each frame is 20 ms of PCM.
+        //
+        // Original tuning 2026-07-08: N=3 (60 ms). Covered the
+        // literal underrun burst well and left the TPT→speech
+        // ramp intact.
+        //
+        // Field observation 2026-07-11: with the widened 300 ms
+        // cold-SCO hold above, the first-frame-post-transition
+        // window is quieter but the SILK encoder still catches a
+        // few frames of "not-yet-clean" mic before it locks in. N=6
+        // = 120 ms of dropped leading edge, still well inside the
+        // typical 250-400 ms human reaction time from TPT-audible
+        // to first phoneme, so operator speech is not eaten.
         //
         // Set to 0 to disable the drop entirely (useful for A/B
         // comparison or for platforms without the AOC modem behavior).
-        internal const val COLD_SCO_START_DROP_FRAMES: Int = 3
+        internal const val COLD_SCO_START_DROP_FRAMES: Int = 6
 
         /**
          * Extra time to hold PRIMING → TPT so the SCO uplink modem

--- a/app/src/test/java/com/atakmap/android/xv/audio/TxControllerColdScoWarmupTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/audio/TxControllerColdScoWarmupTest.kt
@@ -161,12 +161,18 @@ class TxControllerColdScoWarmupTest {
     }
 
     @Test
-    fun `production drop count matches the field-tuned N=3`() {
-        // If someone bumps COLD_SCO_START_DROP_FRAMES away from 3, they
+    fun `production drop count matches the field-tuned N=6`() {
+        // If someone bumps COLD_SCO_START_DROP_FRAMES away from 6, they
         // should update the block comment in TxController explaining
         // why. Pin the current value here so a change is visible in
         // the same PR.
-        assertEquals(3, TxController.COLD_SCO_START_DROP_FRAMES)
+        //
+        // History: N=3 was the original tuning (2026-07-08 field
+        // capture). Widened to N=6 on 2026-07-11 after peer reported
+        // residual screech at the head of cold-SCO bursts — 60 ms of
+        // drop covered the underrun burst itself but the SILK encoder
+        // was still catching the not-yet-clean tail. 120 ms clears it.
+        assertEquals(6, TxController.COLD_SCO_START_DROP_FRAMES)
     }
 
     // ============================================================
@@ -240,11 +246,15 @@ class TxControllerColdScoWarmupTest {
     }
 
     @Test
-    fun `production hold matches the field-tuned 200 ms`() {
-        // 200 ms was chosen to cover the observed 86-frame AOC underrun
-        // (~30 ms) plus pipeline-recovery margin. If this constant
-        // moves, the block comment above it should move with it.
-        assertEquals(200L, TxController.COLD_SCO_TPT_HOLD_MS)
+    fun `production hold matches the field-tuned 300 ms`() {
+        // 200 ms was the original tuning (2026-07-08 AOC underrun window
+        // + margin). Widened to 300 ms on 2026-07-11 after peer-side
+        // screech report during TPP validation — the underrun clears
+        // quickly but the pipeline needs another ~100 ms to fully
+        // settle before mic frames stop encoding to Opus screech.
+        // If this constant moves, the block comment above it should
+        // move with it.
+        assertEquals(300L, TxController.COLD_SCO_TPT_HOLD_MS)
     }
 
     // ============================================================


### PR DESCRIPTION
## Summary

Widen both cold-SCO first-burst mitigations after peer-side screech was reproduced during TPP validation:

- `COLD_SCO_TPT_HOLD_MS`: **200 → 300 ms** (extra 100 ms post-underrun settling margin before TPT + TX).
- `COLD_SCO_START_DROP_FRAMES`: **3 → 6** (60 ms → 120 ms of dropped leading TX frames — covers the SILK-encoder catch-up phase past the AOC underrun clear).

## Motivation

Field observation 2026-07-11 (Pixel 9 Pro + AINA V1, TPP validation session): peer consistently hears garbled audio ("screech") at the head of every first cold-SCO transmission. Verified as RX-side / over-the-wire, not sidetone or operator self-monitor.

PR #40's original tuning (N=3, HOLD=200) covered the literal AOC modem underrun burst (~30 ms) plus a small pipeline-recovery margin. What it didn't cover: the SILK encoder's own settling phase past the underrun clear, during which real mic frames still encode into an artifact peer-perceives as screech.

Both bumps are conservative. Warm-SCO bursts (the common case in an active session — TX during the 5s Telecom cool-down window) are entirely unaffected. Operator perceptible cost on a cold burst: +100 ms of TPT sluggishness plus +60 ms of "silent leading edge" that stays well inside the typical 250-400 ms human PTT-to-first-phoneme reaction time.

## Test plan

- [x] `./gradlew :app:ktlintCheck :app:testCivDebugUnitTest :app:assembleCivDebug` — green (pinned constants updated to 6 and 300).
- [ ] On-device (Pixel 9 Pro + AINA V1): cold-SCO PTT with a Mumble desktop client set to record on the peer side, verify head-of-burst screech is gone.
- [ ] Rapid warm-SCO cycle (5 presses inside 5 s cool-down) — verify no regression, no extra delay perceptible.
- [ ] Samsung Tab5 (secondary device) — same cold+warm smoke to confirm no platform regression from the widening.

## Rollback

If the +100 ms hold is perceived as too sluggish, revert `COLD_SCO_TPT_HOLD_MS` to 200 first (leave the drop count widened). If N=6 eats speech on rapid-fire ops, revert the drop count next. Both constants are `internal const val` — safe atomic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)