### PR TITLE
fix(transport): bound TLS connect timeout — Wi-Fi/cellular handoff wedge

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
+++ b/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
@@ -1940,11 +1940,13 @@ class XvMapComponent : AbstractMapComponent() {
             if (hadAnyChannel) {
                 statusTones?.play(com.atakmap.android.xv.audio.StatusToneKind.CHANNEL_LEAVE)
             }
-            // No settle-sleep here: VoiceTransport.disconnect() is now
-            // synchronous (MumbleSession joins its read thread and
-            // awaits its write executor). If a future transport adds
-            // async teardown, expose an onTeardownComplete callback
-            // rather than reintroducing a UI-thread sleep that ANRs.
+            // No settle-sleep here. ReconnectingMumbleTransport.disconnect()
+            // is ASYNC — it submits the teardown (which joins the inner's
+            // read thread and awaits its write executor) onto the recon
+            // executor and returns immediately, so the UI thread never
+            // blocks. If a future transport needs the caller to observe
+            // teardown completion, expose an onTeardownComplete callback
+            // rather than reintroducing a UI-thread sleep/join that ANRs.
             Log.i(TAG, "stopActiveTransport: cleanup complete")
         }
     }

--- a/app/src/main/java/com/atakmap/android/xv/transport/mumble/MumbleAuth.kt
+++ b/app/src/main/java/com/atakmap/android/xv/transport/mumble/MumbleAuth.kt
@@ -7,6 +7,8 @@ import com.atakmap.net.AtakCertificateDatabase
 import gov.tak.api.engine.net.ICertificateStore
 import gov.tak.api.engine.net.ICredentialsStore
 import java.io.ByteArrayInputStream
+import java.net.InetSocketAddress
+import java.net.Socket
 import java.security.KeyStore
 import java.security.cert.CertPathValidator
 import java.security.cert.CertificateFactory
