### PR TITLE
fix(telecom): call-in-progress collision + warm-SCO PRIMING + cellular-gate self-block

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/audio/AudioPlayback.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/AudioPlayback.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.launch
  *
  * The SCO link is async (~500-1500ms to come up). To avoid losing the first
  * syllable when transitioning IDLE → SCO, we buffer decoded PCM into a small
- * ring (~2s cap) during PENDING_SCO and drain it into the AudioTrack the
+ * ring (~4s cap, pendingBufferMaxSamples) during PENDING_SCO and drain it into the AudioTrack the
  * moment SCO connects. The buffer is ONLY active during the profile switch;
  * once Active, frames write straight through with zero added latency.
  *
@@ -72,7 +72,7 @@ class AudioPlayback(
     // across rapid RX bursts. When false, the manual focus path runs.
     private val telecomActive: () -> Boolean = { false },
     // Fires when AudioPlayback enters / exits the SCO_HOT hold state
-    // — i.e. when the SCO link will stay warm for ~5 s after RX
+    // — i.e. when the SCO link will stay warm for ~8 s (scoHoldMs) after RX
     // completes. TxController subscribes via VoicePlant and uses the
     // edge to allocate AudioCapture during the hold so the BT
     // chipset's mic data path has time to settle before the operator
@@ -394,9 +394,9 @@ class AudioPlayback(
         // Demand-based SCO. HFP-only BT routes need SCO before audio can
         // flow; non-SCO routes (A2DP, speaker, wired) bypass it entirely.
         // Cold-start incoming voice gets buffered into pendingBuffer for
-        // up to ~2s while SCO comes up; once ACTIVE, frames pass through
+        // up to ~4s while SCO comes up; once ACTIVE, frames pass through
         // with no added latency. After idleTimeoutMs of silence we drop
-        // to SCO_HOT, holding SCO for scoHoldMs (5s) so a follow-up
+        // to SCO_HOT, holding SCO for scoHoldMs (8s) so a follow-up
         // transmission resumes instantly. After that → IDLE.
         val btMode = btPolicy?.classify() ?: BtAudioMode.NONE
         val link = scoLink
@@ -700,7 +700,7 @@ class AudioPlayback(
             } catch (_: Throwable) {
             }
         }
-        // Hold audio focus through the SCO_HOT window (5s). If we
+        // Hold audio focus through the SCO_HOT window (8s, scoHoldMs). If we
         // released focus here, media apps would un-pause but SCO is
         // still up + mode is IN_COMMUNICATION → music routes through
         // SCO to the AINA. Keeping focus held means media stays
@@ -708,7 +708,7 @@ class AudioPlayback(
         // when SCO actually goes down (in teardown).
         state = State.SCO_HOT
         // Tell TxController to allocate AudioCapture now so the BT
-        // chipset's mic data path settles during the 5 s hold. Slow
+        // chipset's mic data path settles during the 8 s hold. Slow
         // chipsets (Duo+V1) need 1-3 s of mic-pumping before they
         // stop returning silent samples; doing that BEFORE PTT-down
         // means the operator's response press finishes PRIMING in

--- a/app/src/main/java/com/atakmap/android/xv/audio/ScoLink.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/ScoLink.kt
@@ -993,7 +993,7 @@ class ScoLink(
 
         // Threshold at which a held SCO link is no longer "legitimately
         // warm" but instead probably leaking. Hot Mic's idle release
-        // ceiling is 60s, RX SCO_HOT is 5s, TX cool-down is 5s — so
+        // ceiling is 60s, RX SCO_HOT is 8s, TX cool-down is 5s — so
         // anything past 90s of continuous hold means a holder isn't
         // releasing as expected. Below this, the watchdog logs at DEBUG.
         private const val WATCHDOG_WARN_THRESHOLD_MS = 90_000L

--- a/app/src/main/java/com/atakmap/android/xv/audio/TxController.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/TxController.kt
@@ -511,21 +511,9 @@ class TxController(
         cooldownHandler.postDelayed(primingTimeoutRunnable, timeoutMs)
     }
 
-    // No-op stub. Earlier this used incoming RX frames to pre-warm
-    // AudioRecord while a peer was talking. The backing keep-alive
-    // produced silent reads on every burst after the first (BT chipset
-    // routing went stale on the held-open AudioRecord), so the
-    // capture lifecycle is back to "fresh per-burst." Hook left here
-    // and still wired from AudioPlayback so the architecture is in
-    // place if we revisit RX-driven prewarm via a different
-    // mechanism (e.g. cycle restartRecording rather than reuse).
-    fun notifyRxActivity() {
-        // intentionally empty
-    }
-
     // Bounded mic pre-warm tied to AudioPlayback's SCO_HOT window.
     // When AudioPlayback enters SCO_HOT (RX just ended, SCO link
-    // held warm for ~5 s) we proactively allocate AudioCapture so
+    // held warm for ~8 s — AudioPlayback.scoHoldMs) we proactively allocate AudioCapture so
     // the BT chipset's mic data path can settle. On slow chipsets
     // (Duo+V1, observed) the mic returns silent samples for 1-3 s
     // after a cold SCO setup; if the operator's response press has
@@ -534,13 +522,13 @@ class TxController(
     // BEFORE the operator presses PTT, so PRIMING completes in
     // ~100 ms (we just verify the now-flowing samples are non-silent).
     //
-    // Bounded by SCO_HOT (5 s max) — does NOT bring back the
+    // Bounded by SCO_HOT (8 s max) — does NOT bring back the
     // historical "stale routing across many bursts" bug, which
     // required AudioRecord to be held open through TX bursts and
-    // mode transitions. Here it's only alive during the 5 s window
+    // mode transitions. Here it's only alive during the 8 s window
     // BEFORE TX, then handed off cleanly to the burst.
     // Session-scope mic pre-arm. Distinct from preWarmMic (which is the
-    // 5 s SCO_HOT window): this holds AudioCapture open for the entire
+    // 8 s SCO_HOT window): this holds AudioCapture open for the entire
     // duration of a connected Mumble session, regardless of route.
     // VoicePlant.setMumbleSessionLive drives it: connect → arm,
     // disconnect → disarm.
@@ -881,39 +869,12 @@ class TxController(
         // log "encoder is null!" and drop on each cold-SCO burst.)
         framesSent = 0
         txFrameNumber = 0
-        val enc = opusEncoderFactory()
-        encoder = enc
+        encoder = opusEncoderFactory()
         state = State.TRANSMITTING
-        // Flush the TPT-overlap ring BEFORE live frames start arriving.
-        // These are real mic samples captured while TPT was playing —
-        // the operator started speaking the moment they heard the
-        // permit tone and we caught those words. Ordering matters: the
-        // ring is FIFO so flushing in order preserves speech continuity
-        // on the receiving end (no "out-of-order audio" glitches). The
-        // encode path is the same one onPcmFrame uses for live frames
-        // (encodeAndQueueFrame), so opus framing + the trailing-click
-        // swallow window apply uniformly.
-        val flushedFrames: List<ShortArray>
-        synchronized(preTxBuffer) {
-            flushedFrames =
-                if (preTxBuffer.isEmpty()) {
-                    emptyList()
-                } else {
-                    val copy = preTxBuffer.toList()
-                    preTxBuffer.clear()
-                    copy
-                }
-        }
-        if (flushedFrames.isNotEmpty()) {
-            Log.i(TAG, "TX: flushing ${flushedFrames.size} pre-TX frame(s) from TPT-overlap buffer (${flushedFrames.size * 10}ms)")
-            for (frame in flushedFrames) {
-                encodeAndQueueFrame(frame, enc)
-            }
-        }
         // Per-PTT focus management is SKIPPED when Telecom owns the
         // voice session — XvVoiceService holds GAIN focus for the
         // entire Telecom call lifetime (which spans rapid PTT cycles
-        // via the 5 s end-debounce). Grabbing/abandoning focus on
+        // via the 8 s end-debounce). Grabbing/abandoning focus on
         // every PTT down/up confuses media apps (Spotify ducks
         // instead of pauses when it sees focus flapping at sub-second
         // cadence) and risks denying our own RX focus request mid-
@@ -947,21 +908,6 @@ class TxController(
     }
 
     private var framesSent: Long = 0
-
-    // TPT-overlap ring buffer. Frames captured while [state] == TPT
-    // get queued here so the operator's pre-speech (started while the
-    // TPT was still playing, before TX-state flipped) survives instead
-    // of being dropped on the floor. Sized to [PRE_TX_BUFFER_MAX_FRAMES]
-    // ≈ 500 ms which covers the longest TPT play plus a generous
-    // operator-reaction tail. Older frames evicted on push so a stuck
-    // TPT can't grow this without bound. Drained by startTransmitting
-    // ahead of the first live frame; cleared by stopInternal.
-    //
-    // synchronized() because AudioCapture reads on a worker thread
-    // (frame producer) and startTransmitting flushes on the caller of
-    // [start] (typically a Telecom callback or AIDL thread).
-    private val preTxBuffer: ArrayDeque<ShortArray> =
-        ArrayDeque(PRE_TX_BUFFER_MAX_FRAMES + 2)
 
     // Trailing-frame ring buffer to swallow the PTT release click. The
     // physical button click on the AINA V1/V2 happens at time T; the
@@ -1005,9 +951,6 @@ class TxController(
     internal fun setEncoderForTest(enc: OpusEncoder?) {
         encoder = enc
     }
-
-    @VisibleForTesting
-    internal fun preTxBufferSizeForTest(): Int = synchronized(preTxBuffer) { preTxBuffer.size }
 
     @VisibleForTesting
     internal fun currentEncoderForTest(): OpusEncoder? = encoder
@@ -1081,39 +1024,15 @@ class TxController(
             return
         }
         if (state == State.TPT) {
-            // DISABLED 2026-05-21: ring-buffer flush corrupts the Opus
-            // encoder on BT SCO cold-start regardless of RMS gating.
-            //
-            // Original intent: queue mic frames captured during TPT
-            // play so the operator's first syllable (started while TPT
-            // was still audible) survived into the transmitted burst.
-            //
-            // Root cause of the recurring screech bug: on cold-SCO
-            // PTT-down, AudioRecord allocates against a not-yet-stable
-            // BT SCO source. The chipset delivers chunked / irregular
-            // frames for the first 300-500 ms — frames arrive in bursts
-            // instead of the expected 10 ms cadence, sometimes with
-            // sample-rate drift while the chipset settles. Frame
-            // contents pass the RMS gate (real audio amplitude) but
-            // Opus's stateful SILK encoder chokes on the temporal
-            // discontinuity. The frame that throws gets dropped by
-            // the encoder-reset recovery, but subsequent frames
-            // continue to corrupt because the underlying AudioRecord
-            // is STILL delivering irregular data. Result: alternating
-            // tiny / loud RMS pattern on the wire (verified in the
-            // 20:36:52 trace), peer hears continuous screech.
-            //
-            // The pre-TX-overlap capture is a small UX win (catches
-            // the operator's first syllable if they spoke during the
-            // ~100 ms TPT). The screech is intolerable. Disable the
-            // feature outright; operators adapt by waiting for TPT
-            // before speaking (the universal LMR convention anyway).
-            //
-            // If we re-introduce this later, the right fix is to defer
-            // the ring-buffer flush until the AudioRecord cadence has
-            // stabilized (e.g. observe 5 consecutive frames at the
-            // expected ~10 ms interval). Until that's in place, dropping
-            // the feature entirely is the only safe stance.
+            // Drop mic frames captured while the permit tone is playing.
+            // A TPT-overlap ring buffer that flushed these into the
+            // burst was tried and removed 2026-05-21: on cold-SCO
+            // PTT-down AudioRecord delivers chunked/irregular frames for
+            // the first 300-500 ms, and feeding them to Opus's stateful
+            // SILK encoder produced peer-side screech. Operators adapt by
+            // waiting for TPT before speaking (the universal LMR
+            // convention), so pre-speech capture buys little and the
+            // screech was intolerable.
             return
         }
         if (state != State.TRANSMITTING) {
@@ -1221,14 +1140,6 @@ class TxController(
         // while we're still waiting for the mic to produce real samples,
         // we abandon cleanly without playing TPT or transmitting.
         cooldownHandler.removeCallbacks(primingTimeoutRunnable)
-        // Drop anything still sitting in the TPT-overlap ring. Two cases:
-        //   - Stop during TPT (rare; PTT released before TPT completed):
-        //     the queued speech never reaches the wire, which matches the
-        //     existing "don't transmit if no TPT-end" intent.
-        //   - Stop right after TRANSMITTING flushed the ring: it's already
-        //     empty; clear is a no-op.
-        // Either way, leftover frames must not bleed into the next burst.
-        synchronized(preTxBuffer) { preTxBuffer.clear() }
         // Session-arm: keep the capture alive between bursts so the
         // next PTT-down doesn't pay AudioRecord/mic-chipset cold-start
         // latency. Released only on disarmSessionMic (Mumble disconnect)
@@ -1366,13 +1277,6 @@ class TxController(
             }
         }
 
-    // Vestigial — the cool-down keep-alive scheme that owned this is
-    // gone (caused stale AudioRecord on subsequent bursts). Kept as a
-    // no-op so existing removeCallbacks() sites in stopInternal /
-    // shutdown stay safe even if a stale postDelayed reference were
-    // ever scheduled.
-    private val captureReleaseRunnable = Runnable { /* no-op */ }
-
     /**
      * Hot Mic Mode: pre-acquire the SCO link so the next PTT skips the
      * 500-1500 ms cold-start. Idempotent — safe to call repeatedly. No
@@ -1439,7 +1343,6 @@ class TxController(
             if (state != State.IDLE) stopInternal()
         }
         cooldownHandler.removeCallbacks(coolDownReleaseRunnable)
-        cooldownHandler.removeCallbacks(captureReleaseRunnable)
         cooldownHandler.removeCallbacks(primingTimeoutRunnable)
         capture?.let {
             it.stop()
@@ -1476,8 +1379,12 @@ class TxController(
         private const val SCO_WARMUP_MS = 3000L
 
         // Hold the SCO link for this long after PTT-up before releasing
-        // our ref. Matches the RX SCO_HOT window so the operator's
-        // "rapid back-and-forth" UX is consistent across TX and RX.
+        // our ref. NOTE this 5 s TX cool-down is intentionally SHORTER
+        // than the RX SCO_HOT window (8 s, AudioPlayback.scoHoldMs) and
+        // the Telecom end-debounce (8 s, TELECOM_END_DEBOUNCE_MS): the
+        // physical SCO link may drop at 5 s while the higher-level call
+        // (media pause + focus) lingers to 8 s. They are deliberately
+        // not equal — do not "reconcile" them.
         // Exposed (vs. private) so AudioControllerImpl can reuse it as
         // the phone-mode (non-BT) audio-plant hang time — same operator
         // back-and-forth UX whether the route is BT/SCO or phone speaker.
@@ -1490,29 +1397,6 @@ class TxController(
         // a permanently-open SCO link. The next press pays one cold-
         // start cost, then armHotMic re-acquires.
         private const val HOT_MIC_IDLE_RELEASE_MS = 60_000L
-
-        // TPT-overlap ring buffer size. Each frame is 10 ms (480 samples
-        // at 48 kHz), so 8 frames = 80 ms of buffered pre-TX speech.
-        // Tuned down from 50 (500 ms) after field complaint 2026-05-19
-        // about TPT bleed appearing in the buffered audio as "horrible
-        // screeching." 80 ms is enough to catch a fast operator's first
-        // word that lands inside the trailing edge of the TPT play
-        // window; longer windows just risk re-encoding more residual
-        // TPT-bleed for negligible operator benefit.
-        private const val PRE_TX_BUFFER_MAX_FRAMES = 8
-
-        // Skip the first N ms of state.TPT before buffering. The TPT
-        // tone's high-amplitude region drives speaker output that
-        // bleeds into the mic; AEC cancels most of it but residuals
-        // remain. By the tail of TPT play the envelope has rolled off
-        // (the fillSine release window is ~4 ms but the perceptible
-        // tone amplitude drops well before that). 80 ms is long enough
-        // to cover the louder middle of most TPT tones (NEXTEL is
-        // 150 ms total, ASTRO_25 ~150 ms, timeout cutoff ~1200 ms but
-        // never in this path). Frames before SKIP_MS get dropped on
-        // the floor — we don't even put them in the ring — so even an
-        // eviction can't pull them back in.
-        private const val TPT_RING_SKIP_MS: Long = 80L
 
         // Number of mic frames to hold in the trailing buffer before
         // sending. On stop() these queued frames are dropped, swallowing
@@ -1528,26 +1412,6 @@ class TxController(
         // room), so PRIMING completes within ~50-200ms of mic
         // allocation under normal conditions.
         private const val MIC_PRIMING_RMS_THRESHOLD = 5
-
-        // Noise-floor gate on the TPT-overlap ring buffer. Frames with
-        // RMS below this threshold are NOT appended to the ring — they're
-        // either silence (no operator speech overlap, no value in
-        // queueing) or garbage (`-1` fill from a not-yet-routed mic
-        // source during pre-arm). The garbage path is what produced the
-        // 2026-05-19 screech: Concentus' Resampler asserts on stuck-DC
-        // input, the assert wedges the encoder's SILK state, every
-        // subsequent live frame encodes garbage. 50 sits above mic
-        // self-noise (typically rms 5-20 in a quiet room) and well
-        // below normal speech onset (rms 500+ for spoken syllables),
-        // so it excludes garbage and silence but lets real pre-TX
-        // speech through.
-        //
-        // Exposed (internal) so TxControllerScreechTest can pin the
-        // threshold against the documented intent. Any change to this
-        // value must keep the rms=1 garbage pattern below the line and
-        // typical-speech rms above it — see the test for the boundary
-        // assertions.
-        internal const val RING_BUFFER_MIN_RMS = 50
 
         /**
          * RMS amplitude of a PCM frame. Pure function — promoted out of
@@ -1696,7 +1560,8 @@ class TxController(
         //
         //   2. Silently drop the first [COLD_SCO_START_DROP_FRAMES] TX
         //      frames past state=TRANSMITTING on cold-SCO bursts.
-        //      N=3 at 20 ms/frame = 60 ms of dropped leading edge,
+        //      At 10 ms/frame (480 samples @ 48 kHz) the current N=6 is
+        //      60 ms of dropped leading edge,
         //      typically covering a breath or click rather than
         //      intelligible speech. Analogous to the trailing-frame
         //      swallow ([TRAILING_FRAMES]) that eats the PTT release
@@ -1728,9 +1593,10 @@ class TxController(
         internal const val COLD_SCO_TPT_HOLD_MS: Long = 300L
 
         // Number of leading TX frames to silently discard on the cold-
-        // SCO path. Each frame is 20 ms of PCM.
+        // SCO path. Each frame is 10 ms of PCM (480 samples @ 48 kHz —
+        // see AudioCapture.frameSamples).
         //
-        // Original tuning 2026-07-08: N=3 (60 ms). Covered the
+        // Original tuning 2026-07-08: N=3 (30 ms). Covered the
         // literal underrun burst well and left the TPT→speech
         // ramp intact.
         //
@@ -1738,7 +1604,7 @@ class TxController(
         // cold-SCO hold above, the first-frame-post-transition
         // window is quieter but the SILK encoder still catches a
         // few frames of "not-yet-clean" mic before it locks in. N=6
-        // = 120 ms of dropped leading edge, still well inside the
+        // = 60 ms of dropped leading edge, still well inside the
         // typical 250-400 ms human reaction time from TPT-audible
         // to first phoneme, so operator speech is not eaten.
         //

--- a/app/src/main/java/com/atakmap/android/xv/audio/TxController.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/TxController.kt
@@ -203,27 +203,42 @@ class TxController(
     @Volatile
     private var primingFramesObserved: Int = 0
 
-    // Whether PRIMING was entered while SCO was CONNECTED. Captured at
-    // startPriming() so the gate values are stable through the whole
-    // priming window — the SCO chipset noise floor (~5-15 for the
-    // first 300-1000 ms of a cold start) sits above the non-SCO
-    // MIC_PRIMING_RMS_THRESHOLD, which produced the 2026-07-08 field
-    // repro where onPcmFrame declared "mic ready" on chipset warmup
-    // hiss and shipped ~500 ms of near-silent frames before real
-    // audio reached the encoder. Route-aware gates below fix that.
+    // Whether this burst faces a COLD BT SCO chipset ramp — i.e. we had
+    // to acquire SCO from scratch this burst (currentBurstColdSco).
+    // Captured at startPriming() so the gate values are stable through
+    // the whole priming window.
+    //
+    // The cold chipset delivers 300-1000 ms of warmup where frames
+    // arrive late and at only noise-floor amplitude (~5-15, which sits
+    // above the non-SCO MIC_PRIMING_RMS_THRESHOLD) — the 2026-07-08
+    // field repro where onPcmFrame declared "mic ready" on chipset
+    // warmup hiss and shipped ~500 ms of near-silent frames. The
+    // ramp-tolerant SCO gates (30-frame count, rms>=200, 1500 ms
+    // timeout) fix that.
+    //
+    // CRITICAL (2026-07-13 field repro): this must key off COLD SCO, not
+    // "SCO is CONNECTED." When SCO is held WARM across bursts (the whole
+    // point of the cool-down tail), the chipset is already settled and
+    // there is no ramp — but the old `scoLink.state == CONNECTED` check
+    // still forced the 30-frame (~300 ms) cold gate onto every warm
+    // burst. With bursty radio keying that ~300 ms + TPT meant the
+    // operator released before TX ever started and NOTHING went out
+    // (zero frames per burst, observed across a full session). Warm-SCO
+    // and non-SCO bursts use the fast gates (5 frames / ~50 ms).
     @Volatile
-    private var primingUseScoGates: Boolean = false
+    private var primingUseColdScoGates: Boolean = false
 
     // Was this burst started with SCO in a cold state (i.e. we had to
     // acquire SCO from scratch instead of reusing a warm cool-down or
     // RX SCO_HOT link)? Captured at start() BEFORE we transition into
-    // ACQUIRING_SCO / PRIMING, because primingUseScoGates only tells us
-    // "SCO is CONNECTED right now" — by the time the scoListener drives
-    // startPriming() the link is up, so the cold vs. warm distinction
-    // is already lost from scoLink.state. Used to decide (a) whether
-    // to hold TPT play an extra COLD_SCO_TPT_HOLD_MS while the Pixel
-    // AOC modem stabilizes, and (b) whether to silently drop the first
-    // few TX frames past the initial AOC underrun window.
+    // ACQUIRING_SCO / PRIMING, because by the time the scoListener drives
+    // startPriming() the link reads CONNECTED and the cold vs. warm
+    // distinction is otherwise lost from scoLink.state. This is the
+    // single source of truth for "this burst faces a cold chipset ramp"
+    // and drives: the priming gate selection (primingUseColdScoGates),
+    // (a) the extra COLD_SCO_TPT_HOLD_MS TPT hold while the Pixel AOC
+    // modem stabilizes, and (b) the silent drop of the first few TX
+    // frames past the initial AOC underrun window.
     //
     // Field observation 2026-07-10: cold-SCO first-burst on Pixel 9 Pro
     // showed AOC "[AMixMODEM] uplink underrun for 86 frames" in the
@@ -292,7 +307,7 @@ class TxController(
                     // frames may be silent (peer hears nothing for
                     // 0.5-1 s) but then real audio flows. Better UX
                     // than bonking + retrying.
-                    val txRoute = if (primingUseScoGates) TxRoute.SCO else TxRoute.OFFLOAD
+                    val txRoute = if (primingUseColdScoGates) TxRoute.SCO else TxRoute.OFFLOAD
                     val holdMs = computePrimingHoldMs(txRoute, currentBurstColdSco, 0L)
                     if (holdMs > 0L) {
                         Log.w(
@@ -485,13 +500,20 @@ class TxController(
         // Route-aware gate selection. On BT SCO the chipset takes
         // 300-1000 ms of cold-start warmup during which frames arrive
         // late and/or with only noise-floor amplitude. Non-SCO routes
-        // (built-in mic, wired headset) stabilize within one frame
-        // period. Capture the route decision once so the timeout
-        // callback and onPcmFrame use consistent thresholds even if
-        // SCO state changes mid-priming.
-        primingUseScoGates = scoLink.state == ScoLink.State.CONNECTED
-        val timeoutMs =
-            if (primingUseScoGates) MIC_PRIMING_TIMEOUT_MS_SCO else MIC_PRIMING_TIMEOUT_MS
+        // period. Only a COLD SCO acquire faces the chipset ramp; a
+        // warm-held SCO link (cool-down tail / RX SCO_HOT) has a settled
+        // chipset and must NOT pay the 30-frame cold gate. Capture the
+        // decision once so the timeout callback and onPcmFrame use
+        // consistent thresholds even if SCO state changes mid-priming.
+        primingUseColdScoGates = currentBurstColdSco
+        val timeoutMs = primingTimeoutMs(primingUseColdScoGates)
+        val scoUp = scoLink.state == ScoLink.State.CONNECTED
+        val routeLabel =
+            when {
+                !scoUp -> "non-sco"
+                primingUseColdScoGates -> "sco-cold"
+                else -> "sco-warm"
+            }
         if (capture == null) {
             val cap =
                 audioCaptureFactory { pcm ->
@@ -502,10 +524,10 @@ class TxController(
             Log.i(
                 TAG,
                 "PRIMING: mic capture started — waiting for first non-silent frame " +
-                    "(route=${if (primingUseScoGates) "sco" else "non-sco"}, timeout=${timeoutMs}ms)",
+                    "(route=$routeLabel, timeout=${timeoutMs}ms)",
             )
         } else {
-            Log.i(TAG, "PRIMING: mic capture already alive — waiting for non-silent frame")
+            Log.i(TAG, "PRIMING: mic capture already alive (route=$routeLabel) — waiting for non-silent frame")
         }
         cooldownHandler.removeCallbacks(primingTimeoutRunnable)
         cooldownHandler.postDelayed(primingTimeoutRunnable, timeoutMs)
@@ -981,10 +1003,8 @@ class TxController(
             // is delivering frames at all, the mic is up and TPT can
             // play; the worst that can happen is the first few ms of
             // speech encode as silence, which is unnoticeable.
-            val rmsThreshold =
-                if (primingUseScoGates) MIC_PRIMING_RMS_THRESHOLD_SCO else MIC_PRIMING_RMS_THRESHOLD
-            val minFrames =
-                if (primingUseScoGates) MIC_PRIMING_MIN_FRAMES_ALIVE_SCO else MIC_PRIMING_MIN_FRAMES_ALIVE
+            val rmsThreshold = primingRmsThreshold(primingUseColdScoGates)
+            val minFrames = primingMinFramesToConfirmAlive(primingUseColdScoGates)
             val micAlive =
                 rms >= rmsThreshold ||
                     primingFramesObserved >= minFrames
@@ -999,8 +1019,13 @@ class TxController(
                             } else {
                                 "frames-confirm-alive"
                             }
-                        val route = if (primingUseScoGates) "sco" else "non-sco"
-                        val txRoute = if (primingUseScoGates) TxRoute.SCO else TxRoute.OFFLOAD
+                        val route =
+                            when {
+                                scoLink.state != ScoLink.State.CONNECTED -> "non-sco"
+                                primingUseColdScoGates -> "sco-cold"
+                                else -> "sco-warm"
+                            }
+                        val txRoute = if (primingUseColdScoGates) TxRoute.SCO else TxRoute.OFFLOAD
                         val holdMs = computePrimingHoldMs(txRoute, currentBurstColdSco, 0L)
                         if (holdMs > 0L) {
                             Log.i(
@@ -1479,9 +1504,11 @@ class TxController(
         // chipset's noise floor, require ~300 ms of stable frame
         // delivery before declaring ready via the frame-count path,
         // and extend the timeout so the chipset has room to warm up
-        // before we call it dead. Selected at startPriming() based on
-        // scoLink.state and pinned into primingUseScoGates so mid-
-        // priming SCO state changes don't split-brain the gate logic.
+        // before we call it dead. Applied ONLY to cold-SCO bursts:
+        // selected at startPriming() from currentBurstColdSco and pinned
+        // into primingUseColdScoGates so mid-priming SCO state changes
+        // don't split-brain the gate logic. Warm-SCO bursts (settled
+        // chipset) deliberately use the fast non-SCO gates.
         //
         // Values calibrated from field capture 2026-07-08 (AINA V2
         // APTT316782 + Pixel 9 Pro), where a cold-SCO PTT produced:
@@ -1638,6 +1665,30 @@ class TxController(
             if (COLD_SCO_TPT_HOLD_MS <= 0L) return baseMs
             return baseMs + COLD_SCO_TPT_HOLD_MS
         }
+
+        // ---------- PRIMING gate selection (cold-SCO vs everything else) ----------
+        //
+        // The ramp-tolerant SCO gates exist ONLY for a cold BT SCO
+        // acquire, where the chipset delivers 300-1000 ms of warmup
+        // noise. A warm-held SCO link (cool-down tail / RX SCO_HOT) has a
+        // settled chipset with no ramp, so it — like a non-SCO route —
+        // uses the fast gates. Keying these on `coldSco` (not "SCO is
+        // connected") is the 2026-07-13 field fix: warm bursts previously
+        // paid the 30-frame (~300 ms) cold gate, and with bursty keying
+        // the operator released before TX started and zero frames went
+        // out. Pure functions so the selection is unit-tested directly.
+
+        /** Min frames delivered before PRIMING declares the mic alive. */
+        internal fun primingMinFramesToConfirmAlive(coldSco: Boolean): Int =
+            if (coldSco) MIC_PRIMING_MIN_FRAMES_ALIVE_SCO else MIC_PRIMING_MIN_FRAMES_ALIVE
+
+        /** RMS above which PRIMING treats a frame as real speech. */
+        internal fun primingRmsThreshold(coldSco: Boolean): Int =
+            if (coldSco) MIC_PRIMING_RMS_THRESHOLD_SCO else MIC_PRIMING_RMS_THRESHOLD
+
+        /** Upper bound on the PRIMING wait before bonking/proceeding. */
+        internal fun primingTimeoutMs(coldSco: Boolean): Long =
+            if (coldSco) MIC_PRIMING_TIMEOUT_MS_SCO else MIC_PRIMING_TIMEOUT_MS
 
         /**
          * Should this leading TX frame be silently discarded to skip

--- a/app/src/main/java/com/atakmap/android/xv/audio/TxController.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/TxController.kt
@@ -1511,7 +1511,7 @@ class TxController(
         // chipset) deliberately use the fast non-SCO gates.
         //
         // Values calibrated from field capture 2026-07-08 (AINA V2
-        // APTT316782 + Pixel 9 Pro), where a cold-SCO PTT produced:
+        // AINA V2 puck + Pixel 9 Pro), where a cold-SCO PTT produced:
         //   - AudioRecord alloc → first frame: ~863 ms
         //   - Frames #1-30 rms range: 1-13 (chipset ramp)
         //   - Frame #60 (~570 ms in): rms 1070 (first real speech)

--- a/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
+++ b/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
@@ -899,12 +899,6 @@ class XvMapComponent : AbstractMapComponent() {
                     ) {
                         currentChannelTag = null
                     }
-                    // L4 fix: tell the call bridge the call has ended
-                    // externally so its callActive flag flips back to
-                    // false. Without this, TxController + AudioPlayback
-                    // consult isCallActive() and stay-true blocks their
-                    // manual focus-fallback paths after a peer hangup.
-                    callBridge?.notifyExternallyEnded()
                     // Belt-and-suspenders UI refresh — the transport's
                     // rejoin-to-pre-call-channel will trigger
                     // onChannelChanged which already calls refreshNow,
@@ -1309,7 +1303,7 @@ class XvMapComponent : AbstractMapComponent() {
         want += Manifest.permission.RECORD_AUDIO
         // CALL_PHONE — Telecom's placeCall enforces this on Android
         // 14+ even for self-managed VoIP accounts. Without it, our
-        // service's ACTION_PLACE_CALL throws SecurityException.
+        // service's TelecomManager.placeCall throws SecurityException.
         want += Manifest.permission.CALL_PHONE
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             want += Manifest.permission.BLUETOOTH_CONNECT
@@ -2510,13 +2504,9 @@ class XvMapComponent : AbstractMapComponent() {
                 // Hang Up action does — endChannelCall() routes through
                 // AIDL to XvVoiceService, which tears down the Telecom
                 // Connection; the externalTeardownListener then unwinds
-                // Mumble + voice plant. notifyExternallyEnded clears
-                // the local callActive flag immediately so refreshMain
-                // hides the bar without waiting for the async Telecom
-                // round-trip.
+                // Mumble + voice plant.
                 Log.i(TAG, "Controller.endCall — in-app escape hatch tapped")
                 callBridge?.endChannelCall()
-                callBridge?.notifyExternallyEnded()
             }
         }
 

--- a/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
+++ b/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
@@ -4519,7 +4519,7 @@ class XvMapComponent : AbstractMapComponent() {
         // up". Nothing re-triggers autoConnect, so the reader stays
         // unspawned until the operator manually touches the picker.
         // Observed: OS-level BT reconnect completed at ~4-5 s after
-        // STATE_ON (log: `XvAudioRouter: added: BT_SCO(APTT316782)`
+        // STATE_ON (log: `XvAudioRouter: added: BT_SCO(APTT000000)`
         // at 20:39:54 vs STATE_ON at 20:39:49).
         //
         // 3000 ms gives a safety margin over the observed 4-5 s

--- a/app/src/main/java/com/atakmap/android/xv/service/PttCellularGate.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/PttCellularGate.kt
@@ -95,6 +95,45 @@ fun shouldGateForCellularCall(
     }
 
 /**
+ * Suppress a [PttGate.BLOCK_CELLULAR_CALL] verdict when XV itself is
+ * currently holding the BT SCO link.
+ *
+ * The gate infers "a call is active" from [AudioManager.getMode]. But
+ * XV's OWN audio plant drives the device into MODE_IN_COMMUNICATION /
+ * MODE_IN_CALL whenever it holds the SCO link — RX SCO_HOT, the TX
+ * cool-down tail, Hot-Mic, and the pre-warm window all acquire SCO with
+ * no Telecom call registered. Field repro 2026-07-13 (Pixel 9 Pro):
+ * after the operator's own Telecom call had ended ~39 s earlier, an
+ * Assistant-screensaver wake re-acquired SCO_HOT; the gate saw
+ * MODE_IN_COMMUNICATION with no registered call, mapped it to OFFHOOK,
+ * and blocked a legitimate PTT with "Cellular call active." The
+ * ActiveCallRegistry disambiguation could not catch it — there was no
+ * Telecom call by then, only XV's audio-plant SCO hold.
+ *
+ * If XV holds the SCO link, the comm mode is unambiguously OURS, so the
+ * OFFHOOK-derived block is a false positive → ALLOW. [PttGate.BLOCK_CELLULAR_RINGING]
+ * is never suppressed: it comes from MODE_RINGTONE, which XV's plant
+ * never sets, so a ringing state is always genuinely external.
+ *
+ * Trade-off (accepted): if a real external call is active AND XV happens
+ * to be holding SCO at the same moment, this would let XV place its own
+ * call. That requires XV to be actively holding SCO during an external
+ * call — during which the cellular stack owns HFP/SCO and XV's acquire
+ * would normally lose — so it is a rare edge. The gate is a fidget-guard,
+ * not a hard interlock, and blocking a legitimate tactical PTT is the
+ * worse failure (see [shouldGateForCellularCall]'s fail-open rationale).
+ */
+fun resolveGateWithOwnSco(
+    gate: PttGate,
+    xvHoldsSco: Boolean,
+): PttGate =
+    if (xvHoldsSco && gate == PttGate.BLOCK_CELLULAR_CALL) {
+        PttGate.ALLOW
+    } else {
+        gate
+    }
+
+/**
  * Decide whether a "cellular call active — hang up before XV PTT"
  * toast should be shown right now, given [nowMs] and the timestamp of
  * the previous toast [lastToastAtMs]. Rapid PTT button mashing during

--- a/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
@@ -901,9 +901,14 @@ class VoicePlant(
         // "hardware = intentional" assumption was too generous.
         // See [shouldGateForCellularCall] for the pure decision.
         val cellState = cellularCallStateProvider()
-        val gate = shouldGateForCellularCall(cellState, source)
+        // If XV is currently holding the SCO link, the comm-mode the gate
+        // read is OURS (RX SCO_HOT / TX cool-down / pre-warm), not an
+        // external call — suppress the false-positive block. See
+        // resolveGateWithOwnSco for the 2026-07-13 screensaver-wake repro.
+        val xvHoldsSco = scoLink.holdersCount() > 0
+        val gate = resolveGateWithOwnSco(shouldGateForCellularCall(cellState, source), xvHoldsSco)
         if (gate != PttGate.ALLOW) {
-            Log.i(TAG, "PTT blocked — cellular call state=$cellState source=$source (gate=$gate)")
+            Log.i(TAG, "PTT blocked — cellular call state=$cellState source=$source xvHoldsSco=$xvHoldsSco (gate=$gate)")
             val now = nowMsProvider()
             if (shouldToastCellularBlock(nowMs = now, lastToastAtMs = lastCellCallToastAtMs)) {
                 lastCellCallToastAtMs = now

--- a/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
@@ -144,6 +144,8 @@ class XvVoiceService : Service() {
         com.atakmap.android.xv.telecom.ActiveCallRegistry
             .addExternalTeardownListener(externalTeardownListener)
         com.atakmap.android.xv.telecom.ActiveCallRegistry
+            .addPlaceFailedListener(placeFailedListener)
+        com.atakmap.android.xv.telecom.ActiveCallRegistry
             .addHoldStateListener(holdStateListener)
         com.atakmap.android.xv.telecom.ActiveCallRegistry
             .addIncomingDecisionListener(incomingDecisionListener)
@@ -525,6 +527,8 @@ class XvVoiceService : Service() {
         com.atakmap.android.xv.telecom.ActiveCallRegistry
             .removeExternalTeardownListener(externalTeardownListener)
         com.atakmap.android.xv.telecom.ActiveCallRegistry
+            .removePlaceFailedListener(placeFailedListener)
+        com.atakmap.android.xv.telecom.ActiveCallRegistry
             .removeHoldStateListener(holdStateListener)
         com.atakmap.android.xv.telecom.ActiveCallRegistry
             .removeIncomingDecisionListener(incomingDecisionListener)
@@ -583,6 +587,11 @@ class XvVoiceService : Service() {
     // pttDispatcher.release() and the focus drop.
     private val externalTeardownListener: () -> Unit = {
         Log.w(TAG, "Telecom externally tore down our call — unwinding voice plant")
+        // Call really ended (peer hangup, Telecom preempt, watchdog,
+        // AIDL end). Return the lifecycle to IDLE so the next PTT-down
+        // places a fresh call instead of REUSING a torn-down one.
+        telecomState = TelecomState.IDLE
+        telecomHandler.removeCallbacks(placeTimeoutRunnable)
         telecomHandler.removeCallbacks(pendingEndRunnable)
         // Call really ended — kill the idle watchdog too. Covers all
         // teardown paths (pendingEndRunnable, AIDL endChannelCall,
@@ -1104,14 +1113,94 @@ class XvVoiceService : Service() {
     // Connection (no churn). Idle for the full debounce → call ends,
     // media resumes.
     private val telecomHandler = android.os.Handler(android.os.Looper.getMainLooper())
+
+    // Coarse Telecom-call lifecycle, tracked SYNCHRONOUSLY so PTT input
+    // never double-places a call. The three states mirror the issue's
+    // vocabulary:
+    //   IDLE          — no XV Telecom call; next PTT-down places one.
+    //   ACTIVE_TX_RX  — a call is placed/active (or in-flight: placeCall
+    //                   fired, XvConnection not yet landed in the
+    //                   registry). Set the instant we commit to placing,
+    //                   BEFORE the async tm.placeCall() completes, so a
+    //                   second PTT-down inside the placeCall→
+    //                   onCreateOutgoingConnection registration gap sees
+    //                   "already active" and REUSES instead of issuing a
+    //                   colliding second placeCall ("there is another
+    //                   call connecting").
+    //   TAIL_WARM     — PTT-up fired; the 8 s end-debounce is running.
+    //                   A new PTT-down cancels the debounce and reuses
+    //                   the still-live call.
+    // This is the in-process complement to the PhoneAccount ghost-purge
+    // (#66): ghost-purge drains STALE cross-process Telecom-ledger
+    // entries our registry can't see; this state guards against
+    // IN-process double-placement during the async registration gap.
+    private enum class TelecomState { IDLE, ACTIVE_TX_RX, TAIL_WARM }
+
+    @Volatile
+    private var telecomState: TelecomState = TelecomState.IDLE
+
     private val pendingEndRunnable =
         Runnable {
-            Log.i(TAG, "telecom end-debounce fired — tearing down connection + releasing voice focus")
+            Log.i(TAG, "telecom end-debounce ($TELECOM_END_DEBOUNCE_MS ms) expired — complete teardown (connection + focus)")
+            telecomState = TelecomState.IDLE
+            telecomHandler.removeCallbacks(placeTimeoutRunnable)
             com.atakmap.android.xv.telecom.ActiveCallRegistry
                 .activeConnection()
                 ?.teardownLocal()
             releaseVoiceFocus()
         }
+
+    // Wedge backstop for the state machine. tm.placeCall() is async:
+    // Telecom answers with EITHER onCreateOutgoingConnection (success →
+    // registry populated) OR onCreateOutgoingConnectionFailed. The
+    // failed path fires firePlaceFailed() → placeFailedListener for an
+    // IMMEDIATE reset. This timer covers the pathological case where
+    // NEITHER callback ever arrives (a placeCall that silently produces
+    // no Connection on an OEM-locked ROM): without it, telecomState
+    // would stick at ACTIVE_TX_RX and every subsequent PTT would REUSE a
+    // call that does not exist — PTT wedged until the 8 s debounce.
+    // Self-checks hasActiveCall() so it is a no-op when the connection
+    // DID land (the common case); it only resets the genuinely-stuck
+    // "active state, no connection" wedge.
+    private val placeTimeoutRunnable =
+        Runnable {
+            if (telecomState == TelecomState.ACTIVE_TX_RX &&
+                !com.atakmap.android.xv.telecom.ActiveCallRegistry.hasActiveCall()
+            ) {
+                Log.w(
+                    TAG,
+                    "place-timeout ($PLACE_TIMEOUT_MS ms): no XvConnection landed after placeCall — " +
+                        "resetting telecomState IDLE so the next PTT places cleanly",
+                )
+                com.atakmap.android.xv.util.DiagnosticLogger.event(
+                    tag = "XvVoiceSvc",
+                    severity = 'W',
+                    message = "place-timeout: no Connection landed — telecomState → IDLE (wedge recovery)",
+                )
+                telecomState = TelecomState.IDLE
+                releaseVoiceFocus()
+            }
+        }
+
+    // Fired from XvConnectionService.onCreateOutgoingConnectionFailed
+    // (same service process) via ActiveCallRegistry.firePlaceFailed().
+    // Guarded on !hasActiveCall() so a failed SECOND placeCall (rejected
+    // BECAUSE our first call is legitimately active) never tears down
+    // that good call — in that case telecomState correctly stays
+    // ACTIVE_TX_RX. Only resets the "we tried to place, nothing landed"
+    // wedge, immediately instead of waiting for placeTimeoutRunnable.
+    private val placeFailedListener: () -> Unit = {
+        telecomHandler.post {
+            if (!com.atakmap.android.xv.telecom.ActiveCallRegistry.hasActiveCall() &&
+                telecomState == TelecomState.ACTIVE_TX_RX
+            ) {
+                Log.w(TAG, "onCreateOutgoingConnectionFailed — resetting telecomState IDLE (no call landed)")
+                telecomHandler.removeCallbacks(placeTimeoutRunnable)
+                telecomState = TelecomState.IDLE
+                releaseVoiceFocus()
+            }
+        }
+    }
 
     // Defense-in-depth watchdog for a live Telecom call. The 8s
     // pendingEndRunnable above is activity-gated in the happy path:
@@ -1342,35 +1431,68 @@ class XvVoiceService : Service() {
             scheduleActiveCallActivityLaunch(peerCallsign)
         }
 
-        // If a Connection is already alive, just leave it in ACTIVE
-        // state. No need to placeCall again — Telecom would reject
-        // anyway with "another call connecting" if the prior call's
-        // teardown hasn't fully settled.
-        val existing =
-            com.atakmap.android.xv.telecom.ActiveCallRegistry
-                .activeConnection()
-        if (existing != null) {
-            Log.i(TAG, "placeTelecomCallInternal tag=$tag — reusing existing connection")
-            com.atakmap.android.xv.util.DiagnosticLogger.event(
-                tag = "XvVoiceSvc",
-                message = "placeCall tag='$tag' — REUSING existing XvConnection",
-            )
-            try {
-                existing.setActiveSession()
-            } catch (t: Throwable) {
-                Log.w(TAG, "setActiveSession on existing threw", t)
+        // Decide: reuse the live call, suppress a duplicate placeCall
+        // while the first is still landing, or place a fresh one.
+        // decidePlacement is a pure, unit-tested function of two
+        // synchronous signals — whether the registry holds a live
+        // XvConnection, and whether telecomState says a call is
+        // active/warming.
+        val hasActive =
+            com.atakmap.android.xv.telecom.ActiveCallRegistry.hasActiveCall()
+        val warmOrActive =
+            telecomState == TelecomState.ACTIVE_TX_RX ||
+                telecomState == TelecomState.TAIL_WARM
+        when (decidePlacement(hasActiveConnection = hasActive, warmOrActive = warmOrActive)) {
+            PlaceDecision.REUSE_ACTIVE -> {
+                // Live XvConnection exists — keep it ACTIVE; do NOT place
+                // again (Telecom would reject with "another call
+                // connecting").
+                telecomState = TelecomState.ACTIVE_TX_RX
+                Log.i(TAG, "placeTelecomCallInternal tag=$tag — reusing live XvConnection (state=$telecomState)")
+                com.atakmap.android.xv.util.DiagnosticLogger.event(
+                    tag = "XvVoiceSvc",
+                    message = "placeCall tag='$tag' — REUSING live XvConnection",
+                )
+                try {
+                    com.atakmap.android.xv.telecom.ActiveCallRegistry
+                        .activeConnection()
+                        ?.setActiveSession()
+                } catch (t: Throwable) {
+                    Log.w(TAG, "setActiveSession on existing threw", t)
+                }
+                return
             }
-            return
+            PlaceDecision.REUSE_IN_FLIGHT -> {
+                // telecomState says active/warming but no XvConnection is
+                // registered yet — our first placeCall is still inside
+                // the async onCreateOutgoingConnection gap. Suppress this
+                // second placeCall; the in-flight one serves this press
+                // too. THIS is the double-place race fix.
+                telecomState = TelecomState.ACTIVE_TX_RX
+                Log.i(TAG, "placeTelecomCallInternal tag=$tag — placeCall already in flight; suppressing duplicate (state=$telecomState)")
+                com.atakmap.android.xv.util.DiagnosticLogger.event(
+                    tag = "XvVoiceSvc",
+                    message = "placeCall tag='$tag' — REUSE in-flight (suppressed duplicate placeCall)",
+                )
+                return
+            }
+            PlaceDecision.PLACE -> {
+                // Fall through to a genuinely new placement below.
+            }
         }
 
-        Log.i(TAG, "placeTelecomCallInternal tag=$tag")
+        // New session (telecomState IDLE, no live connection). Commit to
+        // ACTIVE_TX_RX BEFORE the async tm.placeCall() so a concurrent /
+        // rapid second PTT-down takes the REUSE_IN_FLIGHT path above
+        // instead of colliding.
+        telecomState = TelecomState.ACTIVE_TX_RX
+        Log.i(TAG, "placeTelecomCallInternal tag=$tag — requesting NEW Telecom session")
         com.atakmap.android.xv.util.DiagnosticLogger.event(
             tag = "XvVoiceSvc",
             message = "placeCall tag='$tag' — NEW Telecom call attempt",
         )
         if (shouldGhostPurgeBeforePlaceCall(
-                hasActiveConnection =
-                com.atakmap.android.xv.telecom.ActiveCallRegistry.hasActiveCall(),
+                hasActiveConnection = hasActive,
                 hasHadOwnCallInProcess =
                 com.atakmap.android.xv.telecom.ActiveCallRegistry
                     .hasHadOwnCallInProcess(),
@@ -1395,6 +1517,7 @@ class XvVoiceService : Service() {
             getSystemService(Context.TELECOM_SERVICE) as? android.telecom.TelecomManager
         if (tm == null) {
             Log.w(TAG, "TelecomManager unavailable")
+            telecomState = TelecomState.IDLE
             return
         }
         val uri =
@@ -1406,8 +1529,13 @@ class XvVoiceService : Service() {
         try {
             tm.placeCall(uri, extras)
             Log.i(TAG, "placeCall OK for tag=$tag (from PTT-down)")
+            // Arm the wedge backstop: if no XvConnection registers within
+            // PLACE_TIMEOUT_MS, reset to IDLE. No-op once it lands.
+            telecomHandler.removeCallbacks(placeTimeoutRunnable)
+            telecomHandler.postDelayed(placeTimeoutRunnable, PLACE_TIMEOUT_MS)
         } catch (t: Throwable) {
             Log.e(TAG, "placeCall threw", t)
+            telecomState = TelecomState.IDLE
         }
     }
 
@@ -1461,6 +1589,14 @@ class XvVoiceService : Service() {
     }
 
     private fun scheduleEndTelecomCall() {
+        // PTT-up: enter the warm tail. The call stays live for
+        // TELECOM_END_DEBOUNCE_MS so a rapid re-key reuses it; only if
+        // the debounce expires untouched does pendingEndRunnable tear
+        // it down. Guard against clobbering IDLE — a stray end after a
+        // completed teardown must not mark us TAIL_WARM.
+        if (telecomState == TelecomState.ACTIVE_TX_RX) {
+            telecomState = TelecomState.TAIL_WARM
+        }
         telecomHandler.removeCallbacks(pendingEndRunnable)
         telecomHandler.postDelayed(pendingEndRunnable, TELECOM_END_DEBOUNCE_MS)
     }
@@ -2121,14 +2257,30 @@ class XvVoiceService : Service() {
 
         // Holds the Telecom call ACTIVE for 8s after PTT-up so media
         // (Tidal, Spotify) stays paused for the full quiet window
-        // before resuming — matches the SCO_HOT window on the RX side
-        // (AudioPlayback.scoHoldMs) and TxController.SCO_COOL_DOWN_MS.
+        // before resuming — the same 8s as the RX-side SCO_HOT window
+        // (AudioPlayback.scoHoldMs). NOTE this is deliberately LONGER
+        // than TxController.SCO_COOL_DOWN_MS (5s): the SCO physical link
+        // may drop at 5s while the Telecom call (media pause + focus)
+        // lingers to 8s; they are not meant to match.
         // Operator's expectation: "music stays paused until I'm done
         // talking, then quietly resumes after a few seconds." Also
         // absorbs rapid PTT cycles (Telecom needs 200-500ms to settle
         // a disconnect, so the long debounce subsumes the rapid-press
         // protection too).
         private const val TELECOM_END_DEBOUNCE_MS: Long = 8_000L
+
+        // Wedge backstop for the TelecomState machine. After a
+        // successful tm.placeCall() we expect Telecom to answer with
+        // onCreateOutgoingConnection (→ registry populated) or
+        // onCreateOutgoingConnectionFailed within a few hundred ms.
+        // 4s is generous headroom over the observed ~1.5s
+        // placeCall→onCreateOutgoingConnection latency (Pixel-class +
+        // AINA) while still recovering a genuinely-stuck ACTIVE_TX_RX
+        // state fast enough that the operator's next PTT works. The
+        // immediate onCreateOutgoingConnectionFailed → placeFailedListener
+        // path handles the common failure instantly; this only covers
+        // the pathological "no callback ever arrives" case.
+        private const val PLACE_TIMEOUT_MS: Long = 4_000L
 
         // Hard ceiling on Telecom-call lifetime in the absence of any
         // audio activity. Every TX state change and every RX frame
@@ -2250,6 +2402,50 @@ class XvVoiceService : Service() {
         ): Boolean {
             if (hasActiveConnection) return false
             return hasHadOwnCallInProcess
+        }
+
+        /**
+         * Outcome of the placement decision in [placeTelecomCallInternal].
+         *  - [PLACE]           — no live call and none in flight: issue a
+         *                        fresh [android.telecom.TelecomManager.placeCall].
+         *  - [REUSE_ACTIVE]    — a live [com.atakmap.android.xv.telecom.XvConnection]
+         *                        is registered: keep it ACTIVE, do not
+         *                        place again.
+         *  - [REUSE_IN_FLIGHT] — our `telecomState` says a call is
+         *                        active/warming but the connection has
+         *                        not registered yet (the first placeCall
+         *                        is still inside its async
+         *                        onCreateOutgoingConnection gap): suppress
+         *                        the duplicate placeCall.
+         */
+        internal enum class PlaceDecision { PLACE, REUSE_ACTIVE, REUSE_IN_FLIGHT }
+
+        /**
+         * Pure decision for [placeTelecomCallInternal]. Extracted so the
+         * double-place race logic is unit-testable without a Robolectric
+         * service (house convention — cf. [shouldGhostPurgeBeforePlaceCall],
+         * [com.atakmap.android.xv.telecom.ActiveCallRegistry.withinRecentCallGrace]).
+         *
+         * A live registered connection always wins ([REUSE_ACTIVE]) — even
+         * if `telecomState` somehow read IDLE — because placing over a
+         * live self-managed call is exactly what Telecom rejects with
+         * "there is another call connecting." Absent a live connection,
+         * an active/warming `telecomState` means our own first placeCall
+         * is still landing ([REUSE_IN_FLIGHT]); only a fully-idle
+         * lifecycle with no connection warrants a fresh [PLACE].
+         *
+         * @param hasActiveConnection registry snapshot
+         *     ([com.atakmap.android.xv.telecom.ActiveCallRegistry.hasActiveCall]).
+         * @param warmOrActive whether `telecomState` is ACTIVE_TX_RX or
+         *     TAIL_WARM at the placeCall entry point.
+         */
+        internal fun decidePlacement(
+            hasActiveConnection: Boolean,
+            warmOrActive: Boolean,
+        ): PlaceDecision {
+            if (hasActiveConnection) return PlaceDecision.REUSE_ACTIVE
+            if (warmOrActive) return PlaceDecision.REUSE_IN_FLIGHT
+            return PlaceDecision.PLACE
         }
     }
 }

--- a/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
@@ -81,6 +81,41 @@ class XvVoiceService : Service() {
         Log.i(TAG, "onCreate (XV voice plant starting in pid=${Process.myPid()} uid=${Process.myUid()})")
         resolveAuthorizedUids()
         NotificationChannels.ensureAll(this)
+        // Ship-blocking bug (issue #66 item #1): purge any stale self-
+        // managed calls Telecom is still holding under XV's PhoneAccount
+        // from a previous process instance. Field-observed 2026-07-11
+        // TPP validation on Pixel 9 Pro (API 35) and Sonim XP9900:
+        // `dumpsys telecom | grep "SelfMgd Call"` showed XV calls
+        // stacking TC@86..TC@95 with the last entry still ACTIVE
+        // 138+ s after the 8 s [TELECOM_END_DEBOUNCE_MS] should have
+        // torn it down — [ActiveCallRegistry.activeConnection] returned
+        // null (our synchronous view of the call ledger), so the reuse
+        // check in [placeTelecomCallInternal] believed no call existed
+        // and placed a fresh one against a PhoneAccount that Telecom
+        // still associated with a ghost TC@N. Result: system arbitration
+        // fires "Hang up XV to place a new call", PTT press produces no
+        // TX, and the operator sees a toast + confusion.
+        //
+        // The unregister → immediate re-register cycle tells Telecom to
+        // drop every call bound to our PhoneAccountHandle. Safe at
+        // service-process onCreate because we KNOW no live XvConnection
+        // can exist across a fresh process: the connection lives in
+        // this process's [ActiveCallRegistry], which is a Kotlin object
+        // that reinitializes to empty on every classload. Any residual
+        // TC@N in Telecom's own [mCalls] ledger is by definition a
+        // ghost we want gone.
+        //
+        // Explicit constraint (see prior abandoned branch
+        // `copilot/fix-telecom-arbitration-deadlock`): we do NOT touch
+        // `TelecomManager.isInSelfManagedCall(...)` or
+        // `TelecomManager.isInCall()` — both throw SecurityException on
+        // Pixel API 35 because they require READ_PHONE_STATE, a
+        // permission XV does not hold and CANNOT hold (privileged
+        // variant is system-app-only, non-privileged variant requires
+        // Play review for a "phone" app category XV is not). The
+        // unregister path needs no phone-state permission — a self-
+        // managed app is always free to drop its own PhoneAccount.
+        purgeGhostSelfManagedCallsOnFreshProcess()
         // Eagerly construct the voice plant: AudioCapture/AudioTrack/SCO
         // initialization is non-trivial, and the first PTT press
         // shouldn't pay that cost. The plugin's audio plant has been
@@ -1297,8 +1332,42 @@ class XvVoiceService : Service() {
         }
 
         Log.i(TAG, "placeTelecomCallInternal tag=$tag")
-        com.atakmap.android.xv.telecom.XvPhoneAccount
-            .register(this)
+        // Targeted ghost-purge (issue #66 item #1): if a previous own
+        // call has already existed in this process (indicated by
+        // [com.atakmap.android.xv.telecom.ActiveCallRegistry.hasHadOwnCallInProcess]
+        // returning true — checked via [shouldGhostPurgeBeforePlaceCall]),
+        // Telecom may still hold a stale TC@N under our PhoneAccount
+        // even though our synchronous registry says no live connection
+        // exists. Unregistering + re-registering the PhoneAccount tells
+        // Telecom to drop those ghost calls before we attempt a fresh
+        // [TelecomManager.placeCall]; without this, the system
+        // arbitration fires "Hang up XV to place a new call" and the
+        // operator's PTT press produces no TX. Cheap (a couple of
+        // Telecom framework roundtrips) and safe even when no ghost is
+        // present — the register call is idempotent.
+        //
+        // We gate on "there has been an own call in this process" so
+        // the very first PTT press in a fresh process doesn't pay the
+        // cost — [purgeGhostSelfManagedCallsOnFreshProcess] already
+        // handled that window in onCreate.
+        if (shouldGhostPurgeBeforePlaceCall(
+                hasActiveConnection =
+                com.atakmap.android.xv.telecom.ActiveCallRegistry.hasActiveCall(),
+                hasHadOwnCallInProcess =
+                com.atakmap.android.xv.telecom.ActiveCallRegistry
+                    .hasHadOwnCallInProcess(),
+            )
+        ) {
+            Log.w(
+                TAG,
+                "placeTelecomCallInternal: no active connection but this process has ended one " +
+                    "before — purging any Telecom-side ghost calls under our PhoneAccount",
+            )
+            purgeGhostSelfManagedCallsBeforePlaceCall()
+        } else {
+            com.atakmap.android.xv.telecom.XvPhoneAccount
+                .register(this)
+        }
         val tm =
             getSystemService(Context.TELECOM_SERVICE) as? android.telecom.TelecomManager
         if (tm == null) {
@@ -1316,6 +1385,55 @@ class XvVoiceService : Service() {
             Log.i(TAG, "placeCall OK for tag=$tag (from PTT-down)")
         } catch (t: Throwable) {
             Log.e(TAG, "placeCall threw", t)
+        }
+    }
+
+    /**
+     * Fresh-process ghost purge: unregister then re-register the XV
+     * PhoneAccount. Called once at [onCreate] to release any stale
+     * self-managed calls Telecom is still holding from a previous
+     * process instance whose in-memory [ActiveCallRegistry] is no
+     * longer reachable. See the [onCreate] callsite for the field-bug
+     * rationale.
+     *
+     * Wrapped in a helper so it can be swapped in tests and so
+     * exception handling is centralized: an unexpected throw here
+     * MUST NOT prevent the rest of onCreate from completing (the
+     * voice plant would then be permanently unavailable). Any
+     * [Throwable] from either leg is logged and swallowed.
+     */
+    private fun purgeGhostSelfManagedCallsOnFreshProcess() {
+        try {
+            com.atakmap.android.xv.telecom.XvPhoneAccount.unregister(this)
+        } catch (t: Throwable) {
+            Log.w(TAG, "onCreate ghost-purge: unregisterPhoneAccount threw", t)
+        }
+        try {
+            com.atakmap.android.xv.telecom.XvPhoneAccount.register(this)
+        } catch (t: Throwable) {
+            Log.w(TAG, "onCreate ghost-purge: re-register threw", t)
+        }
+    }
+
+    /**
+     * Pre-placeCall ghost purge: same unregister → re-register cycle
+     * as the onCreate path, but invoked from [placeTelecomCallInternal]
+     * when [shouldGhostPurgeBeforePlaceCall] returns true. See the
+     * placeTelecomCallInternal callsite for the full rationale.
+     *
+     * Same exception-handling contract: a throw MUST NOT block the
+     * follow-on [TelecomManager.placeCall]. Log and swallow.
+     */
+    private fun purgeGhostSelfManagedCallsBeforePlaceCall() {
+        try {
+            com.atakmap.android.xv.telecom.XvPhoneAccount.unregister(this)
+        } catch (t: Throwable) {
+            Log.w(TAG, "pre-placeCall ghost-purge: unregisterPhoneAccount threw", t)
+        }
+        try {
+            com.atakmap.android.xv.telecom.XvPhoneAccount.register(this)
+        } catch (t: Throwable) {
+            Log.w(TAG, "pre-placeCall ghost-purge: re-register threw", t)
         }
     }
 
@@ -1405,8 +1523,33 @@ class XvVoiceService : Service() {
         } catch (t: Throwable) {
             Log.w(TAG, "setCallRinging(true) threw", t)
         }
-        com.atakmap.android.xv.telecom.XvPhoneAccount
-            .register(this)
+        // Same ghost-purge as [placeTelecomCallInternal] — an incoming
+        // REQUEST_CALL after a prior teardown hits the same TC@N-
+        // stacking arbitration when Telecom still holds a stale entry
+        // under our PhoneAccount. Field bug #66 was reported for
+        // outgoing PTT calls, but the underlying Telecom bookkeeping is
+        // symmetric: [TelecomManager.addNewIncomingCall] is subject to
+        // the same "already has an active call under this account"
+        // arbitration as [TelecomManager.placeCall]. See
+        // [shouldGhostPurgeBeforePlaceCall] KDoc for the decision.
+        if (shouldGhostPurgeBeforePlaceCall(
+                hasActiveConnection =
+                com.atakmap.android.xv.telecom.ActiveCallRegistry.hasActiveCall(),
+                hasHadOwnCallInProcess =
+                com.atakmap.android.xv.telecom.ActiveCallRegistry
+                    .hasHadOwnCallInProcess(),
+            )
+        ) {
+            Log.w(
+                TAG,
+                "placeIncomingTelecomCallInternal: no active connection but this process has " +
+                    "ended one before — purging any Telecom-side ghost calls under our PhoneAccount",
+            )
+            purgeGhostSelfManagedCallsBeforePlaceCall()
+        } else {
+            com.atakmap.android.xv.telecom.XvPhoneAccount
+                .register(this)
+        }
         val tm = getSystemService(Context.TELECOM_SERVICE) as? android.telecom.TelecomManager
         if (tm == null) {
             Log.w(TAG, "TelecomManager unavailable")
@@ -2030,6 +2173,60 @@ class XvVoiceService : Service() {
             if (lastState == android.bluetooth.BluetoothAdapter.ERROR) return true
             if (newState != lastState) return true
             return (nowMs - lastReactedMs) >= thresholdMs
+        }
+
+        /**
+         * Pure decision function for the pre-[android.telecom.TelecomManager.placeCall]
+         * ghost-purge guard (issue #66 item #1). Extracted from
+         * [placeTelecomCallInternal] so it can be unit-tested without
+         * standing up a Robolectric service.
+         *
+         * The signal we are trying to detect is "our in-process view of
+         * [com.atakmap.android.xv.telecom.ActiveCallRegistry] is empty
+         * but Telecom may still hold a ghost TC@N under our
+         * PhoneAccount." We can not ASK Telecom directly —
+         * [android.telecom.TelecomManager.isInSelfManagedCall] and
+         * [android.telecom.TelecomManager.isInCall] both require
+         * READ_PHONE_STATE (and the privileged variant on API 35+), a
+         * permission XV does not hold and cannot obtain for a non-
+         * system app. So we approximate the signal using ONLY
+         * information we own:
+         *
+         *  - `hasActiveConnection == false` — our registry has no live
+         *    call reference. Necessary condition; the reuse path in
+         *    [placeTelecomCallInternal] short-circuits when this is
+         *    true and never reaches the ghost-purge check.
+         *  - `hasHadOwnCallInProcess == true` — an own call HAS
+         *    existed in this process at some point and been
+         *    unregistered
+         *    ([com.atakmap.android.xv.telecom.ActiveCallRegistry.hasHadOwnCallInProcess]
+         *    reads the same `lastOwnCallEndedAtMs > 0` invariant the
+         *    grace window uses). This is the gate that keeps us from
+         *    paying the Telecom-roundtrip cost on the very first PTT
+         *    press in a fresh process; the fresh-process case is
+         *    handled once at [onCreate] by
+         *    [purgeGhostSelfManagedCallsOnFreshProcess], which runs
+         *    before any call can be attempted.
+         *
+         * Both conditions must hold. Returning `true` from this
+         * function is the exact "we already dropped one call in this
+         * process and are about to start another; make sure Telecom
+         * agrees the previous one is gone" scenario the field bug
+         * describes.
+         *
+         * @param hasActiveConnection the current registry snapshot —
+         *     [com.atakmap.android.xv.telecom.ActiveCallRegistry.hasActiveCall]
+         *     at the placeCall entry point.
+         * @param hasHadOwnCallInProcess whether any own call has been
+         *     unregistered in this process
+         *     ([com.atakmap.android.xv.telecom.ActiveCallRegistry.hasHadOwnCallInProcess]).
+         */
+        internal fun shouldGhostPurgeBeforePlaceCall(
+            hasActiveConnection: Boolean,
+            hasHadOwnCallInProcess: Boolean,
+        ): Boolean {
+            if (hasActiveConnection) return false
+            return hasHadOwnCallInProcess
         }
     }
 }

--- a/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
@@ -78,6 +78,16 @@ class XvVoiceService : Service() {
 
     override fun onCreate() {
         super.onCreate()
+        // Bring the file-backed diagnostic logger up BEFORE anything
+        // else so subsequent init events land in the field-post-mortem
+        // file. Safe to call more than once — subsequent init()s are
+        // no-ops. See DiagnosticLogger KDoc for the field-motivating
+        // 2026-07-12 rollover incident.
+        com.atakmap.android.xv.util.DiagnosticLogger.init(this)
+        com.atakmap.android.xv.util.DiagnosticLogger.event(
+            tag = "XvVoiceSvc",
+            message = "onCreate — pid=${Process.myPid()} uid=${Process.myUid()}",
+        )
         Log.i(TAG, "onCreate (XV voice plant starting in pid=${Process.myPid()} uid=${Process.myUid()})")
         resolveAuthorizedUids()
         NotificationChannels.ensureAll(this)
@@ -460,6 +470,10 @@ class XvVoiceService : Service() {
 
     override fun onDestroy() {
         Log.i(TAG, "onDestroy — releasing voice plant")
+        com.atakmap.android.xv.util.DiagnosticLogger.event(
+            tag = "XvVoiceSvc",
+            message = "onDestroy — releasing voice plant",
+        )
         releaseVolumeKeyCapture()
         telecomHandler.removeCallbacks(pendingEndRunnable)
         // Cancel the watchdog BEFORE removing externalTeardownListener
@@ -515,6 +529,11 @@ class XvVoiceService : Service() {
         }
         plant = null
         listeners.kill()
+        com.atakmap.android.xv.util.DiagnosticLogger.event(
+            tag = "XvVoiceSvc",
+            message = "onDestroy — complete, flushing diagnostic log",
+        )
+        com.atakmap.android.xv.util.DiagnosticLogger.flush()
         super.onDestroy()
     }
 
@@ -968,6 +987,15 @@ class XvVoiceService : Service() {
             }
 
             override fun onPttBlockedByCellularCall(reason: String) {
+                com.atakmap.android.xv.util.DiagnosticLogger.event(
+                    tag = "XvVoiceSvc",
+                    severity = 'W',
+                    message = "PTT blocked by cellular gate: $reason",
+                )
+                com.atakmap.android.xv.util.DiagnosticLogger.stateSnapshot(
+                    context = this@XvVoiceService,
+                    reason = "cellular-gate-block",
+                )
                 fanOut { it.onPttBlockedByCellularCall(reason) }
             }
 
@@ -1288,6 +1316,10 @@ class XvVoiceService : Service() {
                 .activeConnection()
         if (existing != null) {
             Log.i(TAG, "placeTelecomCallInternal tag=$tag — reusing existing connection")
+            com.atakmap.android.xv.util.DiagnosticLogger.event(
+                tag = "XvVoiceSvc",
+                message = "placeCall tag='$tag' — REUSING existing XvConnection",
+            )
             try {
                 existing.setActiveSession()
             } catch (t: Throwable) {
@@ -1297,6 +1329,10 @@ class XvVoiceService : Service() {
         }
 
         Log.i(TAG, "placeTelecomCallInternal tag=$tag")
+        com.atakmap.android.xv.util.DiagnosticLogger.event(
+            tag = "XvVoiceSvc",
+            message = "placeCall tag='$tag' — NEW Telecom call attempt",
+        )
         com.atakmap.android.xv.telecom.XvPhoneAccount
             .register(this)
         val tm =

--- a/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
@@ -1518,6 +1518,9 @@ class XvVoiceService : Service() {
         if (tm == null) {
             Log.w(TAG, "TelecomManager unavailable")
             telecomState = TelecomState.IDLE
+            // No call will be placed — release the voice focus we grabbed
+            // above so media doesn't stay paused/ducked indefinitely.
+            releaseVoiceFocus()
             return
         }
         val uri =
@@ -1536,6 +1539,9 @@ class XvVoiceService : Service() {
         } catch (t: Throwable) {
             Log.e(TAG, "placeCall threw", t)
             telecomState = TelecomState.IDLE
+            // placeCall failed — nothing will land, so release the voice
+            // focus grabbed above rather than leaving media paused.
+            releaseVoiceFocus()
         }
     }
 

--- a/app/src/main/java/com/atakmap/android/xv/telecom/ActiveCallRegistry.kt
+++ b/app/src/main/java/com/atakmap/android/xv/telecom/ActiveCallRegistry.kt
@@ -252,6 +252,35 @@ internal object ActiveCallRegistry {
         }
     }
 
+    // Listeners notified when Telecom REFUSES an outgoing placeCall we
+    // just issued — i.e. XvConnectionService.onCreateOutgoingConnectionFailed
+    // fires (same service process). Distinct from externalTeardown: no
+    // call ever became live, so there is nothing to unwind — the signal
+    // only lets XvVoiceService reset its synchronous TelecomState back to
+    // IDLE immediately instead of waiting for its place-timeout backstop.
+    // The listener is expected to guard on hasActiveCall() so a placeCall
+    // rejected *because* another of our calls is legitimately active does
+    // not disturb that live call.
+    private val placeFailedListeners = java.util.concurrent.CopyOnWriteArrayList<() -> Unit>()
+
+    fun addPlaceFailedListener(listener: () -> Unit) {
+        placeFailedListeners.add(listener)
+    }
+
+    fun removePlaceFailedListener(listener: () -> Unit) {
+        placeFailedListeners.remove(listener)
+    }
+
+    fun firePlaceFailed() {
+        for (l in placeFailedListeners) {
+            try {
+                l()
+            } catch (t: Throwable) {
+                Log.w(TAG, "place-failed listener threw", t)
+            }
+        }
+    }
+
     fun addHoldStateListener(listener: (Boolean) -> Unit) {
         holdStateListeners.add(listener)
     }

--- a/app/src/main/java/com/atakmap/android/xv/telecom/ActiveCallRegistry.kt
+++ b/app/src/main/java/com/atakmap/android/xv/telecom/ActiveCallRegistry.kt
@@ -191,6 +191,31 @@ internal object ActiveCallRegistry {
     @VisibleForTesting
     fun lastOwnCallEndedAtMsForTest(): Long = lastOwnCallEndedAtMs
 
+    /**
+     * True when an own call has been unregistered in this process at
+     * least once — i.e. [unregister] has stamped
+     * [lastOwnCallEndedAtMs] non-zero. False on a fresh process where
+     * no call has ever been placed and torn down.
+     *
+     * Callers: the pre-[android.telecom.TelecomManager.placeCall]
+     * ghost-purge guard in
+     * [com.atakmap.android.xv.service.XvVoiceService.placeTelecomCallInternal]
+     * uses this to distinguish "very first PTT press in a fresh
+     * process (fresh-process purge already happened in onCreate)" from
+     * "we've placed and torn down at least one call already; a fresh
+     * placeCall may collide with a Telecom-side ghost TC@N." See
+     * [com.atakmap.android.xv.service.XvVoiceService.shouldGhostPurgeBeforePlaceCall]
+     * for the exact decision.
+     *
+     * Deliberately not derivable from [hasActiveCall]: a call that's
+     * currently active in the registry would satisfy "has ever
+     * existed" too, but the ghost-purge check dominates on
+     * `hasActiveCall == true` via a separate early-return (the reuse
+     * path). This reader captures ONLY the "ended-in-the-past"
+     * signal, keeping the guard's two conditions orthogonal.
+     */
+    fun hasHadOwnCallInProcess(): Boolean = lastOwnCallEndedAtMs > 0L
+
     fun fanOutRouteChange(state: CallAudioState?) {
         for (l in routeListeners) {
             try {

--- a/app/src/main/java/com/atakmap/android/xv/telecom/XvCallBridge.kt
+++ b/app/src/main/java/com/atakmap/android/xv/telecom/XvCallBridge.kt
@@ -3,77 +3,46 @@ package com.atakmap.android.xv.telecom
 import android.util.Log
 import com.atakmap.android.xv.service.XvVoiceClient
 
-// Plugin-side facade for the Telecom-mediated voice session. Because
+// Plugin-side facade for ENDING the Telecom-mediated voice session.
 // XvConnectionService is gated on BIND_TELECOM_CONNECTION_SERVICE
 // (system-only) AND the plugin runs in ATAK's UID without
-// MANAGE_OWN_CALLS, all Telecom operations have to happen in our
-// APK's UID. This bridge proxies them through XvVoiceClient (which
-// already has a binder to XvVoiceService in our UID). The voice
-// service in turn calls TelecomManager.placeCall — same process as
-// XvConnectionService, so the system-mediated callback chain works.
+// MANAGE_OWN_CALLS, so all Telecom operations must happen in our APK's
+// UID. This bridge proxies the end-call through XvVoiceClient (which
+// holds a binder to XvVoiceService in our UID); the service in turn
+// tears down the XvConnection it owns.
 //
-// callActive is the plugin's local approximation of "is there a
-// Telecom call right now?" — used to gate manual audio focus calls
-// in TxController + AudioPlayback. Flips true on placeCall, false
-// on endCall.
+// Placement is NOT proxied here — outgoing calls originate directly in
+// XvVoiceService.placeTelecomCallInternal (group PTT) or via
+// XvVoiceClient.startChannelCall (private calls). This bridge is the
+// end-call side only.
+//
+// History: this class used to carry a plugin-side `callActive`
+// approximation flag plus a `startChannelCall` proxy and an
+// `isCallActive()` reader. That machinery was superseded by
+// ActiveCallRegistry.hasActiveCall() (the authoritative service-process
+// signal that TxController/AudioPlayback actually consult) and became
+// dead — `startChannelCall` had no callers, so `callActive` was never
+// set true, which in turn made `endChannelCall()`'s old
+// `if (!callActive) return` guard a permanent no-op that silently broke
+// the in-app "End Call" bar. The flag/proxy/reader were removed and
+// `endChannelCall()` now fires unconditionally.
 class XvCallBridge(
     private val voiceClient: XvVoiceClient,
 ) {
-    @Volatile
-    private var callActive: Boolean = false
-
-    fun isCallActive(): Boolean = callActive
-
     /**
-     * Reset the call-active flag from outside. Called by the plugin's
-     * `onPrivateCallEnded` listener (which fires when the service-side
-     * `externalTeardownListener` notifies that Telecom tore down the
-     * call from outside our explicit `endChannelCall` path — peer
-     * hangup, system preempt, BAL kill, etc.).
-     *
-     * L4 fix: without this hook, `callActive` stays true forever after
-     * an external teardown — TxController + AudioPlayback consult
-     * isCallActive() to decide whether to skip their manual focus
-     * fallback, and a stale-true result blocks fallback paths the
-     * plant expects to use when no Telecom call is up.
+     * End the active Telecom call. Fires unconditionally — the
+     * service-side teardown is idempotent (`teardownLocal()` no-ops when
+     * no XvConnection is registered), so a redundant end is harmless.
+     * Teardown converges here from several sites (stopActiveTransport,
+     * the in-app End Call bar, onPrivateCallEnded, direct UI Hang Up);
+     * every one of them needs the Telecom Connection released so audio
+     * focus + BT routing hand back to normal media.
      */
-    fun notifyExternallyEnded() {
-        if (callActive) {
-            callActive = false
-            Log.i(TAG, "notifyExternallyEnded — callActive=false")
-        }
-    }
-
-    fun startChannelCall(channelTag: String): Boolean =
-        try {
-            voiceClient.ifBound {
-                try {
-                    it.startChannelCall(channelTag)
-                } catch (t: Throwable) {
-                    Log.w(TAG, "startChannelCall AIDL threw", t)
-                }
-            }
-            callActive = true
-            Log.i(TAG, "startChannelCall queued for tag=$channelTag (callActive=true)")
-            true
-        } catch (t: Throwable) {
-            Log.e(TAG, "startChannelCall threw", t)
-            false
-        }
-
     fun endChannelCall() {
-        // Idempotent. Teardown converges on this from multiple sites
-        // (stopActiveTransport, callBridge.shutdown, onPrivateCallEnded,
-        // direct UI Hang Up), so a stale-true → stale-false flip is
-        // the only useful work — if callActive is already false the
-        // AIDL has been sent and the service side has cleared its
-        // Telecom call; re-sending just produces a duplicate log line.
-        if (!callActive) return
-        callActive = false
         voiceClient.ifBound {
             try {
                 it.endChannelCall()
-                Log.i(TAG, "endChannelCall sent (callActive=false)")
+                Log.i(TAG, "endChannelCall sent")
             } catch (t: Throwable) {
                 Log.w(TAG, "endChannelCall AIDL threw", t)
             }

--- a/app/src/main/java/com/atakmap/android/xv/telecom/XvConnectionService.kt
+++ b/app/src/main/java/com/atakmap/android/xv/telecom/XvConnectionService.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.telecom.Connection
 import android.telecom.ConnectionRequest
 import android.telecom.ConnectionService
+import android.telecom.DisconnectCause
 import android.telecom.PhoneAccountHandle
 import android.telecom.TelecomManager
 import android.util.Log
@@ -23,9 +24,11 @@ import android.util.Log
 // originating here have the permission.
 //
 // Plugin → Service contract is action-based via startService:
-//   ACTION_PLACE_CALL + EXTRA_CHANNEL_TAG: register account if needed,
-//                                          then placeCall
 //   ACTION_END_CALL: disconnect the active Connection (if any)
+//
+// (The outgoing placeCall now originates solely in XvVoiceService, in
+// this same process/UID — see placeTelecomCallInternal. The legacy
+// startService(ACTION_PLACE_CALL) path was dead code and was removed.)
 //
 // The Connection lives in this process for its entire lifetime; the
 // plugin never touches it directly.
@@ -47,10 +50,6 @@ class XvConnectionService : ConnectionService() {
         val action = intent?.action
         Log.i(TAG, "onStartCommand action=$action")
         when (action) {
-            ACTION_PLACE_CALL -> {
-                val tag = intent.getStringExtra(EXTRA_CHANNEL_TAG) ?: "unknown"
-                handlePlaceCall(tag)
-            }
             ACTION_END_CALL -> {
                 val conn = ActiveCallRegistry.activeConnection()
                 if (conn == null) {
@@ -69,28 +68,6 @@ class XvConnectionService : ConnectionService() {
         return START_NOT_STICKY
     }
 
-    private fun handlePlaceCall(channelTag: String) {
-        registerPhoneAccountIfNeeded()
-        val tm = getSystemService(TELECOM_SERVICE) as? TelecomManager
-        if (tm == null) {
-            Log.w(TAG, "TelecomManager unavailable")
-            return
-        }
-        val uri = XvPhoneAccount.callUri(channelTag)
-        val extras = XvPhoneAccount.placeCallExtras(this, channelTag)
-        try {
-            tm.placeCall(uri, extras)
-            Log.i(TAG, "placeCall fired for tag=$channelTag uri=$uri")
-        } catch (t: SecurityException) {
-            // MANAGE_OWN_CALLS missing OR PhoneAccount registered but
-            // not enabled in system Telecom settings. Some OEM ROMs
-            // require manual enable for self-managed accounts.
-            Log.e(TAG, "placeCall denied — check MANAGE_OWN_CALLS + account enabled", t)
-        } catch (t: Throwable) {
-            Log.e(TAG, "placeCall threw", t)
-        }
-    }
-
     private fun registerPhoneAccountIfNeeded() {
         if (phoneAccountRegistered) return
         XvPhoneAccount.register(this)
@@ -104,17 +81,40 @@ class XvConnectionService : ConnectionService() {
         val tag = request?.address?.schemeSpecificPart ?: "unknown"
         Log.i(TAG, "onCreateOutgoingConnection tag=$tag account=$connectionManagerPhoneAccount")
 
+        // Defense-in-depth for the double-place race: if a live
+        // connection with the SAME tag already exists, a second
+        // placeCall for it raced past XvVoiceService's synchronous
+        // TelecomState guard. Do NOT stack a second XvConnection —
+        // keep the existing one ACTIVE and fail THIS duplicate request
+        // so Telecom drops it. Returning a CANCELED failed connection
+        // (not ERROR) is silent for a self-managed call and, unlike
+        // Telecom's own rejection, never disturbs the live call. This
+        // does NOT invoke onCreateOutgoingConnectionFailed, so the
+        // service's place-failed reset does not fire — correct, because
+        // our real call is still up.
+        ActiveCallRegistry.activeConnection()?.let { prior ->
+            if (prior.tag == tag) {
+                Log.w(
+                    TAG,
+                    "onCreateOutgoingConnection: duplicate placeCall for live tag='$tag' — " +
+                        "rejecting duplicate, keeping the existing connection",
+                )
+                prior.setActiveSession()
+                return Connection.createFailedConnection(
+                    DisconnectCause(DisconnectCause.CANCELED),
+                )
+            }
+        }
+
         // Tear down any prior PRIVATE call before placing a new one.
         // A new outgoing call's tag is either "voice" (group-channel
         // placeholder for PTT) or "→ peer" (private call). When the new
-        // tag is "voice", the prior is usually also "voice" — that's
-        // the existing connection-reuse path. When the new tag is
-        // "→ peer", a prior "voice" must NOT be torn down here for the
-        // same reason as the incoming path: tearing it fires
-        // fireExternalTeardown which the plugin's onPrivateCallEnded
-        // interprets and sends CANCEL_CALL, which the callee receives
-        // and shows on its side. Prior private calls are torn down
-        // normally.
+        // tag is "→ peer", a prior "voice" must NOT be torn down here:
+        // tearing it fires fireExternalTeardown which the plugin's
+        // onPrivateCallEnded interprets and sends CANCEL_CALL, which the
+        // callee receives and shows on its side. Prior private calls are
+        // torn down normally. (Same-tag "voice"-over-"voice" is already
+        // handled by the reuse guard above.)
         ActiveCallRegistry.activeConnection()?.let { prior ->
             val newIsPrivate = tag.startsWith("→ ") || tag.startsWith("← ")
             val priorIsVoice = prior.tag == "voice"
@@ -168,6 +168,15 @@ class XvConnectionService : ConnectionService() {
             TAG,
             "onCreateOutgoingConnectionFailed account=$connectionManagerPhoneAccount address=${request?.address}",
         )
+        // A placeCall we issued did not become a Connection. Signal the
+        // service (same process) so it can reset its synchronous
+        // TelecomState back to IDLE immediately — otherwise the state
+        // would stick at ACTIVE_TX_RX and the next PTT would REUSE a
+        // call that never existed, wedging TX until the place-timeout
+        // backstop fires. The service-side listener guards on
+        // hasActiveCall() so a failure caused by another of our calls
+        // being legitimately active leaves that live call untouched.
+        ActiveCallRegistry.firePlaceFailed()
     }
 
     override fun onCreateIncomingConnection(
@@ -221,9 +230,10 @@ class XvConnectionService : ConnectionService() {
         // Observed 2026-05-11 Pixel→Surface call: Surface had a residual
         // "voice" connection from group PTT, REQUEST_CALL arrived, we
         // tore down the prior, plugin sent CANCEL_CALL, Pixel's call
-        // screen vanished. The group-channel connection's own 5s
-        // end-debounce clears it shortly; Telecom can hold a RINGING +
-        // ACTIVE call in parallel until the user answers.
+        // screen vanished. The group-channel connection's own 8s
+        // end-debounce (TELECOM_END_DEBOUNCE_MS) clears it shortly;
+        // Telecom can hold a RINGING + ACTIVE call in parallel until
+        // the user answers.
         ActiveCallRegistry.activeConnection()?.let { prior ->
             if (prior.tag == "voice") {
                 Log.i(TAG, "skipping prior 'voice' connection teardown — will clear via its own debounce")
@@ -250,10 +260,7 @@ class XvConnectionService : ConnectionService() {
     companion object {
         private const val TAG = "XvConnSvc"
 
-        const val ACTION_PLACE_CALL = "com.atakmap.android.xv.telecom.PLACE_CALL"
         const val ACTION_END_CALL = "com.atakmap.android.xv.telecom.END_CALL"
         const val ACTION_NOOP = "com.atakmap.android.xv.telecom.NOOP"
-
-        const val EXTRA_CHANNEL_TAG = "channel_tag"
     }
 }

--- a/app/src/main/java/com/atakmap/android/xv/util/DiagnosticLogger.kt
+++ b/app/src/main/java/com/atakmap/android/xv/util/DiagnosticLogger.kt
@@ -1,0 +1,447 @@
+package com.atakmap.android.xv.util
+
+import android.content.Context
+import android.media.AudioManager
+import android.os.Build
+import android.os.Handler
+import android.os.HandlerThread
+import android.util.Log
+import java.io.BufferedWriter
+import java.io.File
+import java.io.FileWriter
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * File-backed diagnostic logger for post-mortem field-session analysis.
+ *
+ * ## Why this exists
+ *
+ * Android's logcat main ring is bounded (8 MiB per buffer on a Pixel 9
+ * Pro). On a device running a normal mix of system + user apps, high-
+ * volume tags (Instagram, GMS, mem-pressure churn) can evict a full XV
+ * field session's worth of events within a couple of hours. Field-
+ * observed 2026-07-12: an operator hit an XV reliability issue for
+ * hours during a live event, and by the time the log was pulled at
+ * `adb logcat -d` the entire XV-tagged trace had been rolled out —
+ * only Telecom framework references to `XvConnectionService` survived.
+ * Post-mortem with that little context is essentially "diagnose by
+ * inference." Never again.
+ *
+ * This class writes the same events XV already emits to logcat into a
+ * per-day file under `<app-external-files>/xv-logs/xv-<date>.log`.
+ * The location is chosen so:
+ *
+ *  - No `WRITE_EXTERNAL_STORAGE` / `MANAGE_EXTERNAL_STORAGE` permission
+ *    is required (`Context.getExternalFilesDir(...)` is app-scoped).
+ *  - The path is readable over `adb pull` without root even on locked-
+ *    down field devices — the operator can grab it after an incident.
+ *  - The path is app-owned so uninstall clears it (nothing lingers).
+ *  - The path is opaque to Android's normal file scanners, so operator
+ *    photos etc. don't get indexed alongside it.
+ *
+ * ## What gets written
+ *
+ * Every [event] call produces one line:
+ * ```
+ * [HH:mm:ss.SSS] TAG severity : message
+ * ```
+ * plus a one-shot session-start header on [init] with device fingerprint,
+ * OS build, XV version, and PID. A periodic heartbeat (every
+ * [HEARTBEAT_INTERVAL_MS]) writes process-state summary so a long silent
+ * gap in the file is a plausible signal that the plugin was frozen /
+ * killed even if we never got to log the death event itself.
+ *
+ * ## Redaction
+ *
+ * All output is subject to the sensitive-content rules in `CLAUDE.md`:
+ * MAC addresses, TAK server URLs, and operator callsigns MUST be
+ * redacted before they reach this class. Callers pass already-redacted
+ * strings. This class does not attempt a second-pass redaction — that
+ * would give a false sense of safety. Discipline is at the caller site.
+ *
+ * ## Rotation policy
+ *
+ * - One file per calendar day (`xv-YYYY-MM-DD.log`).
+ * - Soft size cap [MAX_FILE_BYTES]; on cross, the current file is
+ *   renamed with a `.1`, `.2`, ... suffix and a fresh file is opened.
+ * - Files older than [RETENTION_DAYS] are deleted at [init] time.
+ *
+ * ## Thread safety
+ *
+ * All I/O happens on a single background [HandlerThread] so callers can
+ * fire-and-forget from any thread (main, Telecom binder, GATT callback,
+ * SPP read loop). If [init] has not been called the [event] path is a
+ * cheap no-op — no NPE hazard from misordered lifecycle.
+ */
+object DiagnosticLogger {
+    private const val TAG = "XvDiag"
+    private const val DIR_NAME = "xv-logs"
+    private const val FILE_PREFIX = "xv-"
+    private const val FILE_SUFFIX = ".log"
+
+    /**
+     * Soft cap per file before rotation. Sized so a busy field session
+     * with heartbeats + PTT bursts + Telecom transitions doesn't hit
+     * the cap in a single day. When it does, `.1`, `.2`, ... files
+     * appear alongside for that day.
+     */
+    private const val MAX_FILE_BYTES: Long = 5 * 1024 * 1024
+
+    /**
+     * Delete daily files older than this many days on [init]. Field
+     * captures rarely need more than a week of history; anything older
+     * is either already pulled off the device or forgotten.
+     */
+    private const val RETENTION_DAYS = 7
+
+    /**
+     * How often the heartbeat runnable fires. Long enough that the log
+     * stays readable (about 1 line per minute at idle), short enough
+     * that a service kill / freeze shows up as a gap in the file that
+     * a post-mortem grep will notice.
+     */
+    private const val HEARTBEAT_INTERVAL_MS: Long = 60_000L
+
+    private val started = AtomicBoolean(false)
+    private var appContext: Context? = null
+    private var writer: BufferedWriter? = null
+    private var currentFile: File? = null
+    private var currentDay: String = ""
+    private var writeThread: HandlerThread? = null
+    private var writeHandler: Handler? = null
+
+    private val pending = ConcurrentLinkedQueue<String>()
+
+    private val dateFmt = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+    private val timeFmt = SimpleDateFormat("HH:mm:ss.SSS", Locale.US)
+
+    /**
+     * Start the logger. Safe to call more than once; subsequent calls
+     * are no-ops. `context` is used for its application context only —
+     * do not pass an Activity that will be destroyed soon.
+     *
+     * On success this writes a session-start marker with device
+     * fingerprint (see [writeSessionHeader]) and schedules the
+     * heartbeat. On failure (I/O error, storage unavailable), logs a
+     * warning to Android logcat and remains a no-op — the plugin
+     * still functions, we just lose the file backup.
+     */
+    fun init(context: Context) {
+        if (!started.compareAndSet(false, true)) return
+        val appCtx = context.applicationContext ?: context
+        appContext = appCtx
+        val thread = HandlerThread("XvDiag").apply { start() }
+        writeThread = thread
+        val handler = Handler(thread.looper)
+        writeHandler = handler
+        handler.post {
+            try {
+                pruneOldFiles(appCtx)
+                openTodaysFile(appCtx)
+                writeSessionHeader(appCtx)
+                flushPending()
+                scheduleHeartbeat()
+            } catch (t: Throwable) {
+                // I/O setup failed. Log to Android logcat and keep the
+                // singleton in "started but no writer" state so [event]
+                // silently no-ops rather than crashing the caller.
+                Log.w(TAG, "init failed — file logging disabled", t)
+            }
+        }
+    }
+
+    /**
+     * Record one diagnostic event. Fire-and-forget; safe from any
+     * thread and any lifecycle stage. Never throws.
+     *
+     * The [tag] should match the caller's Android logcat tag (e.g.
+     * `"XvVoicePlant"`) so a `grep TAG` on either the logcat dump or
+     * the file surfaces the same events. Severity is one letter:
+     * `I`, `W`, `E`, or `D` — matches the [Log] class shorthand.
+     */
+    fun event(
+        tag: String,
+        severity: Char = 'I',
+        message: String,
+    ) {
+        if (!started.get()) return
+        val line = formatLine(tag, severity, message)
+        val handler = writeHandler
+        if (handler == null) {
+            // init() invoked but its handler post hasn't landed yet.
+            // Queue for the flushPending pass.
+            pending.offer(line)
+            return
+        }
+        handler.post { writeLine(line) }
+    }
+
+    /**
+     * Force any queued writes to disk. Callers should invoke this on
+     * plugin teardown so a final flush lands before the process may
+     * be reaped. Safe from any thread.
+     */
+    fun flush() {
+        val handler = writeHandler ?: return
+        handler.post {
+            try {
+                writer?.flush()
+            } catch (_: Throwable) {
+            }
+        }
+    }
+
+    /**
+     * Shut down the writer + background thread. After [shutdown] the
+     * next [init] call will re-open cleanly. Safe from any thread.
+     */
+    fun shutdown() {
+        if (!started.compareAndSet(true, false)) return
+        val handler = writeHandler
+        val thread = writeThread
+        writeHandler = null
+        writeThread = null
+        handler?.post {
+            try {
+                writer?.close()
+            } catch (_: Throwable) {
+            }
+            writer = null
+        }
+        thread?.quitSafely()
+    }
+
+    /**
+     * On-demand snapshot of process-observable state. Writes an audio
+     * mode, self-managed phone-account count, and free-memory snapshot
+     * to the log so a "why was PTT flaky right here" question can be
+     * answered without needing an adb attach.
+     *
+     * Uses only APIs that do NOT require `READ_PHONE_STATE` (that
+     * permission is deliberately not requested by XV — see
+     * `PttCellularGate` for the why).
+     */
+    fun stateSnapshot(
+        context: Context,
+        reason: String,
+    ) {
+        if (!started.get()) return
+        try {
+            val am = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
+            val mode =
+                when (am?.mode) {
+                    AudioManager.MODE_IN_CALL -> "IN_CALL"
+                    AudioManager.MODE_IN_COMMUNICATION -> "IN_COMMUNICATION"
+                    AudioManager.MODE_RINGTONE -> "RINGTONE"
+                    AudioManager.MODE_NORMAL -> "NORMAL"
+                    null -> "?"
+                    else -> "mode=${am.mode}"
+                }
+            val rt = Runtime.getRuntime()
+            val freeMb = rt.freeMemory() / (1024 * 1024)
+            val totalMb = rt.totalMemory() / (1024 * 1024)
+            val maxMb = rt.maxMemory() / (1024 * 1024)
+            event(
+                tag = "XvDiag",
+                severity = 'I',
+                message =
+                "snapshot: reason='$reason' audioMode=$mode " +
+                    "vmem=${freeMb}M/${totalMb}M/${maxMb}M",
+            )
+        } catch (t: Throwable) {
+            event(tag = "XvDiag", severity = 'W', message = "snapshot threw: ${t.javaClass.simpleName}")
+        }
+    }
+
+    /** Record a `Throwable` — writes the class name + message on one
+     *  line so common grep patterns still work, then the stack trace
+     *  on continuation lines. Never throws. */
+    fun exception(
+        tag: String,
+        prefix: String,
+        t: Throwable,
+    ) {
+        event(tag = tag, severity = 'E', message = "$prefix — ${t.javaClass.simpleName}: ${t.message}")
+        val sw = StringWriter()
+        t.printStackTrace(PrintWriter(sw))
+        // Split the stack trace across multiple log lines so the
+        // per-line severity prefix stays parseable. Cap at 20 frames
+        // to bound worst-case output size on a runaway loop.
+        sw.toString().lineSequence().take(20).forEach { frame ->
+            event(tag = tag, severity = 'E', message = "  at $frame")
+        }
+    }
+
+    private fun formatLine(
+        tag: String,
+        severity: Char,
+        message: String,
+    ): String = "[${timeFmt.format(Date())}] $tag $severity : $message"
+
+    private fun writeLine(line: String) {
+        val ctx = appContext ?: return
+        try {
+            rotateIfDayChanged(ctx)
+            rotateIfTooLarge(ctx)
+            val w = writer ?: return
+            w.write(line)
+            w.newLine()
+            // Deliberately no per-line flush() — the write buffer +
+            // shutdown flush() are the durability boundary. Per-line
+            // flush would triple I/O cost on burst-PTT sessions.
+        } catch (t: Throwable) {
+            // I/O died mid-session (storage full, permission revoked).
+            // Fall back to logcat and stop trying to write for this
+            // process lifetime. Do NOT throw — callers must be safe
+            // to fire-and-forget.
+            Log.w(TAG, "writeLine failed — file logging paused", t)
+            try {
+                writer?.close()
+            } catch (_: Throwable) {
+            }
+            writer = null
+        }
+    }
+
+    private fun flushPending() {
+        while (true) {
+            val line = pending.poll() ?: break
+            writeLine(line)
+        }
+    }
+
+    private fun openTodaysFile(context: Context) {
+        val dir = ensureDir(context) ?: return
+        val today = dateFmt.format(Date())
+        currentDay = today
+        val file = File(dir, "$FILE_PREFIX$today$FILE_SUFFIX")
+        currentFile = file
+        writer =
+            try {
+                // FileWriter(file, true) → append mode
+                BufferedWriter(FileWriter(file, true))
+            } catch (t: Throwable) {
+                Log.w(TAG, "cannot open $file for append", t)
+                null
+            }
+    }
+
+    private fun rotateIfDayChanged(context: Context) {
+        val today = dateFmt.format(Date())
+        if (today == currentDay) return
+        try {
+            writer?.close()
+        } catch (_: Throwable) {
+        }
+        writer = null
+        openTodaysFile(context)
+    }
+
+    private fun rotateIfTooLarge(context: Context) {
+        val f = currentFile ?: return
+        if (f.length() < MAX_FILE_BYTES) return
+        try {
+            writer?.close()
+        } catch (_: Throwable) {
+        }
+        writer = null
+        val dir = f.parentFile ?: return
+        var idx = 1
+        while (File(dir, "${f.nameWithoutExtension}.$idx$FILE_SUFFIX").exists()) idx++
+        f.renameTo(File(dir, "${f.nameWithoutExtension}.$idx$FILE_SUFFIX"))
+        openTodaysFile(context)
+    }
+
+    private fun pruneOldFiles(context: Context) {
+        val dir = ensureDir(context) ?: return
+        val cutoff = System.currentTimeMillis() - RETENTION_DAYS * 24L * 60L * 60L * 1000L
+        dir.listFiles { f -> f.isFile && f.name.startsWith(FILE_PREFIX) && f.name.endsWith(FILE_SUFFIX) }
+            ?.forEach { f ->
+                if (f.lastModified() < cutoff) {
+                    try {
+                        f.delete()
+                    } catch (_: Throwable) {
+                    }
+                }
+            }
+    }
+
+    private fun ensureDir(context: Context): File? {
+        val base = context.getExternalFilesDir(DIR_NAME) ?: return null
+        if (!base.exists()) base.mkdirs()
+        return base
+    }
+
+    private fun writeSessionHeader(context: Context) {
+        val ctx = context
+        val versionName =
+            try {
+                val pi = ctx.packageManager.getPackageInfo(ctx.packageName, 0)
+                pi.versionName ?: "?"
+            } catch (_: Throwable) {
+                "?"
+            }
+        val versionCode =
+            try {
+                val pi = ctx.packageManager.getPackageInfo(ctx.packageName, 0)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    pi.longVersionCode.toString()
+                } else {
+                    @Suppress("DEPRECATION")
+                    pi.versionCode.toString()
+                }
+            } catch (_: Throwable) {
+                "?"
+            }
+        val pid = android.os.Process.myPid()
+        val uid = android.os.Process.myUid()
+        event(
+            tag = "XvDiag",
+            severity = 'I',
+            message = "======== SESSION START ========",
+        )
+        event(
+            tag = "XvDiag",
+            severity = 'I',
+            message =
+            "session: pkg=${ctx.packageName} v=$versionName vc=$versionCode " +
+                "pid=$pid uid=$uid",
+        )
+        event(
+            tag = "XvDiag",
+            severity = 'I',
+            message =
+            "device: brand=${Build.BRAND} model=${Build.MODEL} " +
+                "product=${Build.PRODUCT} device=${Build.DEVICE}",
+        )
+        event(
+            tag = "XvDiag",
+            severity = 'I',
+            message =
+            "os: release=${Build.VERSION.RELEASE} sdk=${Build.VERSION.SDK_INT} " +
+                "build=${Build.DISPLAY}",
+        )
+    }
+
+    private fun scheduleHeartbeat() {
+        val handler = writeHandler ?: return
+        val runnable =
+            object : Runnable {
+                override fun run() {
+                    val ctx = appContext
+                    if (ctx == null) return
+                    stateSnapshot(ctx, "heartbeat")
+                    // Reschedule against the same handler so a shutdown()
+                    // that quits the looper naturally stops the chain.
+                    writeHandler?.postDelayed(this, HEARTBEAT_INTERVAL_MS)
+                }
+            }
+        handler.postDelayed(runnable, HEARTBEAT_INTERVAL_MS)
+    }
+}

--- a/app/src/main/java/com/atakmap/android/xv/util/DiagnosticLogger.kt
+++ b/app/src/main/java/com/atakmap/android/xv/util/DiagnosticLogger.kt
@@ -282,12 +282,22 @@ object DiagnosticLogger {
         event(tag = tag, severity = 'E', message = "$prefix — ${t.javaClass.simpleName}: ${t.message}")
         val sw = StringWriter()
         t.printStackTrace(PrintWriter(sw))
-        // Split the stack trace across multiple log lines so the
-        // per-line severity prefix stays parseable. Cap at 20 frames
-        // to bound worst-case output size on a runaway loop.
-        sw.toString().lineSequence().take(20).forEach { frame ->
-            event(tag = tag, severity = 'E', message = "  at $frame")
-        }
+        // Split the stack trace across multiple log lines so the per-line
+        // severity prefix stays parseable. printStackTrace() emits an
+        // exception-header first line (already covered by the event above)
+        // followed by frames that already begin with "\tat …" — so drop
+        // the header and trim the leading tab rather than re-prefixing
+        // with "at " (which produced garbled "  at \tat …" output). Cap at
+        // 20 frames to bound worst-case size on a runaway loop.
+        sw.toString()
+            .lineSequence()
+            .drop(1)
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .take(20)
+            .forEach { frame ->
+                event(tag = tag, severity = 'E', message = "  $frame")
+            }
     }
 
     private fun formatLine(

--- a/app/src/main/java/com/atakmap/android/xv/util/DiagnosticLogger.kt
+++ b/app/src/main/java/com/atakmap/android/xv/util/DiagnosticLogger.kt
@@ -108,6 +108,13 @@ object DiagnosticLogger {
      */
     private const val HEARTBEAT_INTERVAL_MS: Long = 60_000L
 
+    /**
+     * Minimum wall-clock between BufferedWriter flushes in [writeLine].
+     * Coalesces burst-PTT write volume into ~one flush/second while
+     * bounding data loss on a process kill to ~1 s. See [writeLine].
+     */
+    private const val FLUSH_INTERVAL_MS: Long = 1_000L
+
     private val started = AtomicBoolean(false)
     private var appContext: Context? = null
     private var writer: BufferedWriter? = null
@@ -117,6 +124,10 @@ object DiagnosticLogger {
     private var writeHandler: Handler? = null
 
     private val pending = ConcurrentLinkedQueue<String>()
+
+    // Wall-clock of the last BufferedWriter flush. See writeLine() for the
+    // throttled-flush rationale (2026-07-13 zero-byte-log incident).
+    private var lastFlushMs: Long = 0L
 
     private val dateFmt = SimpleDateFormat("yyyy-MM-dd", Locale.US)
     private val timeFmt = SimpleDateFormat("HH:mm:ss.SSS", Locale.US)
@@ -292,9 +303,20 @@ object DiagnosticLogger {
             val w = writer ?: return
             w.write(line)
             w.newLine()
-            // Deliberately no per-line flush() — the write buffer +
-            // shutdown flush() are the durability boundary. Per-line
-            // flush would triple I/O cost on burst-PTT sessions.
+            // Time-throttled flush. Field incident 2026-07-13: a fresh
+            // install ran for ~2 h and the pulled log was 0 bytes — the
+            // BufferedWriter's 8 KiB buffer never filled at idle
+            // heartbeat volume, and a long-running service never reaches
+            // the shutdown()/flush() durability boundary, so a process
+            // kill lost the entire session. Flushing at most once per
+            // FLUSH_INTERVAL_MS coalesces burst-PTT writes (100+/s) into
+            // one flush per second while bounding worst-case data loss on
+            // a kill to ~1 s — the whole point of a post-mortem log.
+            val now = System.currentTimeMillis()
+            if (now - lastFlushMs >= FLUSH_INTERVAL_MS) {
+                w.flush()
+                lastFlushMs = now
+            }
         } catch (t: Throwable) {
             // I/O died mid-session (storage full, permission revoked).
             // Fall back to logcat and stop trying to write for this

--- a/app/src/main/java/com/atakmap/android/xv/util/DiagnosticLogger.kt
+++ b/app/src/main/java/com/atakmap/android/xv/util/DiagnosticLogger.kt
@@ -251,6 +251,7 @@ object DiagnosticLogger {
                     AudioManager.MODE_IN_COMMUNICATION -> "IN_COMMUNICATION"
                     AudioManager.MODE_RINGTONE -> "RINGTONE"
                     AudioManager.MODE_NORMAL -> "NORMAL"
+                    AudioManager.MODE_CALL_SCREENING -> "CALL_SCREENING"
                     null -> "?"
                     else -> "mode=${am.mode}"
                 }

--- a/app/src/test/java/com/atakmap/android/xv/aina/AinaProtocolProbeTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/aina/AinaProtocolProbeTest.kt
@@ -209,7 +209,7 @@ class AinaProtocolProbeTest {
 
     private fun mockBondedDevice(
         mac: String,
-        name: String = "APTT316782",
+        name: String = "APTT000000",
     ): BluetoothDevice {
         val dev = mockk<BluetoothDevice>(relaxed = true)
         every { dev.address } returns mac

--- a/app/src/test/java/com/atakmap/android/xv/audio/TxControllerColdScoWarmupTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/audio/TxControllerColdScoWarmupTest.kt
@@ -272,4 +272,46 @@ class TxControllerColdScoWarmupTest {
             TxRoute.entries.map { it.name },
         )
     }
+
+    // ============================================================
+    // Part 4 — PRIMING gate selection keys off COLD SCO, not "SCO up"
+    //
+    // 2026-07-13 field repro: SCO was held WARM across a full session
+    // (the cool-down tail working as intended), yet every burst still
+    // used the 30-frame (~300 ms) cold gate because the selection was
+    // tied to "SCO connected." With bursty keying the operator released
+    // before TX started and ZERO frames went out. The gates must be
+    // slow ONLY for a cold acquire; warm-SCO and non-SCO get fast gates.
+    // ============================================================
+
+    @Test
+    fun `cold-SCO burst uses the ramp-tolerant gates`() {
+        assertEquals(30, TxController.primingMinFramesToConfirmAlive(coldSco = true))
+        assertEquals(200, TxController.primingRmsThreshold(coldSco = true))
+        assertEquals(1500L, TxController.primingTimeoutMs(coldSco = true))
+    }
+
+    @Test
+    fun `warm-SCO or non-SCO burst uses the fast gates`() {
+        // The regression guard: coldSco=false MUST select the fast
+        // gates so a warm-held-SCO key reaches the tone in ~50 ms
+        // (5 frames), not ~300 ms.
+        assertEquals(5, TxController.primingMinFramesToConfirmAlive(coldSco = false))
+        assertEquals(5, TxController.primingRmsThreshold(coldSco = false))
+        assertEquals(500L, TxController.primingTimeoutMs(coldSco = false))
+    }
+
+    @Test
+    fun `warm gates are strictly faster to confirm than cold gates`() {
+        // Intent invariant independent of the exact tuned values: a warm
+        // burst never waits longer than a cold one to declare mic-alive.
+        assertTrue(
+            TxController.primingMinFramesToConfirmAlive(coldSco = false) <
+                TxController.primingMinFramesToConfirmAlive(coldSco = true),
+        )
+        assertTrue(
+            TxController.primingTimeoutMs(coldSco = false) <
+                TxController.primingTimeoutMs(coldSco = true),
+        )
+    }
 }

--- a/app/src/test/java/com/atakmap/android/xv/audio/TxControllerScreechTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/audio/TxControllerScreechTest.kt
@@ -12,27 +12,21 @@ import org.junit.Test
  *
  * Field complaint: on the first TX after install — when AINA SCO hadn't
  * yet bound — the operator's first transmission produced loud screech
- * on the receiving peer. Root cause traced through logcat:
+ * on the receiving peer. Root cause: AudioRecord read from a not-yet-
+ * routed BT SCO source and returned stuck `-1`-fill frames (rms=1);
+ * those garbage frames reached Concentus' Opus encoder and tripped an
+ * AssertionError inside `Resampler.silk_resampler`, corrupting the SILK
+ * state so every subsequent real-speech frame encoded to garbage on the
+ * wire = screech on the peer.
  *
- *   1. Mic pre-arm fires before SCO is bound. AudioRecord reads from a
- *      not-yet-routed source and returns stuck `-1`-fill frames
- *      (rms=1, samples=[-1,-1,-1,-1,-1]).
- *   2. During state=TPT (past the 80ms skip), those garbage frames
- *      land in the TPT-overlap ring buffer.
- *   3. On TX start, the ring flushes into Concentus' Opus encoder. The
- *      first encode trips an AssertionError inside
- *      `Resampler.silk_resampler` on the pathological -1-fill input.
- *   4. The throw leaves the encoder's SILK state corrupt. Every
- *      subsequent live frame from real speech encodes against the
- *      corrupted state — garbage on the wire = screech on the peer.
- *
- * Two-line defense in TxController:
- *   - Gate the ring-buffer append on rms(frame) >= RING_BUFFER_MIN_RMS.
- *   - On encode failure, close + recreate the encoder via the factory
- *     so the next frame encodes against fresh state.
- *
- * These tests pin the contract of both lines so a future refactor of
- * the audio path can't silently re-introduce the regression.
+ * The original TPT-overlap ring buffer (and its RMS append gate) that
+ * carried those garbage frames into the encoder was removed outright
+ * 2026-05-21 — see TxController.onPcmFrame. The surviving defenses
+ * pinned here are:
+ *   - rms(): the pure amplitude helper, still used by the PRIMING
+ *     mic-alive gate (Part 1).
+ *   - Encoder reset on encode failure: close + recreate via the factory
+ *     so the next frame encodes against fresh state (Part 3).
  */
 class TxControllerScreechTest {
     // ============================================================
@@ -81,51 +75,6 @@ class TxControllerScreechTest {
         val maxAmp = ShortArray(480) { Short.MAX_VALUE }
         val r = TxController.rms(maxAmp)
         assertEquals(Short.MAX_VALUE.toInt(), r)
-    }
-
-    // ============================================================
-    // Part 2 — RMS threshold (RING_BUFFER_MIN_RMS) contract
-    // ============================================================
-
-    @Test
-    fun `threshold sits above the garbage rms but below speech rms`() {
-        val garbageRms = TxController.rms(ShortArray(480) { -1 })
-        val silenceRms = TxController.rms(ShortArray(480) { 0 })
-        // Both pathological / silent cases must fail the gate.
-        assertTrue(
-            "garbage rms=$garbageRms must be below threshold=${TxController.RING_BUFFER_MIN_RMS}",
-            garbageRms < TxController.RING_BUFFER_MIN_RMS,
-        )
-        assertTrue(
-            "silence rms=$silenceRms must be below threshold=${TxController.RING_BUFFER_MIN_RMS}",
-            silenceRms < TxController.RING_BUFFER_MIN_RMS,
-        )
-        // Real speech must pass.
-        val speech = ShortArray(480) { i -> (10_000.0 * kotlin.math.sin(i * 0.2)).toInt().toShort() }
-        val speechRms = TxController.rms(speech)
-        assertTrue(
-            "speech rms=$speechRms must be above threshold=${TxController.RING_BUFFER_MIN_RMS}",
-            speechRms >= TxController.RING_BUFFER_MIN_RMS,
-        )
-    }
-
-    @Test
-    fun `mic self-noise (rms ~5-20 in a quiet room) is correctly rejected`() {
-        // Real mic self-noise on a quiet AINA / built-in mic sits in
-        // the rms 5-20 range — well below speech but above the
-        // garbage pattern. The gate must still reject it because
-        // self-noise has no useful audio content for the operator
-        // and only inflates the buffered TPT-overlap window with
-        // pointless frames.
-        val selfNoise = ShortArray(480) { kotlin.random.Random.nextInt(-15, 16).toShort() }
-        val r = TxController.rms(selfNoise)
-        // self-noise rms is bounded above by 15 (uniform [-15,15] →
-        // rms ~= 8.7), well below the 50 threshold.
-        assertTrue("self-noise rms=$r should be < 30", r < 30)
-        assertTrue(
-            "self-noise rms=$r must be rejected by threshold=${TxController.RING_BUFFER_MIN_RMS}",
-            r < TxController.RING_BUFFER_MIN_RMS,
-        )
     }
 
     // ============================================================

--- a/app/src/test/java/com/atakmap/android/xv/audio/TxControllerStateMachineTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/audio/TxControllerStateMachineTest.kt
@@ -22,9 +22,9 @@ import org.robolectric.RobolectricTestRunner
  *
  * The seams are the minimum needed to exercise:
  *
- *   - The TPT-overlap ring buffer's RMS gate (the 2026-05-19 screech
- *     fix) end-to-end through `onPcmFrame`, not just the helper in
- *     [TxControllerScreechTest].
+ *   - The state=TPT frame-drop contract (the TPT-overlap ring was
+ *     removed 2026-05-21 after it corrupted the Opus encoder on
+ *     cold-SCO cadence) end-to-end through `onPcmFrame`.
  *   - The encoder-reset path on encode failure, end-to-end through
  *     `encodeAndQueueFrame` in state=TRANSMITTING.
  *   - The frame-drop branches in IDLE / PRIMING / ACQUIRING_SCO.
@@ -61,72 +61,31 @@ class TxControllerStateMachineTest {
         )
 
     // ============================================================
-    // RMS gate in state=TPT — the central screech fix.
+    // Frame handling in state=TPT — the TPT-overlap ring was removed
+    // 2026-05-21 (it corrupted the Opus encoder on cold-SCO cadence).
+    // Contract: frames captured while the permit tone plays are dropped
+    // — nothing is encoded and the state machine does not advance.
     // ============================================================
 
     @Test
-    fun `state=TPT past skip window — garbage frame is rejected by RMS gate`() {
+    fun `state=TPT — mic frames are dropped, not encoded (TPT-overlap ring removed 2026-05-21)`() {
         val tx = buildController()
-        // Past the TPT_RING_SKIP_MS (80ms) window so the gate is active.
-        tx.setStateForTest(TxController.State.TPT, tptEnteredAtMs = System.currentTimeMillis() - 200L)
-
-        val garbage = ShortArray(480) { -1 } // rms=1, the field-reported pattern
-        tx.onPcmFrameForTest(garbage)
-
-        assertEquals(
-            "garbage frame must not enter pre-TX ring",
-            0,
-            tx.preTxBufferSizeForTest(),
-        )
-    }
-
-    @Test
-    fun `state=TPT past skip window — frames are dropped (ring buffer disabled 2026-05-21)`() {
-        // The TPT-overlap ring buffer was disabled outright after a
-        // recurring cold-SCO screech bug — flushing those frames into
-        // Opus corrupts the encoder regardless of RMS gating. Pinned
-        // here as the new contract: state=TPT frames are dropped, no
-        // ring buffer accumulates. See the long comment in
-        // TxController.onPcmFrame for the rationale and the re-enable
-        // checklist.
-        val tx = buildController()
-        tx.setStateForTest(TxController.State.TPT, tptEnteredAtMs = System.currentTimeMillis() - 200L)
-
-        val speech = ShortArray(480) { i -> (10_000.0 * kotlin.math.sin(i * 0.2)).toInt().toShort() }
-        tx.onPcmFrameForTest(speech)
-
-        assertEquals(
-            "TPT frames must be dropped, not buffered",
-            0,
-            tx.preTxBufferSizeForTest(),
-        )
-    }
-
-    @Test
-    fun `state=TPT during skip window — even speech is dropped (TPT bleed defense)`() {
-        val tx = buildController()
-        // tptEnteredAtMs = now → elapsed = 0, well inside the 80ms skip.
         tx.setStateForTest(TxController.State.TPT, tptEnteredAtMs = System.currentTimeMillis())
 
         val speech = ShortArray(480) { i -> (10_000.0 * kotlin.math.sin(i * 0.2)).toInt().toShort() }
-        tx.onPcmFrameForTest(speech)
-
-        assertEquals(
-            "frame within skip window must be dropped, even if loud",
-            0,
-            tx.preTxBufferSizeForTest(),
-        )
-    }
-
-    @Test
-    fun `state=TPT — ring buffer stays empty no matter how many frames arrive`() {
-        // Companion to the disabled-buffer change. Even under sustained
-        // TPT-state frame delivery, the buffer remains empty.
-        val tx = buildController()
-        tx.setStateForTest(TxController.State.TPT, tptEnteredAtMs = System.currentTimeMillis() - 200L)
-        val speech = ShortArray(480) { 1_000 }
+        val garbage = ShortArray(480) { -1 } // rms=1, the field-reported pattern
         repeat(15) { tx.onPcmFrameForTest(speech) }
-        assertEquals(0, tx.preTxBufferSizeForTest())
+        tx.onPcmFrameForTest(garbage)
+
+        assertTrue(
+            "no opus frames may be emitted from state=TPT",
+            sentOpusFrames.isEmpty(),
+        )
+        assertEquals(
+            "frames in state=TPT must not advance the machine — only onTptComplete does",
+            TxController.State.TPT,
+            tx.currentStateForTest(),
+        )
     }
 
     // ============================================================
@@ -219,7 +178,6 @@ class TxControllerStateMachineTest {
 
         tx.onPcmFrameForTest(ShortArray(480) { 1_000 })
 
-        assertEquals(0, tx.preTxBufferSizeForTest())
         assertEquals(0, sentOpusFrames.size)
         assertNull("encoder stays unallocated", tx.currentEncoderForTest())
     }
@@ -231,7 +189,6 @@ class TxControllerStateMachineTest {
 
         tx.onPcmFrameForTest(ShortArray(480) { 1_000 })
 
-        assertEquals(0, tx.preTxBufferSizeForTest())
         assertEquals(0, sentOpusFrames.size)
     }
 

--- a/app/src/test/java/com/atakmap/android/xv/service/PttCellularGateTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/service/PttCellularGateTest.kt
@@ -697,4 +697,67 @@ class PttCellularGateTest {
             ),
         )
     }
+
+    // ============================================================
+    // resolveGateWithOwnSco — suppress the false-positive block when
+    // XV's own audio plant is holding the SCO link (the comm-mode the
+    // gate detected is ours, not an external call). 2026-07-13 repro:
+    // screensaver-wake re-acquired SCO_HOT ~39 s after XV's own call
+    // ended, and the gate misread MODE_IN_COMMUNICATION as external.
+    // ============================================================
+
+    @Test
+    fun `own-SCO hold flips a cellular-call block to ALLOW`() {
+        assertEquals(
+            PttGate.ALLOW,
+            resolveGateWithOwnSco(PttGate.BLOCK_CELLULAR_CALL, xvHoldsSco = true),
+        )
+    }
+
+    @Test
+    fun `no SCO hold leaves a cellular-call block intact (real external call)`() {
+        assertEquals(
+            PttGate.BLOCK_CELLULAR_CALL,
+            resolveGateWithOwnSco(PttGate.BLOCK_CELLULAR_CALL, xvHoldsSco = false),
+        )
+    }
+
+    @Test
+    fun `ringing is never suppressed even when XV holds SCO`() {
+        // MODE_RINGTONE is unambiguously an incoming external call; XV's
+        // plant never drives it. Holding SCO must NOT unlock PTT here.
+        assertEquals(
+            PttGate.BLOCK_CELLULAR_RINGING,
+            resolveGateWithOwnSco(PttGate.BLOCK_CELLULAR_RINGING, xvHoldsSco = true),
+        )
+    }
+
+    @Test
+    fun `ALLOW stays ALLOW regardless of SCO hold`() {
+        assertEquals(
+            PttGate.ALLOW,
+            resolveGateWithOwnSco(PttGate.ALLOW, xvHoldsSco = true),
+        )
+        assertEquals(
+            PttGate.ALLOW,
+            resolveGateWithOwnSco(PttGate.ALLOW, xvHoldsSco = false),
+        )
+    }
+
+    @Test
+    fun `full chain — VoLTE-style block during XV SCO_HOT resolves to ALLOW`() {
+        // End-to-end: no own Telecom call (grace expired), mode reads
+        // IN_COMMUNICATION (XV's SCO_HOT hold), operator presses PTT.
+        // Raw gate would BLOCK; the own-SCO override rescues it.
+        val rawGate =
+            shouldGateForCellularCall(
+                cellularCallStateFromAudioMode(
+                    audioMode = AudioManager.MODE_IN_COMMUNICATION,
+                    xvHasActiveTelecomCall = false,
+                ),
+                PttSource.ON_SCREEN,
+            )
+        assertEquals(PttGate.BLOCK_CELLULAR_CALL, rawGate)
+        assertEquals(PttGate.ALLOW, resolveGateWithOwnSco(rawGate, xvHoldsSco = true))
+    }
 }

--- a/app/src/test/java/com/atakmap/android/xv/service/TelecomGhostPurgeDecisionTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/service/TelecomGhostPurgeDecisionTest.kt
@@ -1,0 +1,152 @@
+package com.atakmap.android.xv.service
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-function coverage for the pre-[android.telecom.TelecomManager.placeCall]
+ * ghost-purge guard extracted from [XvVoiceService.shouldGhostPurgeBeforePlaceCall].
+ *
+ * Field bug (issue #66 item #1, ship-blocking): XV's
+ * [com.atakmap.android.xv.telecom.ActiveCallRegistry] (a Kotlin object
+ * in the plugin service process) can desync from Android Telecom's
+ * internal `mCalls` ledger. When it does:
+ *  - `ActiveCallRegistry.activeConnection() == null` — our reuse check
+ *    in [XvVoiceService.placeTelecomCallInternal] concludes there is no
+ *    active call.
+ *  - We call [android.telecom.TelecomManager.placeCall].
+ *  - Android Telecom sees the new call attempt against the same self-
+ *    managed PhoneAccount that ALREADY has a ghost `TC@N` in its
+ *    `mCalls` ledger.
+ *  - The "Hang up XV to place a new call" system arbitration fires.
+ *  - Field operators experience: PTT press → no TX → toast → confusion.
+ *
+ * Observed 2026-07-11 during TPP validation on Pixel 9 Pro (API 35)
+ * and Sonim XP9900 with `dumpsys telecom` showing calls stacked TC@86
+ * through TC@95 with the last still ACTIVE 138+ s past the 8 s
+ * [XvVoiceService.TELECOM_END_DEBOUNCE_MS] teardown timer.
+ *
+ * We can not consult Telecom directly ([android.telecom.TelecomManager.isInSelfManagedCall]
+ * / [android.telecom.TelecomManager.isInCall] require READ_PHONE_STATE
+ * — the abandoned `copilot/fix-telecom-arbitration-deadlock` branch
+ * proved this route dead), so the decision function approximates the
+ * "we might have a ghost" signal from information XV already owns:
+ * (1) no live registry entry AND (2) an own call has been unregistered
+ * in this process before. Both conditions must hold; either alone is
+ * insufficient.
+ *
+ * The remediation itself (an unregister → re-register cycle on
+ * [com.atakmap.android.xv.telecom.XvPhoneAccount]) is tested only for
+ * its side effect on the boolean gate here — the actual
+ * TelecomManager interaction requires Robolectric or an instrumented
+ * device to observe.
+ */
+class TelecomGhostPurgeDecisionTest {
+    /**
+     * Fresh process, no call ever placed. This is the very first PTT
+     * press after plugin load — [XvVoiceService.purgeGhostSelfManagedCallsOnFreshProcess]
+     * already ran in onCreate to cover any cross-process ghost, so the
+     * per-placeCall check MUST short-circuit false and skip the extra
+     * roundtrip. Paying it here would tack a few hundred ms of latency
+     * onto the operator's very first press for no benefit.
+     */
+    @Test
+    fun `fresh process, no active call, no prior call — do not purge`() {
+        val decision =
+            XvVoiceService.shouldGhostPurgeBeforePlaceCall(
+                hasActiveConnection = false,
+                hasHadOwnCallInProcess = false,
+            )
+        assertFalse("fresh process with no history must not purge on first placeCall", decision)
+    }
+
+    /**
+     * The exact bug scenario: a call was placed and ended in this
+     * process (registry unregistered, `lastOwnCallEndedAtMs` stamped
+     * non-zero) and now a fresh placeCall is arriving. Registry says
+     * no live connection, but Telecom may still hold a ghost TC@N
+     * under our PhoneAccount. This is the case the guard MUST fire on.
+     */
+    @Test
+    fun `no active call but process has ended one before — purge`() {
+        val decision =
+            XvVoiceService.shouldGhostPurgeBeforePlaceCall(
+                hasActiveConnection = false,
+                hasHadOwnCallInProcess = true,
+            )
+        assertTrue(
+            "field-bug scenario: registry empty + prior teardown must trigger ghost-purge",
+            decision,
+        )
+    }
+
+    /**
+     * A live connection is already in the registry. This is the reuse
+     * path — [XvVoiceService.placeTelecomCallInternal] returns early
+     * without reaching the ghost-purge check, so the pure decision
+     * function must also return false when the caller passes
+     * `hasActiveConnection = true`. Belt-and-suspenders against a
+     * future caller who forgets the early-return.
+     */
+    @Test
+    fun `active call in registry — never purge`() {
+        val withPriorTeardown =
+            XvVoiceService.shouldGhostPurgeBeforePlaceCall(
+                hasActiveConnection = true,
+                hasHadOwnCallInProcess = true,
+            )
+        assertFalse(
+            "active connection is the reuse path; never purge underneath a live call",
+            withPriorTeardown,
+        )
+        val noPriorTeardown =
+            XvVoiceService.shouldGhostPurgeBeforePlaceCall(
+                hasActiveConnection = true,
+                hasHadOwnCallInProcess = false,
+            )
+        assertFalse(
+            "active connection dominates over the prior-teardown flag either way",
+            noPriorTeardown,
+        )
+    }
+
+    /**
+     * Documentation invariant: the two inputs are AND-gated, not
+     * OR-gated. `hasHadOwnCallInProcess == false` on its own — even
+     * with a null active connection — MUST NOT trigger a purge. That
+     * corresponds to the fresh-process first-press case above, but is
+     * broken out separately as a truth-table pin.
+     */
+    @Test
+    fun `truth table — only both-conditions-true triggers purge`() {
+        // (F, F) — fresh process, first press. No purge.
+        assertFalse(
+            XvVoiceService.shouldGhostPurgeBeforePlaceCall(
+                hasActiveConnection = false,
+                hasHadOwnCallInProcess = false,
+            ),
+        )
+        // (F, T) — the bug case. Purge.
+        assertTrue(
+            XvVoiceService.shouldGhostPurgeBeforePlaceCall(
+                hasActiveConnection = false,
+                hasHadOwnCallInProcess = true,
+            ),
+        )
+        // (T, F) — reuse path with no prior. No purge.
+        assertFalse(
+            XvVoiceService.shouldGhostPurgeBeforePlaceCall(
+                hasActiveConnection = true,
+                hasHadOwnCallInProcess = false,
+            ),
+        )
+        // (T, T) — reuse path after a prior. No purge (reuse dominates).
+        assertFalse(
+            XvVoiceService.shouldGhostPurgeBeforePlaceCall(
+                hasActiveConnection = true,
+                hasHadOwnCallInProcess = true,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/atakmap/android/xv/service/XvPlacementDecisionTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/service/XvPlacementDecisionTest.kt
@@ -1,0 +1,92 @@
+package com.atakmap.android.xv.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-function coverage for the Telecom double-place race guard
+ * extracted from [XvVoiceService.decidePlacement].
+ *
+ * Bug: `TelecomManager.placeCall()` is asynchronous — the [XvConnection]
+ * only lands in
+ * [com.atakmap.android.xv.telecom.ActiveCallRegistry] later, when
+ * Telecom calls `onCreateOutgoingConnection`. The old reuse guard only
+ * checked `activeConnection() != null`, so a second PTT-down inside that
+ * registration gap saw no connection and issued a SECOND placeCall,
+ * which Telecom rejects with "there is another call connecting."
+ *
+ * The fix tracks a synchronous [XvVoiceService] `telecomState`
+ * (IDLE / ACTIVE_TX_RX / TAIL_WARM) that flips to active the instant we
+ * commit to placing — BEFORE the async placeCall completes. This pure
+ * function encodes the resulting decision from two synchronous signals:
+ * whether the registry holds a live connection, and whether that state
+ * says a call is active/warming.
+ */
+class XvPlacementDecisionTest {
+    /**
+     * IDLE lifecycle, no live connection — the only case that warrants a
+     * fresh placeCall.
+     */
+    @Test
+    fun `no connection and not warm-or-active — PLACE`() {
+        assertEquals(
+            XvVoiceService.PlaceDecision.PLACE,
+            XvVoiceService.decidePlacement(hasActiveConnection = false, warmOrActive = false),
+        )
+    }
+
+    /**
+     * The race case: telecomState is ACTIVE_TX_RX/TAIL_WARM (our first
+     * placeCall committed) but the connection has not registered yet.
+     * A second press MUST NOT place again — it reuses the in-flight one.
+     */
+    @Test
+    fun `no connection but warm-or-active — REUSE_IN_FLIGHT (the race fix)`() {
+        assertEquals(
+            XvVoiceService.PlaceDecision.REUSE_IN_FLIGHT,
+            XvVoiceService.decidePlacement(hasActiveConnection = false, warmOrActive = true),
+        )
+    }
+
+    /**
+     * A live connection always wins — placing over a live self-managed
+     * call is exactly what Telecom rejects — regardless of the state flag.
+     */
+    @Test
+    fun `live connection always reuses, regardless of state flag`() {
+        assertEquals(
+            XvVoiceService.PlaceDecision.REUSE_ACTIVE,
+            XvVoiceService.decidePlacement(hasActiveConnection = true, warmOrActive = true),
+        )
+        assertEquals(
+            "a registered connection with a stale-IDLE flag must still reuse, never place",
+            XvVoiceService.PlaceDecision.REUSE_ACTIVE,
+            XvVoiceService.decidePlacement(hasActiveConnection = true, warmOrActive = false),
+        )
+    }
+
+    /**
+     * Full truth table pin so a future refactor can't silently let the
+     * "no connection but warming" case fall through to PLACE (which is
+     * the collision).
+     */
+    @Test
+    fun `truth table`() {
+        assertEquals(
+            XvVoiceService.PlaceDecision.PLACE,
+            XvVoiceService.decidePlacement(hasActiveConnection = false, warmOrActive = false),
+        )
+        assertEquals(
+            XvVoiceService.PlaceDecision.REUSE_IN_FLIGHT,
+            XvVoiceService.decidePlacement(hasActiveConnection = false, warmOrActive = true),
+        )
+        assertEquals(
+            XvVoiceService.PlaceDecision.REUSE_ACTIVE,
+            XvVoiceService.decidePlacement(hasActiveConnection = true, warmOrActive = false),
+        )
+        assertEquals(
+            XvVoiceService.PlaceDecision.REUSE_ACTIVE,
+            XvVoiceService.decidePlacement(hasActiveConnection = true, warmOrActive = true),
+        )
+    }
+}

--- a/app/src/test/java/com/atakmap/android/xv/telecom/ActiveCallRegistryGraceTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/telecom/ActiveCallRegistryGraceTest.kt
@@ -159,4 +159,46 @@ class ActiveCallRegistryGraceTest {
         // "why is this still blocked?" threshold.
         assertEquals(3_000L, ActiveCallRegistry.RECENT_OWN_CALL_GRACE_MS)
     }
+
+    // ============================================================
+    // hasHadOwnCallInProcess — signal for the ghost-purge guard
+    // ============================================================
+
+    @Test
+    fun `hasHadOwnCallInProcess is false on fresh sentinel-zero state`() {
+        // The @Before hook resets the timestamp to zero — matching the
+        // state of the singleton on a fresh service-process load
+        // (Kotlin object initializes to zero). The
+        // XvVoiceService.shouldGhostPurgeBeforePlaceCall guard relies
+        // on this reader to distinguish "first PTT ever" from "we've
+        // already placed and ended a call" — the first case must NOT
+        // pay the extra Telecom roundtrip.
+        assertFalse(ActiveCallRegistry.hasHadOwnCallInProcess())
+    }
+
+    @Test
+    fun `hasHadOwnCallInProcess is true after a teardown timestamp is stamped`() {
+        // Any non-zero stamp counts — the exact value is irrelevant to
+        // the boolean signal. Ordering: this is what
+        // ActiveCallRegistry.unregister() does synchronously the
+        // moment the last own call teardown lands (via
+        // SystemClock.elapsedRealtime()).
+        ActiveCallRegistry.setLastOwnCallEndedAtMsForTest(1L)
+        assertTrue(ActiveCallRegistry.hasHadOwnCallInProcess())
+    }
+
+    @Test
+    fun `hasHadOwnCallInProcess flips back to false only via explicit reset`() {
+        // The stamp is not zeroed on re-register — a subsequent call
+        // going ACTIVE does not clear the "has had one before" flag.
+        // The ghost-purge guard depends on the flag NOT resetting when
+        // a fresh call comes up; otherwise a rapid PTT cycle could see
+        // the signal drop and lose its protection between calls.
+        ActiveCallRegistry.setLastOwnCallEndedAtMsForTest(2_000L)
+        assertTrue(ActiveCallRegistry.hasHadOwnCallInProcess())
+        // The only way back to false is an explicit test reset (or a
+        // fresh process, which reinitializes the object).
+        ActiveCallRegistry.setLastOwnCallEndedAtMsForTest(0L)
+        assertFalse(ActiveCallRegistry.hasHadOwnCallInProcess())
+    }
 }

--- a/app/src/test/java/com/atakmap/android/xv/telecom/XvCallBridgeTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/telecom/XvCallBridgeTest.kt
@@ -1,0 +1,65 @@
+package com.atakmap.android.xv.telecom
+
+import com.atakmap.android.xv.service.IXvVoice
+import com.atakmap.android.xv.service.XvVoiceClient
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+
+/**
+ * Regression coverage for the XvCallBridge dead-flag fix.
+ *
+ * Previously the bridge carried a plugin-side `callActive` flag that was
+ * only ever set true by a `startChannelCall` proxy that nothing called.
+ * As a result `callActive` was always false, and `endChannelCall()`'s
+ * `if (!callActive) return` guard made it a permanent no-op — silently
+ * breaking the in-app "End Call" bar and the pre-transport-teardown
+ * end-call in stopActiveTransport. The flag/proxy were removed and
+ * `endChannelCall()` now routes to the service unconditionally (the
+ * service side is idempotent).
+ */
+class XvCallBridgeTest {
+    private fun bridgeWithBoundVoice(voice: IXvVoice): XvCallBridge {
+        val client = mockk<XvVoiceClient>()
+        // Simulate a bound service: ifBound invokes the action with the
+        // live IXvVoice, mirroring XvVoiceClient.ifBound's bound branch.
+        every { client.ifBound(any()) } answers {
+            firstArg<(IXvVoice) -> Unit>().invoke(voice)
+        }
+        return XvCallBridge(client)
+    }
+
+    @Test
+    fun `endChannelCall routes to the service unconditionally`() {
+        val voice = mockk<IXvVoice>(relaxed = true)
+        val bridge = bridgeWithBoundVoice(voice)
+
+        bridge.endChannelCall()
+
+        verify(exactly = 1) { voice.endChannelCall() }
+    }
+
+    @Test
+    fun `endChannelCall fires every time (idempotent, no self-gating flag)`() {
+        val voice = mockk<IXvVoice>(relaxed = true)
+        val bridge = bridgeWithBoundVoice(voice)
+
+        bridge.endChannelCall()
+        bridge.endChannelCall()
+
+        // The old callActive guard would have suppressed the second (and
+        // in practice the first) call. Both must reach the service now.
+        verify(exactly = 2) { voice.endChannelCall() }
+    }
+
+    @Test
+    fun `shutdown ends the channel call`() {
+        val voice = mockk<IXvVoice>(relaxed = true)
+        val bridge = bridgeWithBoundVoice(voice)
+
+        bridge.shutdown()
+
+        verify(exactly = 1) { voice.endChannelCall() }
+    }
+}

--- a/app/src/test/java/com/atakmap/android/xv/util/DiagnosticLoggerTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/util/DiagnosticLoggerTest.kt
@@ -1,0 +1,62 @@
+package com.atakmap.android.xv.util
+
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * Fire-and-forget safety pin for [DiagnosticLogger]. The public API
+ * MUST be safe to call before [DiagnosticLogger.init] (early plugin
+ * lifecycle) and after [DiagnosticLogger.shutdown] (teardown races).
+ * Neither should throw and neither should require a Context.
+ *
+ * Field-motivating incident: 2026-07-12 post-mortem could not see
+ * whether the plugin was alive during the outage because our own
+ * logger became a footgun — if callers had to defend against "am I
+ * in the right lifecycle stage to log?" every site would rot.
+ * These tests pin the invariant that logging is always safe.
+ */
+class DiagnosticLoggerTest {
+    @Test
+    fun `event before init is a silent no-op`() {
+        // Do NOT call init(). Call event(). Expect no throw.
+        DiagnosticLogger.event(tag = "test", message = "before-init")
+    }
+
+    @Test
+    fun `flush before init is a silent no-op`() {
+        DiagnosticLogger.flush()
+    }
+
+    @Test
+    fun `shutdown before init is a silent no-op`() {
+        DiagnosticLogger.shutdown()
+    }
+
+    @Test
+    fun `exception before init is a silent no-op`() {
+        DiagnosticLogger.exception(
+            tag = "test",
+            prefix = "before-init exception",
+            t = RuntimeException("simulated"),
+        )
+    }
+
+    @Test
+    fun `severity char defaults to I when omitted`() {
+        // No throw and no crash: the default severity path exercises
+        // the same code as an explicit call. This is a smoke test to
+        // pin the default so a future refactor can't silently make
+        // this an error severity (which would flood peer logs on hot
+        // paths like PTT down / up).
+        DiagnosticLogger.event(tag = "test", message = "default severity")
+        DiagnosticLogger.event(tag = "test", severity = 'W', message = "warn severity")
+        DiagnosticLogger.event(tag = "test", severity = 'E', message = "error severity")
+        // Not much to assert positively — the point is that all four
+        // permitted severity chars are accepted without exception.
+        // Any regression would surface here as a thrown IAE.
+        assertFalse(
+            "test finished without exception",
+            false,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Operators hit a "call in progress" / "Hang up XV to place a new call" collision that blocked PTT (no TX) after prior bursts — disruptive on both the BT speaker-mic and the on-screen PTT button. This PR consolidates the strongest work from several competing branches into one change and adds the missing pieces. It has **four field-validated fixes**: draining stale cross-process Telecom-ledger entries (PhoneAccount ghost-purge, from #70), a synchronous `TelecomState` machine that prevents in-process double-placement during the async `placeCall` registration gap, warm-SCO PRIMING gates that let bursty keying actually transmit frames, and a cellular-gate self-block fix that stops XV from blocking its own PTT during an audio-plant SCO hold. Also folds in the file-backed `DiagnosticLogger` (#69) for field post-mortems and a batch of code-review cleanups (doc drift + dead code) that the review surfaced.

This supersedes and consolidates #67, #69, #70, and #71 into a single PR.

## What changed

**Telecom collision (`service/XvVoiceService.kt`, `telecom/XvConnectionService.kt`, `telecom/ActiveCallRegistry.kt`)** — `135bf25`
- Synchronous `TelecomState { IDLE, ACTIVE_TX_RX, TAIL_WARM }` lifecycle. `decidePlacement()` (pure, unit-tested) decides reuse-live / suppress-duplicate-in-flight / place-new. State flips to `ACTIVE_TX_RX` **before** the async `tm.placeCall()`, closing the window where a second press saw no registered connection and issued a colliding second `placeCall`.
- Wedge hardening: `onCreateOutgoingConnectionFailed → ActiveCallRegistry.firePlaceFailed()` resets state immediately (guarded on `!hasActiveCall()` so a rejected second place never tears down a live call); a bounded place-timeout backstops the "no callback ever arrives" case.
- Defense-in-depth: `onCreateOutgoingConnection` reuses a same-tag `"voice"` connection instead of stacking a second one.
- (from #70) PhoneAccount ghost-purge: fresh-process purge in `onCreate` + a pre-`placeCall` purge gated on `shouldGhostPurgeBeforePlaceCall()`.

**Warm-SCO PRIMING gates (`audio/TxController.kt`)** — `54c868c`
- Field repro 2026-07-13: with SCO held warm across a session (cool-down tail working as designed), the operator keyed ~20 times and **zero frames** went out — 14 bursts abandoned during PRIMING and the one burst that reached TRANSMITTING sent 0 frames.
- Root cause: PRIMING selected the ramp-tolerant cold-SCO gates (30 frames / ~300 ms / rms≥200 / 1500 ms timeout) whenever `scoLink.state == CONNECTED`, including a warm-held link. But those gates exist only for a cold chipset acquire; a warm-held SCO link has no ramp. So every warm burst paid ~300 ms before the permit tone, and bursty keying released before TX ever started.
- Fix: key the gate selection on `currentBurstColdSco` (the existing "this burst had to acquire SCO cold" flag) instead of the live link state. Warm-SCO and non-SCO bursts now use fast gates (5 frames / ~50 ms), dropping PTT-to-tone latency on a warm link from ~300 ms to ~50 ms. Extracted the three selections into pure, unit-tested helpers.
- Also: DiagnosticLogger `~1 s time-throttled flush` — the prior 8 KiB buffer never filled at heartbeat volume, so a process kill lost the whole session (this incident's log was 0 bytes). Now bounds loss on a kill to ~1 s.

**Cellular-gate self-block (`service/PttCellularGate.kt`, `service/VoicePlant.kt`)** — `f59704d`
- Field repro 2026-07-13 (Pixel 9 Pro): operator's PTT was blocked with "Cellular call active — hang up before XV PTT" while NOT on any phone call. XV's own Telecom call had DISCONNECTED ~39 s earlier, so the existing `ActiveCallRegistry` disambiguation couldn't catch it — there was no registered call by then, only XV's own audio-plant SCO hold. An Assistant-screensaver wake re-acquired RX SCO_HOT, which drove `AudioManager.getMode()` into `MODE_IN_COMMUNICATION` with no registered call. The gate mapped that to OFFHOOK and blocked.
- Fix: `resolveGateWithOwnSco()` suppresses a `BLOCK_CELLULAR_CALL` verdict when XV currently holds the SCO link (`scoLink.holdersCount() > 0`) — the comm-mode the gate read is ours (SCO_HOT / TX cool-down / pre-warm), not an external call. `BLOCK_CELLULAR_RINGING` is never suppressed (`MODE_RINGTONE` is unambiguously external; XV's plant never sets it). Pure helper + unit tests.
- Accepted trade-off: if a real external call is active AND XV happens to hold SCO simultaneously, XV could place its own call — a rare edge (the cellular stack owns HFP/SCO during a real call), and blocking a legitimate tactical PTT is the worse failure per the gate's fail-open philosophy.

**Dead / vestigial code** — `135bf25`
- Removed the unreachable `ACTION_PLACE_CALL` / `handlePlaceCall` path in `XvConnectionService` (a second, dead `placeCall` site).
- Fixed vestigial `XvCallBridge`: `startChannelCall` had no callers, so `callActive` was never set true, making `endChannelCall()`'s guard a permanent no-op that silently broke the in-app "End Call" bar. Dropped the dead flag/proxy; `endChannelCall` now fires unconditionally (service-side teardown is idempotent). Removed the two dead callers in `plugin/XvMapComponent.kt`.
- Removed the disabled TPT-overlap ring buffer in `audio/TxController.kt` (never written since it was disabled) plus its dead constants and test seam, and two self-described no-ops (`notifyRxActivity`, `captureReleaseRunnable`).

**Documentation drift (`audio/TxController.kt`, `audio/AudioPlayback.kt`, `audio/ScoLink.kt`)** — `4fd883d`
- Corrected the "5 s" comments that contradicted the real constants: Telecom end-debounce and RX SCO_HOT are both 8 s; the TX SCO cool-down is 5 s; the "these windows match" rationales were false.
- Fixed the frame-duration contradiction (TX frames are 10 ms / 480 samples @ 48 kHz, not 20 ms) and stale buffer-size comments.

**Diagnostics (from #69):** `util/DiagnosticLogger.kt` — app-scoped, per-day rotating field log (no extra permissions; local-only, not committed). `MODE_CALL_SCREENING` added to the friendly-name table (was logging raw `mode=4`).

**Sensitive-content scrub** — `91a13e3`: replaced an operator-hardware identifier (an AINA BT device name) with `APTT000000` placeholder in two comments + a test fixture, per CLAUDE.md rules.

## Root cause / motivation

`TelecomManager.placeCall()` is asynchronous — the `XvConnection` only registers in `ActiveCallRegistry` when Telecom later invokes `onCreateOutgoingConnection`. The prior reuse guard only checked the *registered* connection (`activeConnection() != null`), so a second PTT inside that gap saw nothing and placed again → "there is another call connecting."

Separately, field capture (validated on a Pixel-class handset and a ruggedized Sonim unit, API 35) showed XV self-managed calls stacking in Telecom's own ledger and staying ACTIVE ~138 s past the 8 s debounce, while `activeConnection()` read null — a cross-process desync that the ghost-purge drains. The two mechanisms are complementary; both are needed.

The warm-SCO and self-block fixes are downstream of the state-machine + ghost-purge base. The state machine correctly held SCO across bursty keying, which surfaced the two latent bugs the older cold-SCO-only code path had masked.

## Field validation — 2026-07-13

On-device verification on Pixel 9 Pro (`caiman`, Android 17, ATAK-CIV 5.7.0.10 Developer edition, DEBUGGABLE, `assembleCivDebug -PatakBaselineVersion=5.7.0`):

**State machine + ghost-purge base:** ~100 `placeTelecomCallInternal` calls across three service lifetimes, all correctly short-circuited as `REUSING live XvConnection` while `TelecomState == ACTIVE_TX_RX`. Five legitimate `NEW Telecom call attempt` decisions on cool-down expiry, each preceded by defensive ghost-purge. `dumpsys telecom` showed a single `TC@N` at any time — no stacking. Zero "call in progress" collisions observed.

**Warm-SCO PRIMING (`54c868c`):** operator confirmed "That seems to be doing better" after install; the "TX stopped after 0 frames" symptom captured pre-fix was not observed post-fix.

**Cellular-gate self-block (`f59704d`):** the exact 11:42:31 scenario (Assistant screensaver dream → wake → PTT during XV's own SCO hold) does not reproduce on the fixed build. Ten `PTT blocked by cellular gate` events fired across a session, all clustered inside a ~70-minute window of continuous `audioMode=IN_COMMUNICATION` that operator confirmed was a real cellular call; the first PTT press after that call ended was cleanly promoted to a new `NEW Telecom call attempt`. Zero false-positive blocks against XV's own audio-plant SCO hold.

**DiagnosticLogger durability (`54c868c`):** prior sessions' logs were 0 bytes; on this build the logger produced 46 KB of structured session content across three service lifetimes, spanning 7+ hours.

## Test plan

- [x] `./gradlew ktlintCheck` — CI green.
- [x] `./gradlew assembleCivDebug` — CI green + local `-PatakBaselineVersion=5.7.0` clean.
- [x] `./gradlew testCivDebugUnitTest` — CI green. New: `XvPlacementDecisionTest` (placement truth table), `XvCallBridgeTest` (unconditional end-call), `PttCellularGateTest` (self-SCO suppression), `TxControllerColdScoWarmupTest` (gate-selection helpers). Adjusted: `TxControllerStateMachineTest` / `TxControllerScreechTest` for the removed ring. Inherited-green: `TelecomGhostPurgeDecisionTest`, `DiagnosticLoggerTest`, `ActiveCallRegistryGraceTest`.
- [x] **On-device smoke** on Pixel 9 Pro / ATAK-CIV 5.7.0.10 Developer / AINA V2 speakermic — see "Field validation" above. Bursty rapid re-key ✓; force-stop + relaunch ghost purge ✓; screensaver-dream wake + PTT ✓; real cellular call block ✓; recovery on call-end ✓.
- [x] Regression watch — private (VX) call answer/hangup, in-app End Call bar (behavior-changed here), media pause/resume around a burst, SCO warm-window UX. No regressions observed in field session.

## Known follow-ups (not in scope)

- **First-syllable clipping at TX onset.** Operator reports losing "just the first syllable or so of audio" at the start of a transmission. Not root-caused; two candidates (TPT-vs-speech ordering; PRIMING window shorter than mic capture latency for leading transient). Separate PR.

## Reviewer notes

- The race fix hinges on flipping `telecomState` to `ACTIVE_TX_RX` *before* `tm.placeCall()`; the place-timeout + `firePlaceFailed` reset are the recovery paths if a placement never lands. `@Volatile` state, no added locking (matches the existing pattern).
- `XvCallBridge.endChannelCall` now actually fires — please sanity-check there's no double-teardown concern (service side is idempotent via `teardownLocal()`'s identity guard).
- The self-SCO suppression in `resolveGateWithOwnSco()` is deliberately narrow to `BLOCK_CELLULAR_CALL`; `BLOCK_CELLULAR_RINGING` remains authoritative because `MODE_RINGTONE` is unambiguous.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5d9hpLUvYR12yG8zuNBDz)_
