### PR TITLE
feat(reconnect): retry forever — quiet escalation, dormant tail, outage cues

### DIFF
--- a/app/src/main/java/com/atakmap/android/xv/audio/StatusTones.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/StatusTones.kt
@@ -29,6 +29,17 @@ enum class StatusToneKind {
     // when the callee declines, the call times out, or the server
     // refuses the temp channel.
     CALL_BUSY,
+
+    // "Still trying" — one quiet blip per failed reconnect attempt while
+    // the outage is young. Gated by ReconnectNotificationTracker, which
+    // stops it after the audible window even though the ladder keeps
+    // retrying. Deliberately NOT subject to the shared status cooldown
+    // (see DEFAULT_PER_KIND_COOLDOWN_MS).
+    RECONNECT_RETRY,
+
+    // "You're back" — fires once when a reconnect succeeds after a real
+    // outage. Not played for a first-time connect.
+    RECONNECT_RECOVERED,
 }
 
 // Plays status tones with a per-kind cooldown so flapping events
@@ -43,6 +54,11 @@ class StatusTones(
     private val tptPlayer: TptPlayer,
     private val enabled: () -> Boolean = { true },
     private val cooldownMs: () -> Long = { DEFAULT_COOLDOWN_MS },
+    // Per-kind cooldown overrides for kinds whose cadence is already
+    // governed by a caller-side state machine, where the shared cooldown
+    // would silently eat legitimate plays. Falls back to [cooldownMs] for
+    // any kind not listed.
+    private val perKindCooldownMs: Map<StatusToneKind, Long> = DEFAULT_PER_KIND_COOLDOWN_MS,
 ) {
     private val lastPlayedMs = java.util.EnumMap<StatusToneKind, Long>(StatusToneKind::class.java)
 
@@ -62,7 +78,7 @@ class StatusTones(
         if (!enabled()) return
         val now = System.currentTimeMillis()
         val last = lastPlayedMs[kind] ?: 0L
-        val window = cooldownMs()
+        val window = perKindCooldownMs[kind] ?: cooldownMs()
         if (last > 0 && now - last < window) {
             Log.d(TAG, "status $kind suppressed — within ${window}ms cooldown (${now - last}ms since last)")
             return
@@ -80,5 +96,15 @@ class StatusTones(
         // re-emits joinChannel for every existing membership) without
         // beeping the operator's ears off.
         const val DEFAULT_COOLDOWN_MS: Long = 5_000L
+
+        // RECONNECT_RETRY opts out of the shared cooldown. Its cadence is
+        // the reconnect ladder's, whose first gaps (1s, 2s, 4s) are all
+        // inside the 5 s window — the generic cooldown would mute exactly
+        // the early attempts an operator most wants to hear, and the
+        // effect would look like a dropped tone rather than a policy.
+        // ReconnectNotificationTracker is the sole authority on when this
+        // chirp plays and when it stops.
+        val DEFAULT_PER_KIND_COOLDOWN_MS: Map<StatusToneKind, Long> =
+            mapOf(StatusToneKind.RECONNECT_RETRY to 0L)
     }
 }

--- a/app/src/main/java/com/atakmap/android/xv/audio/TptPlayer.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/TptPlayer.kt
@@ -130,6 +130,8 @@ class TptPlayer(
                 -> TptToneGenerator.warningChirp()
                 StatusToneKind.CALL_RINGBACK -> TptToneGenerator.ringbackChirp()
                 StatusToneKind.CALL_BUSY -> TptToneGenerator.busyChirp()
+                StatusToneKind.RECONNECT_RETRY -> TptToneGenerator.retryChirp()
+                StatusToneKind.RECONNECT_RECOVERED -> TptToneGenerator.recoveredChime()
             }
         if (pcm.isEmpty()) return
         val durationMs =
@@ -141,6 +143,8 @@ class TptPlayer(
                 -> TptToneGenerator.WARNING_CHIRP_DURATION_MS
                 StatusToneKind.CALL_RINGBACK -> TptToneGenerator.RINGBACK_CHIRP_DURATION_MS
                 StatusToneKind.CALL_BUSY -> TptToneGenerator.BUSY_CHIRP_DURATION_MS
+                StatusToneKind.RECONNECT_RETRY -> TptToneGenerator.RETRY_CHIRP_DURATION_MS
+                StatusToneKind.RECONNECT_RECOVERED -> TptToneGenerator.RECOVERED_CHIME_DURATION_MS
             }
         playPcmSession(
             pcm = pcm,

--- a/app/src/main/java/com/atakmap/android/xv/audio/TptToneGenerator.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/TptToneGenerator.kt
@@ -95,35 +95,56 @@ object TptToneGenerator {
         return segments.sumOf { it.durationMs }.toLong()
     }
 
-    // Motorola-style "bonk" / no-permit tone — played when the user keys
-    // PTT but the system can't grant TX (no channel joined, transport not
-    // connected, etc.). Single low tone with a short downward slide.
-    // ~305 Hz dropping to ~245 Hz over 250ms; the descending pitch is the
-    // operator-recognizable "deny" cue.
+    // "Bonk" / no-permit tone — played when the operator keys PTT with no
+    // live session (disconnected, not in a channel). Low double-thud: two
+    // short FLAT low tones stepping down (320 Hz → 240 Hz) with a brief
+    // gap — a blunt "buh-BONK" that reads as a firm "denied." Replaces the
+    // old single descending pitch-slide, which sounded mushy/weak. Flat
+    // tones with a punchy attack read as deliberate; the downward step is
+    // the operator-recognizable "no" cue. Stays clearly distinct from the
+    // DENY tone (two descending *slides*, higher) so "not connected" and
+    // "listen-only here" don't sound alike.
     fun noPermitBonk(): ShortArray {
-        val durationMs = 250
-        val n = (SAMPLE_RATE_HZ * durationMs) / 1000
-        val out = ShortArray(n)
-        val startHz = 305.0
-        val endHz = 245.0
+        val firstMs = 70
+        val gapMs = 40
+        val secondMs = 130
+        val firstN = (SAMPLE_RATE_HZ * firstMs) / 1000
+        val gapN = (SAMPLE_RATE_HZ * gapMs) / 1000
+        val secondN = (SAMPLE_RATE_HZ * secondMs) / 1000
+        val out = ShortArray(firstN + gapN + secondN)
+        fillBonkTone(out, 0, firstN, 320.0)
+        // gap is already zero-initialized silence
+        fillBonkTone(out, firstN + gapN, secondN, 240.0)
+        return out
+    }
+
+    // One flat tone of the bonk with a punchy-but-click-free envelope.
+    // Low tones (240-320 Hz, ~3-4 ms period) need a slightly longer edge
+    // than fillSine's ≤2 ms cap or the onset/offset clicks; 4 ms attack /
+    // 12 ms release keeps it blunt without a pop. 0.85 peak matches the
+    // other voice-comm-stream tones (which need the headroom).
+    private fun fillBonkTone(
+        dest: ShortArray,
+        offset: Int,
+        n: Int,
+        freqHz: Double,
+    ) {
         val attack = (SAMPLE_RATE_HZ * 4) / 1000
-        val release = (SAMPLE_RATE_HZ * 30) / 1000
-        var phase = 0.0
+        val release = (SAMPLE_RATE_HZ * 12) / 1000
+        val angularStep = 2.0 * PI * freqHz / SAMPLE_RATE_HZ
         for (i in 0 until n) {
-            val frac = i.toDouble() / n
-            val freq = startHz + (endHz - startHz) * frac
-            phase += 2.0 * PI * freq / SAMPLE_RATE_HZ
             var amp = 0.85
             if (i < attack) amp *= i.toDouble() / attack
             val tailStart = n - release
             if (i > tailStart) amp *= (1.0 - (i - tailStart).toDouble() / release).coerceIn(0.0, 1.0)
-            val s = sin(phase) * amp
-            out[i] = (s * Short.MAX_VALUE).toInt().coerceIn(-32768, 32767).toShort()
+            val s = sin(angularStep * i) * amp
+            dest[offset + i] = (s * Short.MAX_VALUE).toInt().coerceIn(-32768, 32767).toShort()
         }
-        return out
     }
 
-    const val NO_PERMIT_DURATION_MS: Long = 250L
+    // 70 ms + 40 ms gap + 130 ms = 240 ms. Kept in sync with the segment
+    // lengths in [noPermitBonk]; TptToneGeneratorTest pins the two together.
+    const val NO_PERMIT_DURATION_MS: Long = 240L
 
     // "DENY" tone — played when the operator presses PTT on a channel
     // they're allowed to enter but suppressed from speaking on (OTS

--- a/app/src/main/java/com/atakmap/android/xv/audio/TptToneGenerator.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/TptToneGenerator.kt
@@ -238,8 +238,8 @@ object TptToneGenerator {
     private fun twoBeepStatus(
         firstHz: Double,
         secondHz: Double,
+        perBeepMs: Int = 60,
     ): ShortArray {
-        val perBeepMs = 60
         val n = (SAMPLE_RATE_HZ * perBeepMs * 2) / 1000
         val out = ShortArray(n)
         val half = n / 2
@@ -273,6 +273,50 @@ object TptToneGenerator {
     }
 
     const val WARNING_CHIRP_DURATION_MS: Long = 50L * 2 + 90L // 190 ms
+
+    // Reconnect retry chirp — ONE 150 ms beep at 700 Hz. The "still
+    // trying" cue: played per failed reconnect attempt for the first
+    // ReconnectNotificationTracker.DEFAULT_AUDIBLE_UNTIL_MS of an
+    // outage, so an operator working the problem can hear the radio
+    // working it too (the LMR habit — you know the set is still
+    // reaching for the repeater).
+    //
+    // A SINGLE pulse is what makes this distinct: every other cue in
+    // the system is two or more pulses (join/leave/interrupt are
+    // two-tone, warning is a double-tap, deny is a double-slide, TPT is
+    // multi-tone, ringback/busy are dual-tone pairs). One mid-frequency
+    // blip can't be confused with any of them.
+    //
+    // Deliberately quiet at -12 dBFS — roughly a third the amplitude of
+    // warningChirp. This fires repeatedly over minutes, so it has to sit
+    // under the conversation rather than interrupt it; WARNING_VOICE_LOST
+    // is the cue that's allowed to demand attention, and it fires once.
+    fun retryChirp(): ShortArray {
+        val beepMs = 150
+        val n = (SAMPLE_RATE_HZ * beepMs) / 1000
+        val out = ShortArray(n)
+        fillSine(out, 0, n, 700.0, peakAmp = 0.25)
+        return out
+    }
+
+    const val RETRY_CHIRP_DURATION_MS: Long = 150L
+
+    // Reconnect recovery chime — two ascending beeps (800 → 1200 Hz),
+    // 100 ms each. Plays once when a reconnect succeeds after a real
+    // outage. Ascending = "resolved," the same grammar as joinChirp.
+    //
+    // Intentionally close in shape to joinChirp (which is also two
+    // ascending beeps) but a fifth higher and wider (1.5 ratio vs 1.33):
+    // "you're back on the server" and "you're in the channel" are
+    // adjacent ideas, so a related-but-brighter cue is a feature. If
+    // field use says the two are confusable, move this one to a
+    // three-beep ascending run rather than flattening the pitch gap —
+    // pattern, not frequency, is what operators actually discriminate.
+    fun recoveredChime(): ShortArray = twoBeepStatus(800.0, 1200.0, perBeepMs = RECOVERED_CHIME_PER_BEEP_MS)
+
+    private const val RECOVERED_CHIME_PER_BEEP_MS: Int = 100
+
+    const val RECOVERED_CHIME_DURATION_MS: Long = RECOVERED_CHIME_PER_BEEP_MS * 2L
 
     // Phase E call-progress tones. Synthesized to match North American
     // PSTN conventions so operators recognize them instantly:

--- a/app/src/main/java/com/atakmap/android/xv/audio/TxController.kt
+++ b/app/src/main/java/com/atakmap/android/xv/audio/TxController.kt
@@ -85,9 +85,18 @@ class TxController(
     //   2) Server has us suppressed on that slot's channel (OTS
     //      direction enforcement = OUT, or Mumble admin mute).
     // When false, TX is a no-op — no TPT, no SCO, no mic capture; we
-    // play the deny tone. Avoids the "tone played but no one heard
-    // you" experience.
+    // play a reject tone. Avoids the "tone played but no one heard
+    // you" experience. The specific reject cue depends on WHY (see
+    // [sessionLive]): no live session → bonk, listen-only → deny.
     private val canTransmit: (slot: Int) -> Boolean = { _ -> true },
+    // True when a Mumble session is live (connected + in a channel).
+    // Consulted only on a denied press to pick the reject cue: no live
+    // session → the "not in a channel" BONK; live-but-can't-speak (OTS
+    // direction OUT / admin mute) → the "listen-only" DENY tone. The two
+    // sound distinct so the operator can tell "I'm disconnected" from
+    // "I'm connected but muted here" without looking. Defaults to
+    // always-live so an unwired gate keeps the prior deny-only behavior.
+    private val sessionLive: () -> Boolean = { true },
     // Returns true if a peer's voice is currently being played out on
     // the local audio path. When true, TxController plays a short
     // interrupt chirp instead of the full TPT — audibly distinct cue
@@ -155,23 +164,24 @@ class TxController(
     private var activeSlot: Int = 0
 
     // Set true by the deny path when the operator presses on a
-    // listen-only channel from cold SCO. The deny tone is played in
+    // reject cue (bonk or deny) from cold SCO. The tone is played in
     // the scoListener's CONNECTED branch so it actually reaches the
     // AINA. Without this defer, the tone fires immediately while
     // SCO is still CONNECTING and gets routed to the phone speaker
-    // — operator hears nothing on the speakermic.
+    // — operator hears nothing on the speakermic. Null = nothing
+    // deferred; non-null carries WHICH reject cue to play on connect.
     @Volatile
-    private var pendingDenyTone: Boolean = false
+    private var pendingRejectTone: RejectTone? = null
 
     private val scoListener =
         object : ScoLink.StateListener {
             override fun onScoStateChanged(s: ScoLink.State) {
                 when (s) {
                     ScoLink.State.CONNECTED -> {
-                        if (pendingDenyTone) {
-                            pendingDenyTone = false
-                            Log.i(TAG, "SCO connected — playing deferred deny tone")
-                            tptPlayer.playDeny(useScoRoute = true)
+                        pendingRejectTone?.let { kind ->
+                            pendingRejectTone = null
+                            Log.i(TAG, "SCO connected — playing deferred $kind tone")
+                            playRejectTone(kind, useScoRoute = true)
                         }
                         synchronized(this@TxController) {
                             if (state == State.ACQUIRING_SCO) startPriming()
@@ -184,7 +194,7 @@ class TxController(
                         // SCO dropped before it ever connected — give
                         // up on the deferred tone so it doesn't fire
                         // on the next unrelated CONNECTED.
-                        pendingDenyTone = false
+                        pendingRejectTone = null
                         synchronized(this@TxController) {
                             if (state != State.IDLE && holdsSco) {
                                 Log.w(TAG, "SCO $s during TX — abandoning")
@@ -364,7 +374,13 @@ class TxController(
         val canTx = canTransmit(slot)
         Log.i(TAG, "start(slot=$slot) called — canTransmit=$canTx state=$state")
         if (!canTx) {
-            Log.w(TAG, "start(slot=$slot) refused — channel/permission denies TX; playing deny tone")
+            // Pick the reject cue by WHY we can't transmit: no live
+            // session (disconnected / not in a channel) → the "not in a
+            // channel" bonk; live but suppressed on this slot (listen-
+            // only) → the descending deny tone. Distinct sounds so the
+            // operator can tell the two apart without looking.
+            val rejectTone = rejectToneFor(sessionLive())
+            Log.w(TAG, "start(slot=$slot) refused — canTransmit=false; playing $rejectTone tone")
             // A denied press is still a strong intent signal — the
             // operator meant to TX, just on the wrong slot. Treat it
             // like a real press for SCO purposes: pre-warm the link
@@ -377,13 +393,13 @@ class TxController(
                 holdsSco = true
             }
             if (isHfp && scoLink.state != ScoLink.State.CONNECTED) {
-                // Cold SCO — defer the deny tone until the link is
+                // Cold SCO — defer the reject tone until the link is
                 // actually up so it reaches the AINA speaker rather
                 // than the phone speaker.
-                pendingDenyTone = true
-                Log.i(TAG, "deny tone deferred — waiting for SCO CONNECTED")
+                pendingRejectTone = rejectTone
+                Log.i(TAG, "$rejectTone tone deferred — waiting for SCO CONNECTED")
             } else {
-                tptPlayer.playDeny(useScoRoute = isHfp)
+                playRejectTone(rejectTone, useScoRoute = isHfp)
             }
             // Universal cool-down. Re-arm the 5 s release runnable
             // on every press (real or denied) so OUR teardown is
@@ -1388,6 +1404,21 @@ class TxController(
         }
     }
 
+    // Which reject cue a denied PTT press should play. BONK = "you're
+    // not in a channel / no live session" (single low tone); DENY =
+    // "you're in the channel but listen-only" (descending double tone).
+    internal enum class RejectTone { BONK, DENY }
+
+    private fun playRejectTone(
+        kind: RejectTone,
+        useScoRoute: Boolean,
+    ) {
+        when (kind) {
+            RejectTone.BONK -> tptPlayer.playBonk(useScoRoute = useScoRoute)
+            RejectTone.DENY -> tptPlayer.playDeny(useScoRoute = useScoRoute)
+        }
+    }
+
     companion object {
         private const val TAG = "XvTx"
 
@@ -1454,6 +1485,14 @@ class TxController(
             for (v in s) sum += (v.toDouble() * v.toDouble())
             return kotlin.math.sqrt(sum / s.size).toInt()
         }
+
+        /**
+         * Pick the reject cue for a denied PTT press. Pure so the cue
+         * selection is unit-testable without standing up the controller:
+         * no live session (disconnected / not in a channel) → [RejectTone.BONK];
+         * live but suppressed on this slot (listen-only) → [RejectTone.DENY].
+         */
+        internal fun rejectToneFor(sessionLive: Boolean): RejectTone = if (sessionLive) RejectTone.DENY else RejectTone.BONK
 
         // Frame-count alternative for PRIMING completion: if the mic
         // capture loop has delivered this many frames (regardless of

--- a/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
+++ b/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
@@ -4489,6 +4489,16 @@ class XvMapComponent : AbstractMapComponent() {
 
             override fun onDisconnected(reason: String?) {
                 Log.i(TAG, "transport disconnected: $reason")
+                // Clear the service-side session-live flag the moment the
+                // transport drops (deliberate OR unexpected). Without this
+                // it stayed true until the next channel-change event, so a
+                // PTT press on a dead link played the talk-permit tone —
+                // misleading the operator into talking into a pipe that
+                // goes nowhere. With the flag false, canTransmit() is
+                // false and TxController plays the deny tone instead. The
+                // post-ServerSync channel-rejoin re-drives this true on a
+                // successful reconnect, so recovery restores TPT.
+                voiceClient?.ifBound { it.setMumbleSessionState(false) }
                 if (!deliberateDisconnectInProgress) {
                     // Tell the voice service so it can cut off any
                     // in-flight TX with the emphatic cutoff tone via
@@ -4509,6 +4519,10 @@ class XvMapComponent : AbstractMapComponent() {
 
             override fun onConnectionFailed(error: Throwable) {
                 Log.e(TAG, "transport connect failed", error)
+                // Still not connected — keep the session-live flag false
+                // so PTT keeps playing the deny tone (not the permit tone)
+                // for the whole outage, until a reconnect rejoins a channel.
+                voiceClient?.ifBound { it.setMumbleSessionState(false) }
                 // A failed reconnect attempt never coincides with an
                 // in-flight burst (the burst ended when the link first
                 // dropped), so no notifyTransportLost here — just feed

--- a/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
+++ b/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
@@ -2315,6 +2315,21 @@ class XvMapComponent : AbstractMapComponent() {
                 settings.persistAutoConnectBtEnabled(enabled)
             }
 
+            override fun autoReconnectEnabled(): Boolean = settings.persistedAutoReconnectEnabled()
+
+            override fun setAutoReconnectEnabled(enabled: Boolean) {
+                Log.i(TAG, "Controller.setAutoReconnectEnabled($enabled)")
+                settings.persistAutoReconnectEnabled(enabled)
+                // Re-enabling should immediately re-arm a suspended
+                // ladder rather than waiting for the next drop; nudge the
+                // live transport to try now if it's currently down.
+                if (enabled) {
+                    (activeTransport as? com.atakmap.android.xv.transport.ReconnectingMumbleTransport)
+                        ?.takeIf { !it.isConnected }
+                        ?.retryNow()
+                }
+            }
+
             override fun samsungActiveKeySupported(): Boolean {
                 val ctx = heldMapView?.context ?: heldPluginContext ?: return false
                 return com.atakmap.android.xv.util.SamsungActiveKey.isSupported(ctx)
@@ -4116,8 +4131,12 @@ class XvMapComponent : AbstractMapComponent() {
                 onReconnectStateChanged = { attempt, delayMs ->
                     Log.i(TAG, "reconnect attempt $attempt scheduled in ${delayMs}ms")
                 },
+                reconnectEnabled = { settings.persistedAutoReconnectEnabled() },
             )
         activeTransport = transport
+        // Fresh connect — re-arm the alert escalation so a prior outage's
+        // "already alerted" latch doesn't suppress a real future drop.
+        reconnectNotifier.reset()
         transport.connect(loggingListener)
         // Start the network watcher AFTER connect() so the wrapper is
         // ready to receive notifyNetworkSwap. The watcher itself is
@@ -4397,6 +4416,16 @@ class XvMapComponent : AbstractMapComponent() {
     // the moment to avoid a bigger refactor, but the only event paths
     // that reach it are dead.
     private fun dispatchPttDown(slot: Int) {
+        // Keying a dead channel is an explicit "get me back on" signal —
+        // collapse any reconnect backoff (or re-arm an auto-paused /
+        // switched-off ladder) so the operator doesn't have to wait it
+        // out. No-op when already connected. Fire-and-forget: the connect
+        // runs on the transport's own executor and the burst proceeds
+        // normally (it'll simply have no transport to send to until the
+        // link comes back).
+        (activeTransport as? com.atakmap.android.xv.transport.ReconnectingMumbleTransport)
+            ?.takeIf { !it.isConnected }
+            ?.retryNow()
         voiceClient?.ifBound { it.pttDown(slot) }
     }
 
@@ -4437,30 +4466,51 @@ class XvMapComponent : AbstractMapComponent() {
     @Volatile
     private var deliberateDisconnectInProgress: Boolean = false
 
+    // Gates the audible "voice interface lost" alert so a brief drop the
+    // reconnect ladder heals within a couple of attempts stays silent,
+    // and a sustained outage beeps exactly ONCE instead of once per
+    // failed retry. See ReconnectNotificationTracker — this is the fix
+    // for hotspot-fed devices that used to beep continuously while off-
+    // grid. The amber "reconnecting…" status indicator still shows the
+    // transient state visually the whole time.
+    private val reconnectNotifier = com.atakmap.android.xv.transport.ReconnectNotificationTracker()
+
     private val loggingListener =
         object : TransportListener {
             override fun onConnected() {
                 Log.i(TAG, "transport connected")
+                reconnectNotifier.reset()
             }
 
             override fun onDisconnected(reason: String?) {
                 Log.i(TAG, "transport disconnected: $reason")
                 if (!deliberateDisconnectInProgress) {
-                    statusTones?.play(com.atakmap.android.xv.audio.StatusToneKind.WARNING_VOICE_LOST)
                     // Tell the voice service so it can cut off any
                     // in-flight TX with the emphatic cutoff tone via
                     // the SCO route — operator stays oriented on the
                     // speakermic instead of discovering the silent
                     // drop on the next PTT release. No-op when not
-                    // mid-burst.
+                    // mid-burst; stays prompt because it's about the
+                    // CURRENT transmission, not the outage.
                     voiceClient?.ifBound { it.notifyTransportLost() }
+                    // The "voice lost" alert itself is deferred to the
+                    // notifier: silent until the outage has persisted
+                    // past the escalation threshold, then a single beep.
+                    if (reconnectNotifier.onAttemptFailed()) {
+                        statusTones?.play(com.atakmap.android.xv.audio.StatusToneKind.WARNING_VOICE_LOST)
+                    }
                 }
             }
 
             override fun onConnectionFailed(error: Throwable) {
                 Log.e(TAG, "transport connect failed", error)
-                statusTones?.play(com.atakmap.android.xv.audio.StatusToneKind.WARNING_VOICE_LOST)
-                voiceClient?.ifBound { it.notifyTransportLost() }
+                // A failed reconnect attempt never coincides with an
+                // in-flight burst (the burst ended when the link first
+                // dropped), so no notifyTransportLost here — just feed
+                // the escalation counter and beep once at threshold.
+                if (reconnectNotifier.onAttemptFailed()) {
+                    statusTones?.play(com.atakmap.android.xv.audio.StatusToneKind.WARNING_VOICE_LOST)
+                }
             }
 
             override fun onVoiceFrame(frame: VoiceFrame) {

--- a/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
+++ b/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
@@ -2320,13 +2320,18 @@ class XvMapComponent : AbstractMapComponent() {
             override fun setAutoReconnectEnabled(enabled: Boolean) {
                 Log.i(TAG, "Controller.setAutoReconnectEnabled($enabled)")
                 settings.persistAutoReconnectEnabled(enabled)
-                // Re-enabling should immediately re-arm a suspended
-                // ladder rather than waiting for the next drop; nudge the
-                // live transport to try now if it's currently down.
+                val t = activeTransport as? com.atakmap.android.xv.transport.ReconnectingMumbleTransport
                 if (enabled) {
-                    (activeTransport as? com.atakmap.android.xv.transport.ReconnectingMumbleTransport)
-                        ?.takeIf { !it.isConnected }
-                        ?.retryNow()
+                    // Re-enabling should immediately re-arm a suspended
+                    // ladder rather than waiting for the next drop; nudge
+                    // the live transport to try now if it's currently down.
+                    t?.takeIf { !it.isConnected }?.retryNow()
+                } else {
+                    // Disabling should take visible effect at once —
+                    // cancel any pending backoff and drop the
+                    // "reconnecting…" state now instead of waking once
+                    // more when the queued retry fires.
+                    t?.suspendAutoReconnect()
                 }
             }
 

--- a/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
+++ b/app/src/main/java/com/atakmap/android/xv/plugin/XvMapComponent.kt
@@ -75,6 +75,10 @@ class XvMapComponent : AbstractMapComponent() {
     private var voiceClient: com.atakmap.android.xv.service.XvVoiceClient? = null
     private var tptPlayer: TptPlayer? = null
     private var statusTones: com.atakmap.android.xv.audio.StatusTones? = null
+
+    // Persistent shade surface while the reconnect ladder is grinding.
+    // Outlives the audio cues on purpose — see ReconnectStatusNotifier.
+    private var reconnectStatusNotifier: com.atakmap.android.xv.transport.ReconnectStatusNotifier? = null
     private var dropDown: XvDropDownReceiver? = null
 
     // Persistent settings (SharedPreferences accessors). Constructed
@@ -635,6 +639,11 @@ class XvMapComponent : AbstractMapComponent() {
                 tptPlayer = tpt,
                 enabled = { settings.persistedStatusTonesEnabled() },
             )
+        // atakContext for the same reason as the audio objects above: the
+        // plugin context isn't a working Android context for system
+        // services inside ATAK's process.
+        reconnectStatusNotifier =
+            com.atakmap.android.xv.transport.ReconnectStatusNotifier(context = atakContext)
 
         emergency = EmergencyController(AtakEmergencyDispatcher())
 
@@ -1414,6 +1423,12 @@ class XvMapComponent : AbstractMapComponent() {
         tptPlayer?.stop()
         tptPlayer = null
         statusTones = null
+        // Drop the reconnect surface on the way out. A notification is
+        // process-scoped state, not plugin-scoped: leaving it posted
+        // would strand a stale "no voice connection" in the shade with
+        // nothing left running to ever clear it.
+        reconnectStatusNotifier?.clear()
+        reconnectStatusNotifier = null
         audioRouter?.stop()
         audioRouter = null
     }
@@ -1929,6 +1944,14 @@ class XvMapComponent : AbstractMapComponent() {
             } finally {
                 deliberateDisconnectInProgress = false
             }
+            // Re-arm the outage tracker and drop the shade surface. If the
+            // operator hits Disconnect *during* an outage, the tracker is
+            // mid-count and the notification is up; without this, the next
+            // deliberate connect would look like a recovery (spurious
+            // chime) and a stale "no voice connection" would linger with
+            // no ladder behind it.
+            reconnectNotifier.reset()
+            reconnectStatusNotifier?.clear()
             activeTransport = null
             activeMumbleHost = null
             joinedChannelsBySlot.clear()
@@ -2332,6 +2355,13 @@ class XvMapComponent : AbstractMapComponent() {
                     // "reconnecting…" state now instead of waking once
                     // more when the queued retry fires.
                     t?.suspendAutoReconnect()
+                    // The shade surface claims "XV keeps trying until it
+                    // gets through." With the ladder suspended that's no
+                    // longer true, and a notification that lies about the
+                    // radio still working is worse than none at all —
+                    // it's the exact misread the never-give-up policy
+                    // exists to prevent. Take it down.
+                    reconnectStatusNotifier?.clear()
                 }
             }
 
@@ -4471,20 +4501,40 @@ class XvMapComponent : AbstractMapComponent() {
     @Volatile
     private var deliberateDisconnectInProgress: Boolean = false
 
-    // Gates the audible "voice interface lost" alert so a brief drop the
-    // reconnect ladder heals within a couple of attempts stays silent,
-    // and a sustained outage beeps exactly ONCE instead of once per
-    // failed retry. See ReconnectNotificationTracker — this is the fix
-    // for hotspot-fed devices that used to beep continuously while off-
-    // grid. The amber "reconnecting…" status indicator still shows the
-    // transient state visually the whole time.
+    // Decides what the operator HEARS during an outage: silence for a
+    // brief drop the ladder heals, a single "voice interface lost" beep
+    // once it's sustained, a quiet "still trying" chirp per attempt after
+    // that, and nothing at all once the outage passes the audible window.
+    // See ReconnectNotificationTracker — this is the fix for hotspot-fed
+    // devices that used to beep continuously while off-grid. The amber
+    // "reconnecting…" status indicator still shows the transient state
+    // visually the whole time, and the ladder keeps retrying forever
+    // regardless of whether it's making noise.
     private val reconnectNotifier = com.atakmap.android.xv.transport.ReconnectNotificationTracker()
+
+    // Play the cue for one failed reconnect attempt. The tracker
+    // guarantees at most one of these is set, so this can't stack the
+    // loud alert and the quiet chirp on the same attempt.
+    private fun playReconnectCue(decision: com.atakmap.android.xv.transport.ReconnectNotificationTracker.Decision) {
+        if (decision.playAlert) {
+            statusTones?.play(com.atakmap.android.xv.audio.StatusToneKind.WARNING_VOICE_LOST)
+        } else if (decision.playChirp) {
+            statusTones?.play(com.atakmap.android.xv.audio.StatusToneKind.RECONNECT_RETRY)
+        }
+    }
 
     private val loggingListener =
         object : TransportListener {
             override fun onConnected() {
                 Log.i(TAG, "transport connected")
-                reconnectNotifier.reset()
+                // Chime only if we're recovering from a real outage —
+                // onReconnected() returns false for a first-time connect,
+                // so a normal startup stays silent.
+                if (reconnectNotifier.onReconnected()) {
+                    Log.i(TAG, "transport recovered from outage — playing recovery chime")
+                    statusTones?.play(com.atakmap.android.xv.audio.StatusToneKind.RECONNECT_RECOVERED)
+                }
+                reconnectStatusNotifier?.clear()
             }
 
             override fun onDisconnected(reason: String?) {
@@ -4510,10 +4560,10 @@ class XvMapComponent : AbstractMapComponent() {
                     voiceClient?.ifBound { it.notifyTransportLost() }
                     // The "voice lost" alert itself is deferred to the
                     // notifier: silent until the outage has persisted
-                    // past the escalation threshold, then a single beep.
-                    if (reconnectNotifier.onAttemptFailed()) {
-                        statusTones?.play(com.atakmap.android.xv.audio.StatusToneKind.WARNING_VOICE_LOST)
-                    }
+                    // past the escalation threshold, then a single beep,
+                    // then a quiet per-attempt chirp while it continues.
+                    playReconnectCue(reconnectNotifier.onAttemptFailed())
+                    reconnectStatusNotifier?.onOutageContinuing()
                 }
             }
 
@@ -4526,10 +4576,9 @@ class XvMapComponent : AbstractMapComponent() {
                 // A failed reconnect attempt never coincides with an
                 // in-flight burst (the burst ended when the link first
                 // dropped), so no notifyTransportLost here — just feed
-                // the escalation counter and beep once at threshold.
-                if (reconnectNotifier.onAttemptFailed()) {
-                    statusTones?.play(com.atakmap.android.xv.audio.StatusToneKind.WARNING_VOICE_LOST)
-                }
+                // the escalation counter and let it decide the cue.
+                playReconnectCue(reconnectNotifier.onAttemptFailed())
+                reconnectStatusNotifier?.onOutageContinuing()
             }
 
             override fun onVoiceFrame(frame: VoiceFrame) {

--- a/app/src/main/java/com/atakmap/android/xv/plugin/XvSettings.kt
+++ b/app/src/main/java/com/atakmap/android/xv/plugin/XvSettings.kt
@@ -242,6 +242,22 @@ class XvSettings(
         prefs()?.edit()?.putBoolean(PREF_STATUS_TONES, enabled)?.apply()
     }
 
+    // Whether XV automatically retries the Mumble transport after an
+    // unexpected drop. Default ON — the common case is a transient blip
+    // the reconnect ladder heals silently. Operators running in a
+    // known limited-connectivity environment (no server in reach) can
+    // switch this OFF so XV stops the background retry ladder entirely,
+    // avoiding the battery drain and the periodic "voice lost" alert on
+    // a device that can't connect anyway. Read live on every
+    // scheduleRetry via the reconnectEnabled gate so the toggle takes
+    // effect without a reconnect. Independent of an explicit PTT press,
+    // which still forces a connect attempt regardless of this setting.
+    fun persistedAutoReconnectEnabled(): Boolean = prefs()?.getBoolean(PREF_AUTO_RECONNECT, true) ?: true
+
+    fun persistAutoReconnectEnabled(enabled: Boolean) {
+        prefs()?.edit()?.putBoolean(PREF_AUTO_RECONNECT, enabled)?.apply()
+    }
+
     // Whether the Samsung ruggedized-device Active Key is enabled as
     // a PTT source. The corresponding Settings row is only shown at
     // all when [com.atakmap.android.xv.util.SamsungActiveKey.isSupported]
@@ -336,6 +352,10 @@ class XvSettings(
         private const val PREF_TPT_TONE = "tpt_tone"
         private const val PREF_LATCHED_TIMEOUT = "latched_timeout_sec"
         private const val PREF_STATUS_TONES = "status_tones_enabled"
+
+        // Auto-reconnect toggle (default true). See
+        // persistedAutoReconnectEnabled.
+        private const val PREF_AUTO_RECONNECT = "auto_reconnect_enabled"
 
         // Whether the Samsung ruggedized-device Active Key is used as
         // a PTT source. Only meaningful on hardware that has the key.

--- a/app/src/main/java/com/atakmap/android/xv/security/NotificationChannels.kt
+++ b/app/src/main/java/com/atakmap/android/xv/security/NotificationChannels.kt
@@ -70,6 +70,15 @@ object NotificationChannels {
      *  EmergencyManager owns the primary alert pipeline. */
     const val EMERGENCY = "xv_emergency"
 
+    /** Persistent "no voice connection, still reconnecting" status while
+     *  the reconnect ladder is grinding. Silent by design: the reconnect
+     *  audio cues (WARNING_VOICE_LOST once, then a quiet per-attempt
+     *  chirp that stops after the audible window) own the sound, and this
+     *  notification is what remains once they go quiet. A channel that
+     *  made noise here would re-create the continuous-beeping complaint
+     *  this whole subsystem exists to fix. */
+    const val RECONNECT = "xv_reconnect_status"
+
     /**
      * Ensure all canonical channels exist on the device. Idempotent;
      * cheap to call repeatedly. No-op below Android 8.0 (Oreo)
@@ -117,6 +126,17 @@ object NotificationChannels {
             name = "XV active calls",
             importance = NotificationManager.IMPORTANCE_LOW,
             description = "Mute/hangup controls while a private call is in progress.",
+            showBadge = false,
+        )
+        // RECONNECT: LOW + no badge. The operator is already being told
+        // audibly (for the first stretch of the outage); this is the
+        // quiet, persistent surface that outlives the tones.
+        ensure(
+            nm,
+            id = RECONNECT,
+            name = "XV connection status",
+            importance = NotificationManager.IMPORTANCE_LOW,
+            description = "Shown while XV has lost the voice server and is reconnecting.",
             showBadge = false,
         )
         // EMERGENCY: future-use. Channel created proactively so a

--- a/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/VoicePlant.kt
@@ -437,6 +437,12 @@ class VoicePlant(
             },
             tonePreference = { currentTptTone },
             canTransmit = { slot -> canTransmitOnSlot(slot) },
+            // Session-liveness signal so a denied press picks the right
+            // reject cue: no live Mumble session → bonk, live-but-
+            // listen-only → deny. Transport-wide (not per-slot); the
+            // per-slot suppress state is the canSpeakOnSlot half of
+            // canTransmitOnSlot.
+            sessionLive = { mumbleSessionLive },
             isRxActive = { audioPlayback.isActive() },
             telecomActive = {
                 com.atakmap.android.xv.telecom.ActiveCallRegistry

--- a/app/src/main/java/com/atakmap/android/xv/transport/ReconnectNotificationTracker.kt
+++ b/app/src/main/java/com/atakmap/android/xv/transport/ReconnectNotificationTracker.kt
@@ -29,6 +29,16 @@ class ReconnectNotificationTracker(
     // stated "at least two or three reattempts" tolerance.
     private val alertAfterAttempts: Int = DEFAULT_ALERT_THRESHOLD,
 ) {
+    init {
+        // A threshold below 1 would alert on the very first failure,
+        // defeating the "brief blips stay silent" contract and making
+        // the utility's behavior surprising for any future caller. Fail
+        // fast on misconfiguration rather than silently degrading.
+        require(alertAfterAttempts >= 1) {
+            "alertAfterAttempts must be >= 1, was $alertAfterAttempts"
+        }
+    }
+
     private var consecutiveFailures: Int = 0
     private var alerted: Boolean = false
 

--- a/app/src/main/java/com/atakmap/android/xv/transport/ReconnectNotificationTracker.kt
+++ b/app/src/main/java/com/atakmap/android/xv/transport/ReconnectNotificationTracker.kt
@@ -1,8 +1,7 @@
 package com.atakmap.android.xv.transport
 
-// Decides WHEN a reconnecting transport should surface an audible
-// "voice interface lost" alert to the operator — as opposed to every
-// call site beeping on every dropped/failed attempt.
+// Decides WHAT the operator should HEAR during a reconnect outage — as
+// opposed to every call site beeping on every dropped/failed attempt.
 //
 // The problem this solves (field report 2026-07): a device fed from a
 // phone hotspot (e.g. tossed in a vehicle trunk) that loses its uplink
@@ -14,20 +13,38 @@ package com.atakmap.android.xv.transport
 //   1. A brief blip that the reconnect ladder heals within a couple of
 //      attempts should make NO sound — the amber "reconnecting…" status
 //      indicator already tells an attentive operator what's happening.
-//   2. Only a *sustained* outage earns an audible alert, and only ONCE
-//      per outage — not a beep per retry.
-//   3. A successful (re)connect re-arms the tracker so the next outage
-//      starts the count fresh.
+//   2. Only a *sustained* outage earns the loud WARNING_VOICE_LOST
+//      triple-beep, and only ONCE per outage — not a beep per retry.
+//   3. While the outage continues, a much lighter retry chirp per
+//      attempt tells the operator the radio is still working the problem
+//      — the LMR "still trying" cue. It stops after
+//      [audibleUntilMs] so an unattended off-grid device goes quiet even
+//      though the ladder itself keeps retrying forever.
+//   4. A successful reconnect earns a recovery chime, but ONLY if there
+//      was an outage to recover from — a first-time connect is silent.
+//
+// The two audible cues are deliberately different sounds with different
+// jobs: WARNING_VOICE_LOST means "you have lost voice, act on it," the
+// retry chirp means "still trying, stand by." Stacking both on the same
+// attempt would blur that, so [Decision] never sets both.
 //
 // Pure + synchronized so it can be unit-tested directly (house
 // convention) and shared between the transport read thread and the
-// reconnect executor without a data race. No Android dependencies.
+// reconnect executor without a data race. No Android dependencies —
+// callers pass the clock in.
 class ReconnectNotificationTracker(
     // Number of consecutive failed attempts (initial drop counts as the
     // first) before the single audible alert fires. Default 3 =
     // "initial drop + two failed reattempts" — inside the operator's
     // stated "at least two or three reattempts" tolerance.
     private val alertAfterAttempts: Int = DEFAULT_ALERT_THRESHOLD,
+    // How long into an outage the per-attempt retry chirp keeps playing.
+    // Past this the ladder still retries (forever, by design — see
+    // ReconnectPolicy.DEFAULT_SCHEDULE) but does so silently; the
+    // persistent notification is the only remaining signal. Sized so a
+    // device nobody is holding stops making noise, while an operator
+    // actively working an outage hears the radio trying for a good while.
+    private val audibleUntilMs: Long = DEFAULT_AUDIBLE_UNTIL_MS,
 ) {
     init {
         // A threshold below 1 would alert on the very first failure,
@@ -37,27 +54,69 @@ class ReconnectNotificationTracker(
         require(alertAfterAttempts >= 1) {
             "alertAfterAttempts must be >= 1, was $alertAfterAttempts"
         }
+        require(audibleUntilMs >= 0) {
+            "audibleUntilMs must be >= 0, was $audibleUntilMs"
+        }
     }
 
     private var consecutiveFailures: Int = 0
     private var alerted: Boolean = false
 
+    // Wall clock of the first failure in the current outage; the base
+    // for the [audibleUntilMs] window. Meaningless while
+    // [consecutiveFailures] is 0.
+    private var outageStartMs: Long = 0L
+
+    /** What the audio layer should play for one failed attempt. At most
+     *  one of the two is ever true — see the class doc. */
+    data class Decision(
+        val playAlert: Boolean,
+        val playChirp: Boolean,
+    )
+
     /**
      * Record a failed connection event — either the initial unexpected
-     * disconnect or a subsequent failed reconnect attempt. Returns true
-     * EXACTLY ONCE per outage: on the attempt that first reaches
-     * [alertAfterAttempts]. Every call before the threshold, and every
-     * call after the single alert, returns false so the operator hears
-     * one triple-beep for a sustained outage instead of a beep per retry.
+     * disconnect or a subsequent failed reconnect attempt. [nowMs] is
+     * the wall clock, injected so the audible-window logic is testable.
+     *
+     * [Decision.playAlert] is true EXACTLY ONCE per outage: on the
+     * attempt that first reaches [alertAfterAttempts].
+     * [Decision.playChirp] is true on every other attempt within
+     * [audibleUntilMs] of the outage start, and false forever after
+     * that — including on attempts that keep failing hours later.
      */
     @Synchronized
-    fun onAttemptFailed(): Boolean {
-        consecutiveFailures += 1
-        if (!alerted && consecutiveFailures >= alertAfterAttempts) {
-            alerted = true
-            return true
+    fun onAttemptFailed(nowMs: Long = System.currentTimeMillis()): Decision {
+        if (consecutiveFailures == 0) {
+            outageStartMs = nowMs
         }
-        return false
+        consecutiveFailures += 1
+        val alertNow = !alerted && consecutiveFailures >= alertAfterAttempts
+        if (alertNow) {
+            alerted = true
+        }
+        val withinAudibleWindow = (nowMs - outageStartMs) < audibleUntilMs
+        return Decision(
+            playAlert = alertNow,
+            playChirp = !alertNow && withinAudibleWindow,
+        )
+    }
+
+    /**
+     * Record a clean (re)connect. Returns true if this resolves an
+     * outage that had already produced at least one failed attempt —
+     * i.e. whether the recovery chime is warranted. A first-time
+     * connect, or a reconnect after an operator-initiated disconnect,
+     * returns false and stays silent: nothing was broken, so nothing
+     * was fixed.
+     *
+     * Re-arms the tracker either way; the next outage counts from zero.
+     */
+    @Synchronized
+    fun onReconnected(): Boolean {
+        val recoveredFromOutage = consecutiveFailures > 0
+        resetLocked()
+        return recoveredFromOutage
     }
 
     /**
@@ -67,11 +126,27 @@ class ReconnectNotificationTracker(
      */
     @Synchronized
     fun reset() {
+        resetLocked()
+    }
+
+    // Shared body for reset() and onReconnected(). Kotlin's @Synchronized
+    // is reentrant (it's a monitor on `this`), so onReconnected() could
+    // legally call reset() directly — but going through the private
+    // non-synchronized body keeps the lock discipline obvious to the
+    // next reader rather than resting on reentrancy.
+    private fun resetLocked() {
         consecutiveFailures = 0
         alerted = false
+        outageStartMs = 0L
     }
 
     companion object {
         const val DEFAULT_ALERT_THRESHOLD: Int = 3
+
+        /** 10 minutes. Past this an outage is presumed unattended (or
+         *  the operator has long since got the message) and the retry
+         *  chirp would be noise for nobody. Retries themselves do NOT
+         *  stop here — only the sound does. */
+        const val DEFAULT_AUDIBLE_UNTIL_MS: Long = 10 * 60 * 1000L
     }
 }

--- a/app/src/main/java/com/atakmap/android/xv/transport/ReconnectNotificationTracker.kt
+++ b/app/src/main/java/com/atakmap/android/xv/transport/ReconnectNotificationTracker.kt
@@ -1,0 +1,67 @@
+package com.atakmap.android.xv.transport
+
+// Decides WHEN a reconnecting transport should surface an audible
+// "voice interface lost" alert to the operator — as opposed to every
+// call site beeping on every dropped/failed attempt.
+//
+// The problem this solves (field report 2026-07): a device fed from a
+// phone hotspot (e.g. tossed in a vehicle trunk) that loses its uplink
+// beeps continuously, because the old code played WARNING_VOICE_LOST on
+// the initial drop AND on every failed reconnect attempt of the
+// forever-repeating backoff ladder.
+//
+// The desired UX:
+//   1. A brief blip that the reconnect ladder heals within a couple of
+//      attempts should make NO sound — the amber "reconnecting…" status
+//      indicator already tells an attentive operator what's happening.
+//   2. Only a *sustained* outage earns an audible alert, and only ONCE
+//      per outage — not a beep per retry.
+//   3. A successful (re)connect re-arms the tracker so the next outage
+//      starts the count fresh.
+//
+// Pure + synchronized so it can be unit-tested directly (house
+// convention) and shared between the transport read thread and the
+// reconnect executor without a data race. No Android dependencies.
+class ReconnectNotificationTracker(
+    // Number of consecutive failed attempts (initial drop counts as the
+    // first) before the single audible alert fires. Default 3 =
+    // "initial drop + two failed reattempts" — inside the operator's
+    // stated "at least two or three reattempts" tolerance.
+    private val alertAfterAttempts: Int = DEFAULT_ALERT_THRESHOLD,
+) {
+    private var consecutiveFailures: Int = 0
+    private var alerted: Boolean = false
+
+    /**
+     * Record a failed connection event — either the initial unexpected
+     * disconnect or a subsequent failed reconnect attempt. Returns true
+     * EXACTLY ONCE per outage: on the attempt that first reaches
+     * [alertAfterAttempts]. Every call before the threshold, and every
+     * call after the single alert, returns false so the operator hears
+     * one triple-beep for a sustained outage instead of a beep per retry.
+     */
+    @Synchronized
+    fun onAttemptFailed(): Boolean {
+        consecutiveFailures += 1
+        if (!alerted && consecutiveFailures >= alertAfterAttempts) {
+            alerted = true
+            return true
+        }
+        return false
+    }
+
+    /**
+     * Re-arm the tracker on a clean (re)connect — or when a fresh
+     * connect is initiated. The next outage starts counting from zero
+     * and can alert again.
+     */
+    @Synchronized
+    fun reset() {
+        consecutiveFailures = 0
+        alerted = false
+    }
+
+    companion object {
+        const val DEFAULT_ALERT_THRESHOLD: Int = 3
+    }
+}

--- a/app/src/main/java/com/atakmap/android/xv/transport/ReconnectPolicy.kt
+++ b/app/src/main/java/com/atakmap/android/xv/transport/ReconnectPolicy.kt
@@ -61,33 +61,30 @@ class ReconnectPolicy(
 
     companion object {
         // Capped curve with a dormant tail: 1s, 2s, 4s, 8s, 15s, 30s,
-        // 60s, then 2m, then 5m (5m repeats indefinitely). The fast
-        // front matches "the AINA came back" / "wifi handed off"
-        // timescales; the 2m/5m tail is the auto-slowdown for an
-        // unattended device that's genuinely off-grid (e.g. a
-        // hotspot-fed unit thrown in a vehicle trunk). Retrying a dead
-        // uplink once a minute forever wastes battery and radio for no
-        // one; stretching to 5m keeps a background heartbeat without the
-        // drain. An operator who wants back immediately collapses the
-        // wait with a PTT press (ReconnectingMumbleTransport.retryNow).
+        // 60s, then 2m, then 5m — and 5m repeats FOREVER. The fast front
+        // matches "the AINA came back" / "wifi handed off" timescales;
+        // the 2m/5m tail is the auto-slowdown for an unattended device
+        // that's genuinely off-grid (e.g. a hotspot-fed unit thrown in a
+        // vehicle trunk). Retrying a dead uplink once a minute forever
+        // wastes battery and radio for no one; stretching to 5m keeps a
+        // background heartbeat without the drain. An operator who wants
+        // back immediately collapses the wait with a PTT press
+        // (ReconnectingMumbleTransport.retryNow).
+        //
+        // The ladder never stops on its own, by explicit operator
+        // policy: a real LMR radio never gives up trying to reach the
+        // repeater, and XV must not either. Silence because we quit is
+        // operationally worse than silence because we can't get through
+        // — an operator who keys up expecting the radio to have been
+        // trying, and finds it dormant instead, has been lied to by the
+        // device. The only ways out of the ladder are an explicit
+        // operator disconnect, a Fatal outcome (auth wall — retrying
+        // walks into the same wall), or the auto-reconnect toggle. An
+        // earlier revision auto-paused here after ~10 attempts; it was
+        // removed rather than tuned, so don't reintroduce a "give up
+        // after N" constant.
         val DEFAULT_SCHEDULE: LongArray =
             longArrayOf(1_000L, 2_000L, 4_000L, 8_000L, 15_000L, 30_000L, 60_000L, 120_000L, 300_000L)
-
-        // Auto-pause threshold. After this many consecutive failed
-        // attempts (~19 min of continuous failure with DEFAULT_SCHEDULE),
-        // the transport stops actively scheduling retries entirely and
-        // waits to be re-armed by an operator action (PTT press or a
-        // manual reconnect). This is the "auto-pause after a while" half
-        // of the reconnect-quieting work: the dormant tail slows the
-        // drain, and this stops it once it's clear nobody is around to
-        // benefit from the background attempts. Paused ≠ disconnected-
-        // forever: any explicit reconnect re-arms from zero.
-        const val PAUSE_AFTER_ATTEMPTS: Int = 10
-
-        // Pure predicate for the auto-pause decision — kept here (rather
-        // than inline in the wrapper) so it's unit-testable in isolation
-        // per house convention.
-        fun shouldPause(attemptCount: Int): Boolean = attemptCount >= PAUSE_AFTER_ATTEMPTS
 
         // Faster + tighter cap for AINA SPP. The hardware is local
         // (BR/EDR range), so the operator either walks back into

--- a/app/src/main/java/com/atakmap/android/xv/transport/ReconnectPolicy.kt
+++ b/app/src/main/java/com/atakmap/android/xv/transport/ReconnectPolicy.kt
@@ -60,12 +60,34 @@ class ReconnectPolicy(
         }
 
     companion object {
-        // Capped curve: 1s, 2s, 4s, 8s, 15s, 30s, 60s. Last value
-        // repeats indefinitely (ReconnectingMumbleTransport keeps
-        // trying once a minute until the operator tears down or the
-        // server comes back).
+        // Capped curve with a dormant tail: 1s, 2s, 4s, 8s, 15s, 30s,
+        // 60s, then 2m, then 5m (5m repeats indefinitely). The fast
+        // front matches "the AINA came back" / "wifi handed off"
+        // timescales; the 2m/5m tail is the auto-slowdown for an
+        // unattended device that's genuinely off-grid (e.g. a
+        // hotspot-fed unit thrown in a vehicle trunk). Retrying a dead
+        // uplink once a minute forever wastes battery and radio for no
+        // one; stretching to 5m keeps a background heartbeat without the
+        // drain. An operator who wants back immediately collapses the
+        // wait with a PTT press (ReconnectingMumbleTransport.retryNow).
         val DEFAULT_SCHEDULE: LongArray =
-            longArrayOf(1_000L, 2_000L, 4_000L, 8_000L, 15_000L, 30_000L, 60_000L)
+            longArrayOf(1_000L, 2_000L, 4_000L, 8_000L, 15_000L, 30_000L, 60_000L, 120_000L, 300_000L)
+
+        // Auto-pause threshold. After this many consecutive failed
+        // attempts (~19 min of continuous failure with DEFAULT_SCHEDULE),
+        // the transport stops actively scheduling retries entirely and
+        // waits to be re-armed by an operator action (PTT press or a
+        // manual reconnect). This is the "auto-pause after a while" half
+        // of the reconnect-quieting work: the dormant tail slows the
+        // drain, and this stops it once it's clear nobody is around to
+        // benefit from the background attempts. Paused ≠ disconnected-
+        // forever: any explicit reconnect re-arms from zero.
+        const val PAUSE_AFTER_ATTEMPTS: Int = 10
+
+        // Pure predicate for the auto-pause decision — kept here (rather
+        // than inline in the wrapper) so it's unit-testable in isolation
+        // per house convention.
+        fun shouldPause(attemptCount: Int): Boolean = attemptCount >= PAUSE_AFTER_ATTEMPTS
 
         // Faster + tighter cap for AINA SPP. The hardware is local
         // (BR/EDR range), so the operator either walks back into

--- a/app/src/main/java/com/atakmap/android/xv/transport/ReconnectStatusNotifier.kt
+++ b/app/src/main/java/com/atakmap/android/xv/transport/ReconnectStatusNotifier.kt
@@ -1,0 +1,126 @@
+package com.atakmap.android.xv.transport
+
+import android.app.NotificationManager
+import android.content.Context
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.atakmap.android.xv.security.NotificationChannels
+
+/**
+ * Persistent, silent "XV has lost the voice server and is still trying"
+ * surface in the notification shade.
+ *
+ * This is the signal that OUTLIVES the audio. The reconnect audio cues
+ * deliberately stop after
+ * [ReconnectNotificationTracker.DEFAULT_AUDIBLE_UNTIL_MS] so a device
+ * nobody is holding stops making noise — but the ladder itself keeps
+ * retrying forever (see [ReconnectPolicy.DEFAULT_SCHEDULE]). Without a
+ * visual surface, that combination would be indistinguishable from "XV
+ * gave up," which is precisely the misread the never-give-up policy
+ * exists to prevent. An operator who pulls the shade must be able to see
+ * that the radio is still reaching for the server.
+ *
+ * Live "last attempt Xs ago" without a timer: the notification is posted
+ * with `setWhen(attempt time)` + `setUsesChronometer(true)`, so the
+ * system renders a self-updating counter. We re-post only when an
+ * attempt actually fails — no polling, no wakeups of our own. On the
+ * dormant tail that means one cheap re-post every 5 minutes.
+ *
+ * Threading: [NotificationManager.notify] / `cancel` are thread-safe, so
+ * callers may post from the transport listener's thread without
+ * synchronisation.
+ */
+class ReconnectStatusNotifier(
+    private val context: Context,
+    private val nowMs: () -> Long = { System.currentTimeMillis() },
+) {
+    private val nm: NotificationManager? by lazy {
+        context.getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager
+    }
+
+    @Volatile
+    private var showing: Boolean = false
+
+    /**
+     * Record that a reconnect attempt just failed and the outage
+     * continues. Posts the notification if it isn't up, and refreshes the
+     * "last attempt" chronometer base if it is. Idempotent and cheap.
+     */
+    fun onOutageContinuing() {
+        val mgr =
+            nm ?: run {
+                Log.w(TAG, "NotificationManager unavailable — no reconnect status surface")
+                return
+            }
+        // Cold-create defensively. ensureAll() normally runs in
+        // XvVoiceService.onCreate, but this notifier is driven from the
+        // plugin's transport listener, which can outlive or precede the
+        // service in edge cases (service crash + restart). Posting to a
+        // non-existent channel is silently dropped on API 26+, so a
+        // missing channel would make this surface vanish with no error.
+        NotificationChannels.ensureAll(context)
+        val notification =
+            NotificationCompat
+                .Builder(context, NotificationChannels.RECONNECT)
+                .setSmallIcon(android.R.drawable.stat_sys_warning)
+                .setContentTitle(TITLE)
+                .setContentText(TEXT)
+                .setWhen(nowMs())
+                .setShowWhen(true)
+                // Counts up from the last failed attempt — the operator's
+                // "is this thing still alive?" answer at a glance.
+                .setUsesChronometer(true)
+                .setOngoing(true)
+                // Re-posted on every failed attempt; without this the
+                // shade would re-rank/peek each time even on a LOW
+                // channel.
+                .setOnlyAlertOnce(true)
+                .setSilent(true)
+                .setCategory(NotificationCompat.CATEGORY_STATUS)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .build()
+        try {
+            mgr.notify(NOTIFICATION_ID_RECONNECT, notification)
+            showing = true
+        } catch (t: Throwable) {
+            // Most likely POST_NOTIFICATIONS denied on API 33+. The
+            // reconnect ladder is unaffected — it keeps retrying whether
+            // or not we can draw a notification — so this is a warning,
+            // not a failure path.
+            Log.w(TAG, "reconnect status notify threw", t)
+        }
+    }
+
+    /**
+     * Tear the surface down on a successful reconnect (or teardown).
+     * Safe to call when nothing is showing.
+     */
+    fun clear() {
+        if (!showing) return
+        showing = false
+        try {
+            nm?.cancel(NOTIFICATION_ID_RECONNECT)
+        } catch (t: Throwable) {
+            Log.w(TAG, "reconnect status cancel threw", t)
+        }
+    }
+
+    companion object {
+        private const val TAG = "XvReconnectNotif"
+
+        // 4711 = XvVoiceService foreground, 4712/4713 = CallStyleNotifier
+        // incoming/active, 4801 = AinaA2dpWiring diag.
+        private const val NOTIFICATION_ID_RECONNECT = 4714
+
+        // No server hostname here by policy — the notification shade is a
+        // screenshot surface and TAK server FQDNs are sensitive content.
+        private const val TITLE = "XV: no voice connection"
+
+        // Phrased to promise exactly what the ladder does. "Still trying"
+        // is the load-bearing half: it's what distinguishes this from a
+        // client that has given up, and it must stay true — if the retry
+        // policy ever gains a stop condition, this string is a lie and
+        // has to change with it.
+        private const val TEXT = "Reconnecting — XV keeps trying until it gets through."
+    }
+}

--- a/app/src/main/java/com/atakmap/android/xv/transport/ReconnectingMumbleTransport.kt
+++ b/app/src/main/java/com/atakmap/android/xv/transport/ReconnectingMumbleTransport.kt
@@ -483,8 +483,42 @@ class ReconnectingMumbleTransport(
         }
         pendingRetry =
             executor.schedule({
-                if (!teardownRequested) runAttempt()
+                if (teardownRequested) return@schedule
+                // Re-check the gate at FIRE time, not just at schedule
+                // time: the operator may have switched auto-reconnect off
+                // during the backoff window. Without this, an already-
+                // queued task would still wake the radio for one more
+                // background attempt after the operator disabled it.
+                if (!reconnectEnabled()) {
+                    Log.i(TAG, "pending retry fired but auto-reconnect now disabled — suspending")
+                    reconnectSuspended = true
+                    reconnecting.set(false)
+                    return@schedule
+                }
+                runAttempt()
             }, delay, TimeUnit.MILLISECONDS)
+    }
+
+    /**
+     * Immediately suspend the automatic reconnect ladder: cancel any
+     * pending backoff and drop out of the "reconnecting…" state at once,
+     * rather than waiting for the queued retry to fire (which could be
+     * minutes out on the dormant tail). Called when the operator switches
+     * auto-reconnect off so the change takes visible effect immediately.
+     * A later retryNow() / connect() re-arms. No-op if already connected
+     * or torn down. Runs on the wrapper's executor so it serializes with
+     * any in-flight connect / retry work.
+     */
+    fun suspendAutoReconnect() {
+        executor.submit {
+            if (teardownRequested) return@submit
+            if (inner?.isConnected == true) return@submit
+            Log.i(TAG, "suspendAutoReconnect() — cancelling pending backoff, dropping to disconnected")
+            pendingRetry?.cancel(false)
+            pendingRetry = null
+            reconnectSuspended = true
+            reconnecting.set(false)
+        }
     }
 
     /**

--- a/app/src/main/java/com/atakmap/android/xv/transport/ReconnectingMumbleTransport.kt
+++ b/app/src/main/java/com/atakmap/android/xv/transport/ReconnectingMumbleTransport.kt
@@ -127,11 +127,12 @@ class ReconnectingMumbleTransport(
     @Volatile
     private var lastScheduledDelayMs: Long = 0L
 
-    // Set once the auto-pause threshold is crossed (or auto-reconnect is
-    // switched off): the ladder has stopped scheduling and is waiting for
-    // an explicit re-arm. Read by [isReconnecting] so the UI drops from
-    // amber "reconnecting…" back to a plain "disconnected" state — honest
-    // signalling that XV is no longer actively trying on its own.
+    // Set when the operator switches auto-reconnect off: the ladder has
+    // stopped scheduling and is waiting for an explicit re-arm. Read by
+    // [isReconnecting] so the UI drops from amber "reconnecting…" back to
+    // a plain "disconnected" state — honest signalling that XV is no
+    // longer actively trying on its own. Only the operator toggle sets
+    // this; the ladder itself never suspends on attempt count.
     @Volatile
     private var reconnectSuspended: Boolean = false
 
@@ -151,8 +152,8 @@ class ReconnectingMumbleTransport(
     /** True when the wrapper is between attempts — the upstream
      *  saw an `onDisconnected` and a retry is queued. UI uses this
      *  to render "reconnecting…" instead of "disconnected". False once
-     *  the ladder has auto-paused (or been switched off) so the UI
-     *  stops implying an attempt is imminent. */
+     *  the operator has switched auto-reconnect off, so the UI stops
+     *  implying an attempt is imminent. */
     fun isReconnecting(): Boolean = reconnecting.get() && !teardownRequested && !reconnectSuspended
 
     /** Number of consecutive retry attempts without a successful
@@ -270,10 +271,11 @@ class ReconnectingMumbleTransport(
 
     /**
      * Operator-initiated "reconnect now." Collapses any pending backoff
-     * (or dormant auto-pause) and drives a fresh attempt immediately.
-     * Wired to the PTT-down path so keying a dead channel tries to bring
-     * voice back without waiting out the ladder — and re-arms a ladder
-     * that had auto-paused or been switched off. Deliberately ignores
+     * and drives a fresh attempt immediately. Wired to the PTT-down path
+     * so keying a dead channel tries to bring voice back without waiting
+     * out the ladder — which, on the dormant tail, can be up to 5 minutes
+     * away — and re-arms a ladder the operator had switched off.
+     * Deliberately ignores
      * [reconnectEnabled]: an explicit PTT press is a direct "connect me"
      * request, distinct from the automatic background retries that toggle
      * governs. No-op if already connected or torn down.
@@ -456,20 +458,11 @@ class ReconnectingMumbleTransport(
             reconnecting.set(false)
             return
         }
-        // Auto-pause: after a long run of continuous failures nobody is
-        // benefiting from the periodic retries. Stop scheduling and wait
-        // for an explicit re-arm (retryNow / connect). Complements the
-        // dormant tail — the tail slows the drain, this ends it.
-        if (ReconnectPolicy.shouldPause(policy.attemptCount())) {
-            Log.i(
-                TAG,
-                "auto-pausing reconnect after ${policy.attemptCount()} attempts — " +
-                    "waiting for operator (PTT/manual) to re-arm",
-            )
-            reconnectSuspended = true
-            reconnecting.set(false)
-            return
-        }
+        // NOTE: there is deliberately no "give up after N attempts" branch
+        // here. The ladder retries forever (ReconnectPolicy.DEFAULT_SCHEDULE
+        // settles at a 5-minute dormant heartbeat) until the operator
+        // disconnects, a Fatal outcome latches, or the auto-reconnect
+        // toggle above turns it off. See DEFAULT_SCHEDULE's doc for why.
         val delay = policy.nextDelayMs()
         lastScheduledDelayMs = delay
         Log.i(

--- a/app/src/main/java/com/atakmap/android/xv/transport/ReconnectingMumbleTransport.kt
+++ b/app/src/main/java/com/atakmap/android/xv/transport/ReconnectingMumbleTransport.kt
@@ -66,6 +66,16 @@ class ReconnectingMumbleTransport(
     // Optional per-state hooks for the UI. Defaults to no-op so call
     // sites that don't care about reconnect state don't grow.
     private val onReconnectStateChanged: (attempt: Int, scheduledDelayMs: Long) -> Unit = { _, _ -> },
+    // Operator gate for AUTOMATIC reconnect attempts. Read on every
+    // scheduleRetry so a live settings toggle takes effect without a
+    // reconnect. When it returns false the wrapper stops scheduling
+    // background retries entirely — for limited-connectivity ops where
+    // the operator knows the server is unreachable and doesn't want the
+    // battery drain or the periodic "voice lost" alert. This gates only
+    // the automatic ladder: an explicit connect() or retryNow() (PTT
+    // press) still attempts regardless, because those are direct "connect
+    // me now" requests. Default always-on preserves prior behavior.
+    private val reconnectEnabled: () -> Boolean = { true },
     // Single-threaded executor for ALL connect/disconnect/network-swap
     // work. Daemon thread so it doesn't block process exit. Naming is
     // intentional — grep-able in logcat for thread-attribution. Exposed
@@ -117,6 +127,14 @@ class ReconnectingMumbleTransport(
     @Volatile
     private var lastScheduledDelayMs: Long = 0L
 
+    // Set once the auto-pause threshold is crossed (or auto-reconnect is
+    // switched off): the ladder has stopped scheduling and is waiting for
+    // an explicit re-arm. Read by [isReconnecting] so the UI drops from
+    // amber "reconnecting…" back to a plain "disconnected" state — honest
+    // signalling that XV is no longer actively trying on its own.
+    @Volatile
+    private var reconnectSuspended: Boolean = false
+
     // VS2 ghost-cleanup attempt counter. Resets on a successful VS2
     // connect (in onSecondaryFailed when we get a clean connect, we
     // see the upstream onConnected from the primary, but secondary
@@ -132,8 +150,10 @@ class ReconnectingMumbleTransport(
 
     /** True when the wrapper is between attempts — the upstream
      *  saw an `onDisconnected` and a retry is queued. UI uses this
-     *  to render "reconnecting…" instead of "disconnected". */
-    fun isReconnecting(): Boolean = reconnecting.get() && !teardownRequested
+     *  to render "reconnecting…" instead of "disconnected". False once
+     *  the ladder has auto-paused (or been switched off) so the UI
+     *  stops implying an attempt is imminent. */
+    fun isReconnecting(): Boolean = reconnecting.get() && !teardownRequested && !reconnectSuspended
 
     /** Number of consecutive retry attempts without a successful
      *  connect. Resets to 0 on a clean (re)connect. */
@@ -244,7 +264,39 @@ class ReconnectingMumbleTransport(
         policy.reset()
         secondaryUsernameInUseAttempts.set(0)
         fatalRejected.set(false)
+        reconnectSuspended = false
         executor.submit { runAttempt() }
+    }
+
+    /**
+     * Operator-initiated "reconnect now." Collapses any pending backoff
+     * (or dormant auto-pause) and drives a fresh attempt immediately.
+     * Wired to the PTT-down path so keying a dead channel tries to bring
+     * voice back without waiting out the ladder — and re-arms a ladder
+     * that had auto-paused or been switched off. Deliberately ignores
+     * [reconnectEnabled]: an explicit PTT press is a direct "connect me"
+     * request, distinct from the automatic background retries that toggle
+     * governs. No-op if already connected or torn down.
+     *
+     * Runs on the wrapper's single executor so it serializes with any
+     * in-flight connect / disconnect / retry work.
+     */
+    fun retryNow() {
+        executor.submit {
+            if (teardownRequested) return@submit
+            if (inner?.isConnected == true) return@submit
+            Log.i(TAG, "retryNow() — operator-initiated; collapsing backoff/pause")
+            pendingRetry?.cancel(false)
+            pendingRetry = null
+            policy.reset()
+            reconnectSuspended = false
+            // An explicit reconnect request clears the fatal latch for a
+            // single fresh shot — same rationale as connect(). If the
+            // fatal cause persists the next attempt re-latches it; this
+            // fires once per press, so it can't tight-loop.
+            fatalRejected.set(false)
+            runAttempt()
+        }
     }
 
     override fun sendFrame(frame: VoiceFrame) {
@@ -393,6 +445,31 @@ class ReconnectingMumbleTransport(
             reconnecting.set(false)
             return
         }
+        // Operator switched automatic reconnect off (limited-connectivity
+        // ops). Stop the background ladder — a manual reconnect / PTT
+        // press via retryNow() still works and re-arms. Suspend so the UI
+        // reads "disconnected" rather than a "reconnecting…" that will
+        // never fire.
+        if (!reconnectEnabled()) {
+            Log.i(TAG, "auto-reconnect disabled by setting — suspending ladder (PTT/manual re-arms)")
+            reconnectSuspended = true
+            reconnecting.set(false)
+            return
+        }
+        // Auto-pause: after a long run of continuous failures nobody is
+        // benefiting from the periodic retries. Stop scheduling and wait
+        // for an explicit re-arm (retryNow / connect). Complements the
+        // dormant tail — the tail slows the drain, this ends it.
+        if (ReconnectPolicy.shouldPause(policy.attemptCount())) {
+            Log.i(
+                TAG,
+                "auto-pausing reconnect after ${policy.attemptCount()} attempts — " +
+                    "waiting for operator (PTT/manual) to re-arm",
+            )
+            reconnectSuspended = true
+            reconnecting.set(false)
+            return
+        }
         val delay = policy.nextDelayMs()
         lastScheduledDelayMs = delay
         Log.i(
@@ -493,6 +570,7 @@ class ReconnectingMumbleTransport(
                 Log.i(TAG, "inner connected — resetting backoff")
                 policy.reset()
                 reconnecting.set(false)
+                reconnectSuspended = false
                 secondaryUsernameInUseAttempts.set(0)
                 fatalRejected.set(false)
                 upstream?.onConnected()

--- a/app/src/main/java/com/atakmap/android/xv/ui/XvDropDownReceiver.kt
+++ b/app/src/main/java/com/atakmap/android/xv/ui/XvDropDownReceiver.kt
@@ -266,6 +266,16 @@ class XvDropDownReceiver(
 
         fun setAutoConnectBtEnabled(enabled: Boolean) {}
 
+        // ---- Auto-reconnect toggle (Settings → Server) ----
+        // When ON (default), XV retries the Mumble transport after an
+        // unexpected drop with a backoff that slows to a heartbeat and
+        // eventually auto-pauses. When OFF, XV stops the background
+        // ladder for limited-connectivity ops; a PTT press still forces
+        // an attempt. Persists across launches.
+        fun autoReconnectEnabled(): Boolean = true
+
+        fun setAutoReconnectEnabled(enabled: Boolean) {}
+
         // ---- Samsung ruggedized-device Active Key ----
         // True only when the current device is a Samsung Tab Active5
         // / XCover6 Pro / XCover7 / Tab Active4 Pro / Tab Active3 that
@@ -1158,6 +1168,11 @@ class XvDropDownReceiver(
 
         v.findViewById<Button>(R.id.xv_btn_mumble_connect).setOnClickListener { controller.connectMumble() }
         v.findViewById<Button>(R.id.xv_btn_mumble_disconnect).setOnClickListener { controller.disconnectMumble() }
+
+        v.findViewById<Switch>(R.id.xv_switch_auto_reconnect)?.let { sw ->
+            sw.isChecked = controller.autoReconnectEnabled()
+            sw.setOnCheckedChangeListener { _, on -> controller.setAutoReconnectEnabled(on) }
+        }
     }
 
     private fun renderTakServerLabel(label: TextView) {

--- a/app/src/main/res/layout/xv_settings.xml
+++ b/app/src/main/res/layout/xv_settings.xml
@@ -339,6 +339,55 @@
                         android:background="@drawable/xv_button_bg"/>
                 </LinearLayout>
 
+                <!-- Auto-reconnect toggle. ON (default): XV retries the
+                     Mumble link after an unexpected drop, with a backoff
+                     that slows to a 5-minute heartbeat and eventually
+                     auto-pauses. OFF: XV stops the background retry
+                     ladder for limited-connectivity ops (no server in
+                     reach) so it doesn't drain battery or beep on a
+                     device that can't connect. A PTT press still forces
+                     a connect attempt either way. -->
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Reconnect"
+                    android:textColor="@color/xv_text_dim"
+                    android:textSize="11sp"
+                    android:textAllCaps="true"
+                    android:letterSpacing="0.1"
+                    android:layout_marginTop="20dp"/>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:padding="12dp"
+                    android:background="@drawable/xv_card_bg"
+                    android:layout_marginTop="4dp">
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Auto-reconnect on drop"
+                        android:textColor="@color/xv_text"
+                        android:textSize="14sp"/>
+
+                    <Switch
+                        android:id="@+id/xv_switch_auto_reconnect"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"/>
+                </LinearLayout>
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Automatically retry the Mumble link after an unexpected disconnect. Turn OFF for limited-connectivity operations where there's no server in reach — XV stops retrying in the background (saving battery and silencing the periodic 'voice lost' alert). Pressing PTT still forces a reconnect attempt."
+                    android:textColor="@color/xv_text_dim"
+                    android:textSize="11sp"
+                    android:layout_marginTop="6dp"/>
+
                 <View
                     android:layout_width="match_parent"
                     android:layout_height="40dp"/>

--- a/app/src/test/java/com/atakmap/android/xv/audio/TptToneGeneratorTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/audio/TptToneGeneratorTest.kt
@@ -279,4 +279,85 @@ class TptToneGeneratorTest {
         val sampleIdx = samplesFor(5)
         assertNotEquals(astro[sampleIdx], nextel[sampleIdx])
     }
+
+    // ============================================================
+    // Reconnect cues — retryChirp / recoveredChime
+    // ============================================================
+
+    @Test
+    fun `retryChirp duration constant matches the PCM it actually generates`() {
+        // The duration constant isn't decorative: TptPlayer feeds it to
+        // the AudioTrack marker watchdog. A constant that disagrees with
+        // the buffer either truncates the tone or hangs the track past
+        // the end of the audio.
+        val pcm = TptToneGenerator.retryChirp()
+        assertEquals(
+            samplesFor(TptToneGenerator.RETRY_CHIRP_DURATION_MS.toInt()),
+            pcm.size,
+        )
+    }
+
+    @Test
+    fun `recoveredChime duration constant matches the PCM it actually generates`() {
+        val pcm = TptToneGenerator.recoveredChime()
+        assertEquals(
+            samplesFor(TptToneGenerator.RECOVERED_CHIME_DURATION_MS.toInt()),
+            pcm.size,
+        )
+    }
+
+    @Test
+    fun `reconnect cues stay in PCM range and make actual sound`() {
+        for (pcm in listOf(TptToneGenerator.retryChirp(), TptToneGenerator.recoveredChime())) {
+            assertTrue(allInPcmRange(pcm))
+            assertTrue(hasNonZeroSamples(pcm))
+        }
+    }
+
+    @Test
+    fun `retryChirp is markedly quieter than the warning it accompanies`() {
+        // The design contract: WARNING_VOICE_LOST fires once and is
+        // allowed to demand attention; the retry chirp repeats for
+        // minutes and must sit under the conversation. If a future tweak
+        // brings the chirp up to warning level we're back to the
+        // continuous-beeping field complaint this subsystem exists to fix.
+        val chirpPeak = TptToneGenerator.retryChirp().maxOf { kotlin.math.abs(it.toInt()) }
+        val warningPeak = TptToneGenerator.warningChirp().maxOf { kotlin.math.abs(it.toInt()) }
+        assertTrue(
+            "retry chirp peak ($chirpPeak) must be well below warning peak ($warningPeak)",
+            chirpPeak < warningPeak / 2,
+        )
+    }
+
+    @Test
+    fun `retryChirp is a single pulse — no silence gap splitting it`() {
+        // Single-pulse is what makes this cue distinguishable from every
+        // other tone in the system (all of which are 2+ pulses). A gap
+        // would turn it into "some other status chirp" to the operator's
+        // ear. Checked structurally: the interior of the buffer never
+        // goes silent.
+        val pcm = TptToneGenerator.retryChirp()
+        // Skip the attack/release envelope edges, which legitimately
+        // approach zero.
+        val interior = pcm.copyOfRange(samplesFor(20), pcm.size - samplesFor(20))
+        val longestSilentRun = longestRunOfZeros(interior)
+        assertTrue(
+            "found a $longestSilentRun-sample silent run inside a supposedly single pulse",
+            longestSilentRun < samplesFor(2),
+        )
+    }
+
+    private fun longestRunOfZeros(pcm: ShortArray): Int {
+        var longest = 0
+        var current = 0
+        for (s in pcm) {
+            if (s.toInt() == 0) {
+                current++
+                if (current > longest) longest = current
+            } else {
+                current = 0
+            }
+        }
+        return longest
+    }
 }

--- a/app/src/test/java/com/atakmap/android/xv/audio/TxControllerRejectToneTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/audio/TxControllerRejectToneTest.kt
@@ -1,0 +1,27 @@
+package com.atakmap.android.xv.audio
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the reject-cue selection for a denied PTT press. Two distinct
+ * "can't transmit" reasons must map to two distinct, operator-
+ * recognizable tones:
+ *   - No live Mumble session (disconnected / not in a channel) → BONK.
+ *     This is the fix for "the talk-permit tone fired while disconnected":
+ *     a dead link now bonks instead of either playing the permit tone
+ *     (misleading) or the listen-only deny tone (wrong reason).
+ *   - Live session but suppressed on this slot (OTS direction OUT / admin
+ *     mute) → DENY (the listen-only reject).
+ */
+class TxControllerRejectToneTest {
+    @Test
+    fun `no live session bonks`() {
+        assertEquals(TxController.RejectTone.BONK, TxController.rejectToneFor(sessionLive = false))
+    }
+
+    @Test
+    fun `live-but-listen-only denies`() {
+        assertEquals(TxController.RejectTone.DENY, TxController.rejectToneFor(sessionLive = true))
+    }
+}

--- a/app/src/test/java/com/atakmap/android/xv/transport/ReconnectNotificationTrackerTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/transport/ReconnectNotificationTrackerTest.kt
@@ -1,0 +1,66 @@
+package com.atakmap.android.xv.transport
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+// Pins the escalation contract that keeps a hotspot-fed device from
+// beeping continuously while off-grid: silent until the outage has
+// persisted past the threshold, then a single "voice lost" alert, then
+// silent again until a reconnect re-arms the tracker.
+class ReconnectNotificationTrackerTest {
+    @Test
+    fun `stays silent for failures below the threshold`() {
+        val t = ReconnectNotificationTracker(alertAfterAttempts = 3)
+        assertFalse("first drop must not beep", t.onAttemptFailed())
+        assertFalse("second attempt must not beep", t.onAttemptFailed())
+    }
+
+    @Test
+    fun `alerts exactly once on the attempt that reaches the threshold`() {
+        val t = ReconnectNotificationTracker(alertAfterAttempts = 3)
+        assertFalse(t.onAttemptFailed()) // 1
+        assertFalse(t.onAttemptFailed()) // 2
+        assertTrue("third failed attempt escalates to a single alert", t.onAttemptFailed()) // 3
+    }
+
+    @Test
+    fun `does not re-alert on subsequent failures within the same outage`() {
+        val t = ReconnectNotificationTracker(alertAfterAttempts = 3)
+        repeat(2) { t.onAttemptFailed() }
+        assertTrue(t.onAttemptFailed()) // threshold — the single beep
+        // The whole point: a forever-repeating retry ladder must not
+        // beep on every attempt after the first alert.
+        repeat(100) {
+            assertFalse("no repeat beeps during a sustained outage", t.onAttemptFailed())
+        }
+    }
+
+    @Test
+    fun `reset re-arms so a fresh outage can alert again`() {
+        val t = ReconnectNotificationTracker(alertAfterAttempts = 3)
+        repeat(3) { t.onAttemptFailed() } // reaches the alert
+        t.reset() // clean (re)connect
+        // Next outage counts from zero and can escalate on its own.
+        assertFalse(t.onAttemptFailed())
+        assertFalse(t.onAttemptFailed())
+        assertTrue(t.onAttemptFailed())
+    }
+
+    @Test
+    fun `default threshold matches the documented 'two or three reattempts' tolerance`() {
+        assertEquals(3, ReconnectNotificationTracker.DEFAULT_ALERT_THRESHOLD)
+        val t = ReconnectNotificationTracker()
+        assertFalse(t.onAttemptFailed())
+        assertFalse(t.onAttemptFailed())
+        assertTrue(t.onAttemptFailed())
+    }
+
+    @Test
+    fun `threshold of one alerts immediately on the first failure`() {
+        val t = ReconnectNotificationTracker(alertAfterAttempts = 1)
+        assertTrue(t.onAttemptFailed())
+        assertFalse(t.onAttemptFailed())
+    }
+}

--- a/app/src/test/java/com/atakmap/android/xv/transport/ReconnectNotificationTrackerTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/transport/ReconnectNotificationTrackerTest.kt
@@ -63,4 +63,11 @@ class ReconnectNotificationTrackerTest {
         assertTrue(t.onAttemptFailed())
         assertFalse(t.onAttemptFailed())
     }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `rejects a threshold below one`() {
+        // A pure reusable utility should fail fast on misconfiguration
+        // rather than silently alerting on the first failure.
+        ReconnectNotificationTracker(alertAfterAttempts = 0)
+    }
 }

--- a/app/src/test/java/com/atakmap/android/xv/transport/ReconnectNotificationTrackerTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/transport/ReconnectNotificationTrackerTest.kt
@@ -5,63 +5,67 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-// Pins the escalation contract that keeps a hotspot-fed device from
-// beeping continuously while off-grid: silent until the outage has
-// persisted past the threshold, then a single "voice lost" alert, then
-// silent again until a reconnect re-arms the tracker.
+// Pins the audio contract that keeps a hotspot-fed device from beeping
+// continuously while off-grid: silent for a blip, ONE "voice lost" alert
+// once the outage is sustained, a quiet per-attempt "still trying" chirp
+// after that, and total silence once the outage outlives the audible
+// window — while the ladder itself keeps retrying forever.
 class ReconnectNotificationTrackerTest {
+    // Fixed epoch base so the time-window assertions read as deltas.
+    private val t0 = 1_000_000L
+
     @Test
     fun `stays silent for failures below the threshold`() {
         val t = ReconnectNotificationTracker(alertAfterAttempts = 3)
-        assertFalse("first drop must not beep", t.onAttemptFailed())
-        assertFalse("second attempt must not beep", t.onAttemptFailed())
+        assertFalse("first drop must not beep", t.onAttemptFailed(t0).playAlert)
+        assertFalse("second attempt must not beep", t.onAttemptFailed(t0).playAlert)
     }
 
     @Test
     fun `alerts exactly once on the attempt that reaches the threshold`() {
         val t = ReconnectNotificationTracker(alertAfterAttempts = 3)
-        assertFalse(t.onAttemptFailed()) // 1
-        assertFalse(t.onAttemptFailed()) // 2
-        assertTrue("third failed attempt escalates to a single alert", t.onAttemptFailed()) // 3
+        assertFalse(t.onAttemptFailed(t0).playAlert) // 1
+        assertFalse(t.onAttemptFailed(t0).playAlert) // 2
+        assertTrue("third failed attempt escalates to a single alert", t.onAttemptFailed(t0).playAlert) // 3
     }
 
     @Test
     fun `does not re-alert on subsequent failures within the same outage`() {
         val t = ReconnectNotificationTracker(alertAfterAttempts = 3)
-        repeat(2) { t.onAttemptFailed() }
-        assertTrue(t.onAttemptFailed()) // threshold — the single beep
+        repeat(2) { t.onAttemptFailed(t0) }
+        assertTrue(t.onAttemptFailed(t0).playAlert) // threshold — the single beep
         // The whole point: a forever-repeating retry ladder must not
-        // beep on every attempt after the first alert.
+        // fire the loud alert on every attempt after the first one.
         repeat(100) {
-            assertFalse("no repeat beeps during a sustained outage", t.onAttemptFailed())
+            assertFalse("no repeat alerts during a sustained outage", t.onAttemptFailed(t0).playAlert)
         }
     }
 
     @Test
     fun `reset re-arms so a fresh outage can alert again`() {
         val t = ReconnectNotificationTracker(alertAfterAttempts = 3)
-        repeat(3) { t.onAttemptFailed() } // reaches the alert
+        repeat(3) { t.onAttemptFailed(t0) } // reaches the alert
         t.reset() // clean (re)connect
         // Next outage counts from zero and can escalate on its own.
-        assertFalse(t.onAttemptFailed())
-        assertFalse(t.onAttemptFailed())
-        assertTrue(t.onAttemptFailed())
+        assertFalse(t.onAttemptFailed(t0).playAlert)
+        assertFalse(t.onAttemptFailed(t0).playAlert)
+        assertTrue(t.onAttemptFailed(t0).playAlert)
     }
 
     @Test
     fun `default threshold matches the documented 'two or three reattempts' tolerance`() {
         assertEquals(3, ReconnectNotificationTracker.DEFAULT_ALERT_THRESHOLD)
         val t = ReconnectNotificationTracker()
-        assertFalse(t.onAttemptFailed())
-        assertFalse(t.onAttemptFailed())
-        assertTrue(t.onAttemptFailed())
+        assertFalse(t.onAttemptFailed(t0).playAlert)
+        assertFalse(t.onAttemptFailed(t0).playAlert)
+        assertTrue(t.onAttemptFailed(t0).playAlert)
     }
 
     @Test
     fun `threshold of one alerts immediately on the first failure`() {
         val t = ReconnectNotificationTracker(alertAfterAttempts = 1)
-        assertTrue(t.onAttemptFailed())
-        assertFalse(t.onAttemptFailed())
+        assertTrue(t.onAttemptFailed(t0).playAlert)
+        assertFalse(t.onAttemptFailed(t0).playAlert)
     }
 
     @Test(expected = IllegalArgumentException::class)
@@ -69,5 +73,126 @@ class ReconnectNotificationTrackerTest {
         // A pure reusable utility should fail fast on misconfiguration
         // rather than silently alerting on the first failure.
         ReconnectNotificationTracker(alertAfterAttempts = 0)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `rejects a negative audible window`() {
+        ReconnectNotificationTracker(audibleUntilMs = -1L)
+    }
+
+    // ---- retry chirp ----
+
+    @Test
+    fun `chirps on pre-threshold attempts so the operator hears it trying`() {
+        val t = ReconnectNotificationTracker(alertAfterAttempts = 3)
+        // Attempts 1 and 2 are silent as far as the ALERT goes, but they
+        // are the ones an operator most wants a "still trying" cue for.
+        assertTrue("first drop should chirp", t.onAttemptFailed(t0).playChirp)
+        assertTrue("second attempt should chirp", t.onAttemptFailed(t0 + 1_000).playChirp)
+    }
+
+    @Test
+    fun `never stacks the alert and the chirp on the same attempt`() {
+        val t = ReconnectNotificationTracker(alertAfterAttempts = 3)
+        t.onAttemptFailed(t0)
+        t.onAttemptFailed(t0 + 1_000)
+        val atThreshold = t.onAttemptFailed(t0 + 3_000)
+        assertTrue(atThreshold.playAlert)
+        assertFalse("the loud alert already carries this attempt", atThreshold.playChirp)
+    }
+
+    @Test
+    fun `keeps chirping after the alert while the outage is young`() {
+        val t = ReconnectNotificationTracker(alertAfterAttempts = 3)
+        repeat(3) { t.onAttemptFailed(t0) } // burn through to the alert
+        assertTrue("post-alert attempts still chirp", t.onAttemptFailed(t0 + 10_000).playChirp)
+        assertTrue(t.onAttemptFailed(t0 + 60_000).playChirp)
+    }
+
+    @Test
+    fun `goes silent once the outage outlives the audible window`() {
+        val window = 10 * 60 * 1000L
+        val t = ReconnectNotificationTracker(alertAfterAttempts = 3, audibleUntilMs = window)
+        repeat(3) { t.onAttemptFailed(t0) }
+        assertTrue("just inside the window still chirps", t.onAttemptFailed(t0 + window - 1).playChirp)
+        // At and past the window the device goes quiet — the ladder is
+        // still retrying, it just stops making noise for nobody.
+        assertFalse("at the window boundary", t.onAttemptFailed(t0 + window).playChirp)
+        assertFalse("hours later", t.onAttemptFailed(t0 + 5 * 60 * 60 * 1000L).playChirp)
+    }
+
+    @Test
+    fun `audible window is measured from the outage start, not the last attempt`() {
+        val window = 10 * 60 * 1000L
+        val t = ReconnectNotificationTracker(alertAfterAttempts = 3, audibleUntilMs = window)
+        t.onAttemptFailed(t0) // outage starts here
+        // A long dormant-tail gap must not "refresh" the window — the
+        // clock runs from the drop, so a device that's been down for an
+        // hour stays quiet no matter how sparse its attempts are.
+        assertFalse(t.onAttemptFailed(t0 + window + 1).playChirp)
+    }
+
+    @Test
+    fun `reset restarts the audible window for the next outage`() {
+        val window = 10 * 60 * 1000L
+        val t = ReconnectNotificationTracker(alertAfterAttempts = 3, audibleUntilMs = window)
+        t.onAttemptFailed(t0)
+        assertFalse(t.onAttemptFailed(t0 + window).playChirp) // gone quiet
+        t.reset() // reconnected
+        // A brand-new outage an hour later is audible again from its own
+        // start — staleness must not carry across outages.
+        assertTrue(t.onAttemptFailed(t0 + 60 * 60 * 1000L).playChirp)
+    }
+
+    @Test
+    fun `default audible window is ten minutes`() {
+        assertEquals(10 * 60 * 1000L, ReconnectNotificationTracker.DEFAULT_AUDIBLE_UNTIL_MS)
+    }
+
+    // ---- recovery chime ----
+
+    @Test
+    fun `recovery chime fires when reconnecting after a real outage`() {
+        val t = ReconnectNotificationTracker(alertAfterAttempts = 3)
+        t.onAttemptFailed(t0)
+        assertTrue("we were down and now we're up", t.onReconnected())
+    }
+
+    @Test
+    fun `no recovery chime on a first-time connect`() {
+        val t = ReconnectNotificationTracker(alertAfterAttempts = 3)
+        // Nothing was broken, so nothing was fixed — normal startup must
+        // not chime at the operator.
+        assertFalse(t.onReconnected())
+    }
+
+    @Test
+    fun `no recovery chime twice for one outage`() {
+        val t = ReconnectNotificationTracker(alertAfterAttempts = 3)
+        t.onAttemptFailed(t0)
+        assertTrue(t.onReconnected())
+        // A duplicate onConnected (the transport can re-fire it on a
+        // channel re-sync) must not re-chime.
+        assertFalse(t.onReconnected())
+    }
+
+    @Test
+    fun `recovery chime fires even for a blip that never reached the alert`() {
+        val t = ReconnectNotificationTracker(alertAfterAttempts = 3)
+        t.onAttemptFailed(t0) // one silent failure, healed immediately
+        // The drop was real even though it never earned the loud alert;
+        // the chime is the "you're back" confirmation for it.
+        assertTrue(t.onReconnected())
+    }
+
+    @Test
+    fun `onReconnected re-arms the tracker like reset`() {
+        val t = ReconnectNotificationTracker(alertAfterAttempts = 3)
+        repeat(3) { t.onAttemptFailed(t0) } // alerted
+        t.onReconnected()
+        // Fresh outage escalates on its own schedule again.
+        assertFalse(t.onAttemptFailed(t0).playAlert)
+        assertFalse(t.onAttemptFailed(t0).playAlert)
+        assertTrue(t.onAttemptFailed(t0).playAlert)
     }
 }

--- a/app/src/test/java/com/atakmap/android/xv/transport/ReconnectPolicyTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/transport/ReconnectPolicyTest.kt
@@ -31,13 +31,24 @@ class ReconnectPolicyTest {
     }
 
     @Test
-    fun `shouldPause fires only after the auto-pause threshold`() {
-        // Below the threshold we keep retrying; at/after it the wrapper
-        // auto-pauses the ladder to wait for an operator re-arm.
-        assertFalse(ReconnectPolicy.shouldPause(0))
-        assertFalse(ReconnectPolicy.shouldPause(ReconnectPolicy.PAUSE_AFTER_ATTEMPTS - 1))
-        assertTrue(ReconnectPolicy.shouldPause(ReconnectPolicy.PAUSE_AFTER_ATTEMPTS))
-        assertTrue(ReconnectPolicy.shouldPause(ReconnectPolicy.PAUSE_AFTER_ATTEMPTS + 50))
+    fun `ladder never gives up — no attempt count ever stops the retries`() {
+        // Operator policy, not an implementation detail: a real LMR radio
+        // never stops reaching for the repeater, so neither does XV. An
+        // earlier revision auto-paused after ~10 attempts; it was removed
+        // outright. This pins the contract at a deliberately absurd
+        // attempt count so that reintroducing any "give up after N" gate
+        // fails here with a name that explains why.
+        val p = ReconnectPolicy()
+        repeat(10_000) { p.nextDelayMs() }
+        assertEquals(
+            "the 10,000th consecutive failure must still schedule another try",
+            300_000L,
+            p.nextDelayMs(),
+        )
+        assertTrue(
+            "a transient outcome stays retryable no matter how long it has been failing",
+            p.shouldRetry(ReconnectPolicy.Outcome.Transient),
+        )
     }
 
     @Test

--- a/app/src/test/java/com/atakmap/android/xv/transport/ReconnectPolicyTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/transport/ReconnectPolicyTest.kt
@@ -7,9 +7,12 @@ import org.junit.Test
 
 class ReconnectPolicyTest {
     @Test
-    fun `default schedule walks the documented backoff curve`() {
+    fun `default schedule walks the documented backoff curve with dormant tail`() {
         val p = ReconnectPolicy()
-        val expected = longArrayOf(1_000L, 2_000L, 4_000L, 8_000L, 15_000L, 30_000L, 60_000L)
+        // Fast front (blip / handoff recovery) then a dormant tail
+        // (2m, 5m) that slows the drain for an off-grid device.
+        val expected =
+            longArrayOf(1_000L, 2_000L, 4_000L, 8_000L, 15_000L, 30_000L, 60_000L, 120_000L, 300_000L)
         for ((i, want) in expected.withIndex()) {
             val got = p.nextDelayMs()
             assertEquals("attempt #${i + 1}", want, got)
@@ -19,13 +22,22 @@ class ReconnectPolicyTest {
     @Test
     fun `last entry repeats forever after schedule exhaustion`() {
         val p = ReconnectPolicy()
-        repeat(7) { p.nextDelayMs() }
-        // Past the end of the curve — the cap should hold steady at 60s
-        // so the wrapper keeps probing once-a-minute rather than
-        // refusing to retry.
+        repeat(9) { p.nextDelayMs() }
+        // Past the end of the curve — the cap should hold steady at the
+        // 5-minute dormant heartbeat rather than refusing to retry.
         repeat(20) {
-            assertEquals(60_000L, p.nextDelayMs())
+            assertEquals(300_000L, p.nextDelayMs())
         }
+    }
+
+    @Test
+    fun `shouldPause fires only after the auto-pause threshold`() {
+        // Below the threshold we keep retrying; at/after it the wrapper
+        // auto-pauses the ladder to wait for an operator re-arm.
+        assertFalse(ReconnectPolicy.shouldPause(0))
+        assertFalse(ReconnectPolicy.shouldPause(ReconnectPolicy.PAUSE_AFTER_ATTEMPTS - 1))
+        assertTrue(ReconnectPolicy.shouldPause(ReconnectPolicy.PAUSE_AFTER_ATTEMPTS))
+        assertTrue(ReconnectPolicy.shouldPause(ReconnectPolicy.PAUSE_AFTER_ATTEMPTS + 50))
     }
 
     @Test

--- a/app/src/test/java/com/atakmap/android/xv/transport/ReconnectingMumbleTransportTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/transport/ReconnectingMumbleTransportTest.kt
@@ -536,6 +536,41 @@ class ReconnectingMumbleTransportTest {
         assertEquals("no rebuild when the link is already up", before, factoryInvocations.size)
     }
 
+    @Test
+    fun `suspendAutoReconnect cancels a pending backoff and drops the reconnecting state`() {
+        primaryConnectedResult = false
+        val r = build()
+        r.connect(upstream)
+        capturedListeners[0].onDisconnected("blip")
+        val pending = executor.lastScheduledFuture
+        assertTrue("backoff pending before suspend", r.isReconnecting())
+        // Operator switched auto-reconnect off — take effect at once.
+        r.suspendAutoReconnect()
+        assertTrue("pending backoff cancelled immediately", pending?.isCancelled == true)
+        assertFalse("suspended ladder is not 'reconnecting'", r.isReconnecting())
+    }
+
+    @Test
+    fun `pending retry is suppressed when auto-reconnect is toggled off during backoff`() {
+        var enabled = true
+        val r = buildWith { enabled }
+        r.connect(upstream)
+        capturedListeners[0].onDisconnected("blip")
+        assertTrue(executor.hasPendingSchedule())
+        val before = factoryInvocations.size
+        // Operator flips the toggle off while the backoff is still pending;
+        // the queued task must re-check the gate at fire time and suppress
+        // the attempt rather than waking the radio one more time.
+        enabled = false
+        executor.fireScheduled()
+        assertEquals(
+            "fired retry must not rebuild when disabled mid-backoff",
+            before,
+            factoryInvocations.size,
+        )
+        assertFalse(r.isReconnecting())
+    }
+
     // ============================================================
     // Auto-pause — stop scheduling after a long run of failures
     // ============================================================

--- a/app/src/test/java/com/atakmap/android/xv/transport/ReconnectingMumbleTransportTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/transport/ReconnectingMumbleTransportTest.kt
@@ -68,7 +68,9 @@ class ReconnectingMumbleTransportTest {
         tx
     }
 
-    private fun build(): ReconnectingMumbleTransport =
+    private fun build(): ReconnectingMumbleTransport = buildWith { true }
+
+    private fun buildWith(reconnectEnabled: () -> Boolean): ReconnectingMumbleTransport =
         ReconnectingMumbleTransport(
             config =
             TransportConfig.Mumble(
@@ -79,6 +81,7 @@ class ReconnectingMumbleTransportTest {
             primarySlotSuffix = "VS1",
             secondarySlotSuffix = "VS2",
             factory = factory,
+            reconnectEnabled = reconnectEnabled,
             executor = executor,
         )
 
@@ -472,6 +475,90 @@ class ReconnectingMumbleTransportTest {
         r.connect(upstream)
         capturedListeners[0].onPeerStoppedTalking("alice")
         verify { upstream.onPeerStoppedTalking("alice") }
+    }
+
+    // ============================================================
+    // Auto-reconnect toggle — OFF suspends the background ladder
+    // ============================================================
+
+    @Test
+    fun `auto-reconnect disabled suspends the ladder instead of scheduling`() {
+        val r = buildWith { false }
+        r.connect(upstream)
+        capturedListeners[0].onDisconnected("blip")
+        // Operator turned auto-reconnect off (limited-connectivity ops):
+        // a drop must NOT queue a background retry, and the UI reads
+        // "disconnected" rather than a "reconnecting…" that never fires.
+        assertFalse(
+            "auto-reconnect off must not schedule a background retry",
+            executor.hasPendingSchedule(),
+        )
+        assertFalse("suspended ladder is not 'reconnecting'", r.isReconnecting())
+        assertEquals("no fresh attempt while suspended", 1, factoryInvocations.size)
+    }
+
+    // ============================================================
+    // retryNow — operator PTT collapses backoff / re-arms a paused ladder
+    // ============================================================
+
+    @Test
+    fun `retryNow forces an attempt even when auto-reconnect is disabled`() {
+        primaryConnectedResult = false
+        val r = buildWith { false }
+        r.connect(upstream)
+        capturedListeners[0].onDisconnected("blip")
+        assertFalse(executor.hasPendingSchedule())
+        val before = factoryInvocations.size
+        // Operator keys PTT on the dead channel — an explicit "connect me"
+        // request that ignores the toggle and rebuilds immediately.
+        r.retryNow()
+        assertEquals("retryNow must rebuild a fresh inner", before + 1, factoryInvocations.size)
+    }
+
+    @Test
+    fun `retryNow collapses a pending backoff into an immediate attempt`() {
+        val r = build()
+        r.connect(upstream)
+        capturedListeners[0].onDisconnected("blip")
+        val pending = executor.lastScheduledFuture
+        r.retryNow()
+        assertTrue("pending backoff cancelled by retryNow", pending?.isCancelled == true)
+        assertEquals("immediate rebuild after collapse", 2, factoryInvocations.size)
+    }
+
+    @Test
+    fun `retryNow is a no-op when already connected`() {
+        val r = build()
+        r.connect(upstream)
+        capturedListeners[0].onConnected()
+        val before = factoryInvocations.size
+        r.retryNow()
+        assertEquals("no rebuild when the link is already up", before, factoryInvocations.size)
+    }
+
+    // ============================================================
+    // Auto-pause — stop scheduling after a long run of failures
+    // ============================================================
+
+    @Test
+    fun `ladder auto-pauses after the pause threshold and stops scheduling`() {
+        val r = build()
+        r.connect(upstream)
+        // Drive consecutive transient failures. Each disconnect schedules
+        // a retry (attemptCount++); each fire rebuilds a fresh inner whose
+        // freshly-captured listener we fail again next iteration.
+        var idx = 0
+        repeat(ReconnectPolicy.PAUSE_AFTER_ATTEMPTS) {
+            capturedListeners[idx].onDisconnected("blip")
+            assertTrue("still retrying below the pause threshold", executor.hasPendingSchedule())
+            executor.fireScheduled()
+            idx++
+        }
+        // attemptCount has now reached the threshold — the next failure
+        // must auto-pause rather than schedule yet another retry.
+        capturedListeners[idx].onDisconnected("blip past threshold")
+        assertFalse("ladder must auto-pause at the threshold", executor.hasPendingSchedule())
+        assertFalse("auto-paused ladder reads as not-reconnecting", r.isReconnecting())
     }
 
     /**

--- a/app/src/test/java/com/atakmap/android/xv/transport/ReconnectingMumbleTransportTest.kt
+++ b/app/src/test/java/com/atakmap/android/xv/transport/ReconnectingMumbleTransportTest.kt
@@ -517,6 +517,13 @@ class ReconnectingMumbleTransportTest {
 
     @Test
     fun `retryNow collapses a pending backoff into an immediate attempt`() {
+        // The inner must report NOT connected, as it would in production
+        // after onDisconnected. retryNow() deliberately no-ops on a live
+        // link (see `retryNow is a no-op when already connected`), so
+        // without this the mock still claims isConnected=true, retryNow
+        // correctly declines to act, and the assertions below fail for a
+        // reason that has nothing to do with collapsing the backoff.
+        primaryConnectedResult = false
         val r = build()
         r.connect(upstream)
         capturedListeners[0].onDisconnected("blip")
@@ -572,28 +579,58 @@ class ReconnectingMumbleTransportTest {
     }
 
     // ============================================================
-    // Auto-pause — stop scheduling after a long run of failures
+    // Never-give-up — the ladder only stops when the operator says so
     // ============================================================
 
     @Test
-    fun `ladder auto-pauses after the pause threshold and stops scheduling`() {
+    fun `ladder keeps scheduling through a long run of failures — never auto-pauses`() {
         val r = build()
         r.connect(upstream)
-        // Drive consecutive transient failures. Each disconnect schedules
-        // a retry (attemptCount++); each fire rebuilds a fresh inner whose
-        // freshly-captured listener we fail again next iteration.
+        // Drive a long run of consecutive transient failures. Each
+        // disconnect schedules a retry (attemptCount++); each fire
+        // rebuilds a fresh inner whose freshly-captured listener we fail
+        // again next iteration.
+        //
+        // 40 attempts is far past the ~10 where the removed auto-pause
+        // used to kick in, and past the end of the backoff curve — on the
+        // real schedule this is hours of continuous failure. The radio is
+        // still trying, by explicit operator policy: silence because we
+        // quit is worse than silence because we can't get through.
         var idx = 0
-        repeat(ReconnectPolicy.PAUSE_AFTER_ATTEMPTS) {
-            capturedListeners[idx].onDisconnected("blip")
-            assertTrue("still retrying below the pause threshold", executor.hasPendingSchedule())
+        repeat(40) {
+            capturedListeners[idx].onDisconnected("blip #$it")
+            assertTrue(
+                "attempt #${it + 1} must still schedule a retry — the ladder never gives up",
+                executor.hasPendingSchedule(),
+            )
+            assertTrue("still reads as reconnecting at attempt #${it + 1}", r.isReconnecting())
             executor.fireScheduled()
             idx++
         }
-        // attemptCount has now reached the threshold — the next failure
-        // must auto-pause rather than schedule yet another retry.
-        capturedListeners[idx].onDisconnected("blip past threshold")
-        assertFalse("ladder must auto-pause at the threshold", executor.hasPendingSchedule())
-        assertFalse("auto-paused ladder reads as not-reconnecting", r.isReconnecting())
+    }
+
+    @Test
+    fun `only the operator toggle suspends the ladder — not the attempt count`() {
+        // Guards the boundary between the two: a long-running outage keeps
+        // trying forever, but the operator's off-switch still stops it at
+        // any point in that run. If a "give up after N" gate is ever
+        // reintroduced, the first half of this passes and the semantics
+        // silently diverge from the notification text ("XV keeps trying
+        // until it gets through"), so pin both here together.
+        var enabled = true
+        val r = buildWith { enabled }
+        r.connect(upstream)
+        var idx = 0
+        repeat(15) {
+            capturedListeners[idx].onDisconnected("blip #$it")
+            assertTrue("deep into the outage and still trying", executor.hasPendingSchedule())
+            executor.fireScheduled()
+            idx++
+        }
+        enabled = false
+        capturedListeners[idx].onDisconnected("blip after operator opts out")
+        assertFalse("operator opt-out is the one thing that stops it", executor.hasPendingSchedule())
+        assertFalse("suspended ladder reads as not-reconnecting", r.isReconnecting())
     }
 
     /**


### PR DESCRIPTION
## Summary

Reworks the Mumble reconnect UX so an unexpected drop no longer reads as an immediate "error," an off-grid device stops beeping and draining battery — and the radio **never gives up trying**.

This PR supersedes its own earlier auto-pause design. The landed policy (2026-07-14): a real LMR radio never stops reaching for the repeater, and XV must not either. Silence because we quit is operationally worse than silence because we can't get through — an operator who keys up expecting the radio to have been trying, and finds it dormant, has been lied to by the device.

The insight that reconciles this with the original off-grid complaint: **slowing down and giving up are separable**, and only the first was ever wanted. The dormant tail fixes the battery drain; auto-pause was never load-bearing for it.

## What changed

### Ladder — never stops
- **Removed** `PAUSE_AFTER_ATTEMPTS` / `shouldPause()` and the wrapper branch that suspended the ladder after ~10 consecutive failures (~19 min).
- **Kept** the 2m/5m dormant tail. `DEFAULT_SCHEDULE` is `1, 2, 4, 8, 15, 30, 60s → 2m → 5m`, with 5m repeating forever.
- The only things that stop retries: an operator disconnect, a `Fatal` outcome (auth wall — retrying walks into the same wall), or the auto-reconnect toggle.

### Audio — `ReconnectNotificationTracker` now owns all three decisions
| Cue | When | Sound |
|---|---|---|
| `WARNING_VOICE_LOST` | once, at 3 failed attempts | unchanged triple-tap, 80% amp |
| `RECONNECT_RETRY` (new) | per attempt, first 10 min | one 150 ms / 700 Hz pulse, ~1/3 amp |
| `RECONNECT_RECOVERED` (new) | on a reconnect that resolves a real outage | two ascending 800→1200 Hz beeps |

- The retry chirp is a **single** pulse — every other cue in the system is 2+ pulses, so one mid-frequency blip can't be confused with any of them. Deliberately quiet: it repeats over minutes, so it sits under the conversation; `WARNING_VOICE_LOST` is the cue allowed to demand attention, and it still fires once.
- Alert and chirp **never stack** on one attempt — they mean different things ("act on this" vs "stand by").
- Chirping stops at 10 min (`AUDIBLE_UNTIL`); **retries do not**. Only the sound stops.
- A first-time connect does not chime — `onReconnected()` returns false when nothing was broken.
- `RECONNECT_RETRY` opts out of the shared 5 s status cooldown, which would otherwise mute exactly the early attempts (1s/2s/4s gaps) an operator most wants to hear.

### Visual — the signal that outlives the audio
- New `ReconnectStatusNotifier`: silent, ongoing shade notification for the duration of an outage. Once the cues go quiet at 10 min this is the **only** thing distinguishing "still trying" from "gave up," which is what makes the never-give-up policy legible to the operator.
- `setWhen` + `setUsesChronometer` render a live "last attempt" counter with no timer of our own — one cheap re-post per failed attempt (once per 5 min on the tail).
- Cleared on recovery, deliberate disconnect, plugin teardown, and when auto-reconnect is switched off (its text promises XV keeps trying; with the ladder suspended that would be a lie).
- New LOW-importance, no-badge `xv_reconnect_status` channel. No server hostname in the text — the shade is a screenshot surface.

### Retained from the earlier revision
Quiet escalation, the `PREF_AUTO_RECONNECT` toggle (still the operator's manual off-switch for the trunk case), PTT re-arm via `retryNow()`, and the talk-permit-tone suppression on a dead transport.

## Test plan

- [x] `./gradlew ktlintCheck` — **green**
- [x] `./gradlew assembleCivDebug` — **green**
- [x] `./gradlew testCivDebugUnitTest` — **green** (842 tests) — see caveat below
- [ ] **On-device smoke** — the part that can't be exercised in CI:
  - Brief blip → no sound at all, amber indicator only.
  - Sustained outage → exactly one triple-tap, then a quiet chirp per attempt.
  - Leave it down >10 min → chirps stop, notification stays, ladder keeps retrying (watch logcat `XvMumbleReconnect: scheduled reconnect attempt N`).
  - Restore the server → single recovery chime, notification clears.
  - PTT during the dormant tail → collapses the backoff and reconnects.
  - Toggle auto-reconnect off mid-outage → notification clears, ladder stops.
  - Verify the recovery chime is distinguishable from the channel-join chirp in real use (both are two ascending beeps; this one is a fifth higher). If they're confusable, the fix is a three-beep run, not a pitch tweak — pattern is what operators discriminate.

### ⚠️ Caveat on the unit-test gate
`testCivDebugUnitTest` **cannot compile on `main` today**, independent of this PR: `XvPlacementDecisionTest` (landed in #72) references `XvVoiceService.PlaceDecision`, an enum nested in a `companion object`, and fails with `Unresolved reference`. CI runs Detekt/Ktlint/Semgrep but has **no unit-test job**, so it merged silently. I verified this reproduces on `main` with this branch's changes stashed.

To get the green run above I temporarily moved that one file aside, then restored it — it is untouched by this PR. Tracked separately (fix + add a CI unit-test job); **that** is the real bug here.

## Reviewer notes

- `ReconnectNotificationTracker.onAttemptFailed()` now returns a `Decision(playAlert, playChirp)` instead of a `Boolean`. Single call, atomic under the existing `@Synchronized`, and the caller can't get the ordering wrong or stack both cues.
- Clock is injected (`nowMs`) so the audible-window logic is testable; the window is measured from **outage start**, not last attempt, so a sparse dormant-tail cadence can't refresh it.
- `ReconnectPolicyTest` pins the never-give-up contract at 10,000 consecutive failures — a deliberately absurd count, so reintroducing any "give up after N" gate fails with a name that explains why.
- Also fixes a pre-existing failing test on this branch (`retryNow collapses a pending backoff`): it built its inner mock with `isConnected=true`, so `retryNow()` correctly no-opped on a "live" link and the assertions failed for an unrelated reason. Sibling tests already pinned the flag false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