@@ -31,6 +33,16 @@ import javax.net.ssl.X509TrustManager
 //     misses.
 object MumbleAuth {
     private const val TAG = "XvMumbleAuth"
+
+    // Bound on the TCP connect() in [connectTls]. A healthy connect
+    // completes in well under a second on Wi-Fi or a live cellular data
+    // bearer; 8 s catches a black-hole route (the dying Wi-Fi interface
+    // mid Wi-Fi→cellular handoff) without aborting a slow-but-alive
+    // handshake on a marginal link. Matches the wrapper's
+    // PRIMARY_READY_TIMEOUT_MS so a doomed connect surfaces a failure
+    // around the same time the reconnect wrapper stops waiting on it, and
+    // the retry ladder re-attempts on the now-default (cellular) route.
+    internal const val CONNECT_TIMEOUT_MS: Int = 8_000
 
     fun deviceCallsign(): String? =
         try {
@@ -167,7 +179,43 @@ object MumbleAuth {
         takServerHost: String = host,
     ): SSLSocket {
         val ctx = buildSslContext(takServerHost)
-        val socket = ctx.socketFactory.createSocket(host, port) as SSLSocket
+        // Bounded TCP connect. The prior `createSocket(host, port)` form
+        // performed the connect() with the OS-default timeout (tens of
+        // seconds to minutes) and, being a plain blocking socket connect,
+        // was NOT interruptible — so on a Wi-Fi→cellular handoff, where the
+        // fresh reconnect fires against the old Wi-Fi route while it is a
+        // black hole (SYNs get no RST), the read thread wedged in connect()
+        // for the full kernel timeout. Neither disconnect() (the socket
+        // field isn't assigned yet, so socket?.close() is a no-op), nor
+        // readThread.interrupt() (does not unblock a native connect), nor
+        // the network-swap teardown could free it — voice hung
+        // "reconnecting" until an app restart (field report 2026-07-13).
+        //
+        // Connect an explicit plain socket with CONNECT_TIMEOUT_MS, then
+        // layer TLS over the already-connected socket. The
+        // createSocket(socket, host, port, autoClose) overload also carries
+        // the peer host, so SNI + the "HTTPS" endpoint-identification check
+        // below still match against `host`.
+        val plain = Socket()
+        try {
+            plain.connect(InetSocketAddress(host, port), CONNECT_TIMEOUT_MS)
+        } catch (t: Throwable) {
+            try {
+                plain.close()
+            } catch (_: Throwable) {
+            }
+            throw t
+        }
+        val socket =
+            try {
+                ctx.socketFactory.createSocket(plain, host, port, /* autoClose= */ true) as SSLSocket
+            } catch (t: Throwable) {
+                try {
+                    plain.close()
+                } catch (_: Throwable) {
+                }
+                throw t
+            }
         // Hostname verification — without this, any cert chained to one of our
         // trust anchors (TAK private CA OR system trust store) would pass the
         // PinnedAnchorTrustManager regardless of CN/SAN. "HTTPS" is the

--- a/app/src/main/java/com/atakmap/android/xv/transport/mumble/MumbleAuth.kt
+++ b/app/src/main/java/com/atakmap/android/xv/transport/mumble/MumbleAuth.kt
@@ -208,7 +208,8 @@ object MumbleAuth {
         }
         val socket =
             try {
-                ctx.socketFactory.createSocket(plain, host, port, /* autoClose= */ true) as SSLSocket
+                // autoClose = true: closing the SSLSocket also closes `plain`.
+                ctx.socketFactory.createSocket(plain, host, port, true) as SSLSocket
             } catch (t: Throwable) {
                 try {
                     plain.close()

--- a/app/src/test/java/com/atakmap/android/xv/transport/mumble/MumbleAuthTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/transport/mumble/MumbleAuthTest.kt
@@ -1,6 +1,7 @@
 package com.atakmap.android.xv.transport.mumble
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -68,5 +69,17 @@ class MumbleAuthTest {
     fun `mumbleUsername substitutes ALL spaces, not just the first`() {
         val u = MumbleAuth.mumbleUsername(callsign = "Bravo Six Niner", slotSuffix = "112233VS2")
         assertEquals("Bravo_Six_Niner---112233VS2", u)
+    }
+
+    @Test
+    fun `connectTls uses a bounded, positive TCP connect timeout`() {
+        // Contract pin for the Wi-Fi→cellular handoff fix: connectTls must
+        // bound its connect() so a black-hole route can't wedge the read
+        // thread for the OS-default (~1-2 min, un-interruptible) timeout.
+        // Must be positive (0 means "infinite" for Socket.connect) and
+        // capped so a doomed connect fails fast enough to retry on the
+        // new route.
+        assertTrue("connect timeout must be > 0 (0 = infinite blocking)", MumbleAuth.CONNECT_TIMEOUT_MS > 0)
+        assertTrue("connect timeout must stay bounded (<= 15s)", MumbleAuth.CONNECT_TIMEOUT_MS <= 15_000)
     }
 }


### PR DESCRIPTION
## Summary

Fixes a poor Wi-Fi→cellular handoff where voice hangs "reconnecting" long enough that force-quitting the app is the fastest recovery. Root cause is an unbounded, un-interruptible TCP connect in `MumbleAuth.connectTls`. This PR bounds the connect; the existing reconnect ladder then recovers in seconds instead of ~1–2 min (or never).

## What changed

- **`transport/mumble/MumbleAuth.kt`** — `connectTls` now connects an explicit plain `Socket` with `CONNECT_TIMEOUT_MS` (8 s), then layers TLS over the already-connected socket via `createSocket(socket, host, port, autoClose)`. That overload carries the peer host, so SNI + the `HTTPS` endpoint-identification check still match against `host` (security properties preserved).
- **`transport/mumble/MumbleAuthTest.kt`** — constant-contract test pinning the connect timeout (the socket path itself is field-tested, not unit-tested, per the class doc).
- **`plugin/XvMapComponent.kt`** — corrected a stale comment in `stopActiveTransport` that claimed the wrapper's `disconnect()` is synchronous (it's async by design).

## Root cause / motivation

`SSLSocketFactory.createSocket(host, port)` performs the TCP `connect()` with the OS-default timeout (tens of seconds to minutes) and, as a plain blocking socket connect, is **not interruptible**. On a Wi-Fi→cellular handoff the fresh reconnect fires against the old Wi-Fi route while it's a black hole (SYNs get no RST), so the per-session read thread wedges in `connect()`. Nothing frees it:

- `disconnect()`'s `socket?.close()` is a no-op — the `socket` field isn't assigned until `connectTls` returns;
- `readThread.interrupt()` does not unblock a native blocking connect;
- the network-swap teardown (`notifyNetworkSwap`) therefore can't help;
- `SO_TIMEOUT` and the stale-link watchdog only exist *after* the read loop starts, which is never reached.

Since the read thread never surfaces a listener callback, `ReconnectingMumbleTransport.runAttempt`'s `awaitPrimaryReady` timeout returns without scheduling a retry, and — the watcher being edge-only — nothing re-drives recovery. The transport stays down until an app restart.

Bounding the connect makes a doomed attempt fail in ~8 s and hand off to the retry ladder, which re-attempts on the now-default cellular route.

## Related gaps found (not fixed here — flagged for your call)

The investigation surfaced adjacent gaps that the connect-timeout fix largely neutralizes but doesn't eliminate:

1. **`runAttempt` returns with no retry scheduled** on `awaitPrimaryReady` timeout, relying on the listener firing. Bounding the connect makes the listener reliably fire, so this hole closes in practice — but it's still a passive design. Left as-is to avoid aborting slow-but-alive handshakes on marginal cellular.
2. **`fatalRejected` latch + the `else "no live inner, ignoring"` swap branch** can leave a fatal-latched transport permanently down across a later network swap. Separate from this handoff (handoffs produce Transient, not Fatal) and carries self-kick-loop regression risk, so out of scope here.
3. **Audio/SCO/Telecom not unwound on swap** — a swap fires a spurious `WARNING_VOICE_LOST` and, if a Telecom private call is active, leaves Telecom/SCO/focus engaged while the transport rebuilds. Arguably correct (a swap should be transparent), but the spurious warning is a UX nit.

## Test plan

- [ ] `./gradlew ktlintCheck` — runs in CI.
- [ ] `./gradlew assembleCivDebug` — local (ATAK SDK).
- [ ] `./gradlew testCivDebugUnitTest` — local; new `MumbleAuthTest` contract test.
- [ ] **On-device: the actual repro** — join a channel on Wi-Fi, walk out / disable Wi-Fi to force a cellular handoff mid-session, confirm voice recovers within a few seconds without an app restart. Repeat the reverse (cellular→Wi-Fi).

## Reviewer notes

Draft until the on-device handoff repro is validated — this is the exact behavior that can't be exercised in CI or unit tests. The security-sensitive bit is the layered-socket change: please confirm SNI/hostname verification still holds (the `createSocket(socket, host, port, autoClose)` overload preserves the peer host used by the `HTTPS` endpoint check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5d9hpLUvYR12yG8zuNBDz)_