### PR TITLE
chore(scripts): config-driven dev/TPP tooling + harden sanitization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,12 @@ keystore.properties
 signing.properties
 app/atak_keystore
 
+# ---------- Local per-clone script config ----------
+# scripts/config.json is per-operator (real ATAK server hostnames,
+# device-specific ATAK APK paths, callsign redaction lists). Only the
+# committed config.example.json travels with the repo.
+scripts/config.json
+
 # ---------- ATAK SDK (vendored, do not commit) ----------
 app/libs/main.jar
 app/libs/*.jar

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,37 @@ way a refactor breaks plugin loading. `testCivDebugUnitTest` is the
 JUnit/MockK/Robolectric unit suite for the state machines listed in
 the initial commit.
 
+## Scripting recurring workflows
+
+If a multi-step command sequence gets run more than a handful of
+times in a session (build + install to phone, package for TPP, pull
++ scrub + summarize field logs, etc.), turn it into a script under
+`scripts/` rather than re-running the raw commands each time. The
+script is faster for the operator, less mistake-prone (correct
+`.gitignore`-respecting archive command, correct baseline flag,
+correct install path), and gives Claude Code a durable artifact
+to reason about instead of reconstructing the sequence per session.
+
+Script conventions:
+
+- PowerShell (`*.ps1`) is the primary shell — matches the operator's
+  desktop. Bash-only scripts should be the exception, not the default.
+- Per-clone / operator-specific values (ATAK SDK paths, real TAK
+  server hostnames, callsign redaction lists) go in
+  `scripts/config.json` (gitignored). A `scripts/config.example.json`
+  template is committed so a fresh clone knows the schema. Shared
+  config-loader logic lives in `scripts/lib/`.
+- The tooling is generic across TAK plugins — nothing plugin-specific
+  should be hardcoded in `scripts/*.ps1` files. If a script is only
+  useful to this plugin, that's a smell; extract the specific bits
+  to config.
+- Any script that produces a public artifact (TPP zip, PR body,
+  screenshot bundle) MUST run a sensitive-content scan before
+  declaring success. `scripts/package-tpp.ps1` is the reference
+  pattern.
+
+See `scripts/README.md` for the current inventory and usage.
+
 ## ATAK SDK jar
 
 `app/libs/main.jar` is gitignored and is **not** vendored in this

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,8 +152,11 @@ to reason about instead of reconstructing the sequence per session.
 
 Script conventions:
 
-- PowerShell (`*.ps1`) is the primary shell — matches the operator's
-  desktop. Bash-only scripts should be the exception, not the default.
+- PowerShell 7+ (`pwsh`) is the primary shell — matches the operator's
+  desktop. Target `pwsh`, **not** Windows PowerShell 5.1
+  (`powershell.exe`); give each script a `#requires -Version 7.0` so a
+  5.1 invocation fails fast. Bash-only scripts should be the exception,
+  not the default.
 - Per-clone / operator-specific values (ATAK SDK paths, real TAK
   server hostnames, callsign redaction lists) go in
   `scripts/config.json` (gitignored). A `scripts/config.example.json`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,8 @@
 
 Reusable PowerShell tooling for the TAK-XVoice dev + submission workflow. Everything here is generic across TAK plugins — plugin-specific values live in `scripts/config.json` (gitignored).
 
+These scripts target **PowerShell 7+ (`pwsh`)** — not Windows PowerShell 5.1 (`powershell.exe`). Each carries a `#requires -Version 7.0`, so a 5.1 invocation fails fast with a clear message; some also use 7-only cmdlet features (e.g. `Invoke-WebRequest -Form`/`-SkipCertificateCheck`). Run them as `pwsh ./scripts/<name>.ps1` (or just `./scripts/<name>.ps1` from a `pwsh` prompt). Get it via `winget install Microsoft.PowerShell` if it isn't installed.
+
 ## Setup, once per clone
 
 ```powershell

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,57 @@
+# scripts/
+
+Reusable PowerShell tooling for the TAK-XVoice dev + submission workflow. Everything here is generic across TAK plugins — plugin-specific values live in `scripts/config.json` (gitignored).
+
+## Setup, once per clone
+
+```powershell
+Copy-Item scripts/config.example.json scripts/config.json
+notepad scripts/config.json
+```
+
+Then edit the values to match your plugin. Every key is optional; falls back to the safe generic defaults in `scripts/lib/Read-Config.ps1` if omitted. Keys you'll almost certainly want to override: `pluginPackage`, `pluginShortName`, `productFlavor`, `sanityApkBaseName`, `sourceZipBaseName`, `sourceZipPrefix`, `defaultBaseline`, `tppBaselines`. Add any operator-specific redaction patterns to `forbiddenPatterns` (e.g. your real TAK server hostname, callsign lists).
+
+## `install-dev.ps1` — build the debug APK and install on connected phones
+
+Fans out to every authorized adb device so multi-device flashing takes one command.
+
+```powershell
+.\scripts\install-dev.ps1                        # build + install plugin on every attached device
+.\scripts\install-dev.ps1 -Baseline 5.6.0
+.\scripts\install-dev.ps1 -Serial <ID>           # single device
+.\scripts\install-dev.ps1 -Uninstall             # signing cert change (e.g. after replacing a TPP-signed install)
+.\scripts\install-dev.ps1 -SkipBuild             # reinstall the last-built APK
+
+.\scripts\install-dev.ps1 -InstallAtakDev        # install ATAK Developer edition from config.atakDevApkPath
+.\scripts\install-dev.ps1 -InstallAtakRelease    # install production/release ATAK from config.atakReleaseApkPath
+```
+
+The two `-InstallAtak*` switches are terminal — they install ATAK and exit without touching your plugin. Chain another invocation (no switches) to install the plugin afterward. Both variants uninstall any existing ATAK first because signing certs almost always differ between editions.
+
+`-InstallAtakDev` also flags a warning if the installed ATAK does NOT have the `DEBUGGABLE` flag set, which would mean the configured path doesn't actually point at the Developer edition.
+
+## `package-tpp.ps1` — build a TAK Product Portal submission bundle
+
+Produces the artifacts TPP consumes: source zips (the actual submission) plus sanity APKs (for local verification only).
+
+```powershell
+.\scripts\package-tpp.ps1                        # full bundle (source zips + sanity APKs)
+.\scripts\package-tpp.ps1 -SkipApkBuild          # source zips only (fast; skips ~1min of Gradle)
+.\scripts\package-tpp.ps1 -Baselines 5.6.0, 5.7.0
+.\scripts\package-tpp.ps1 -AllowDirtyTree        # override the clean-tree requirement
+```
+
+The load-bearing safety guarantee: source zips are built with `git archive HEAD`, which includes only tracked files. Anything gitignored (`logs/`, `.audio/`, `.logs/`, `.tmp/`, `diagnostics/`, `build/`, `.gradle/`, `keystore.properties`, `credentials`, `.env*`) is automatically excluded. Never use `zip -r`, `Compress-Archive`, or a GUI right-click — those tools ignore `.gitignore` and can leak field captures into a public submission (this happened, 2026-07-11).
+
+Every produced zip is then scanned in two passes and any hit refuses to declare the bundle ready:
+
+- **Path pass** — universal built-ins + your `config.forbiddenPatterns`, matched against every entry's *filename*. Catches leaked files (a stray logcat, an `.env`) by name.
+- **Content pass** — your `config.forbiddenPatterns` only, matched against the *text* of each tracked text file. Catches a real hostname / callsign / unit name embedded in a committed comment or fixture that the path pass would never see. Universal path shapes (`/logs/`, `credentials`, `.env`) are deliberately excluded here so legitimate source that merely mentions those words doesn't false-positive. Binary entries and files over 4 MB are path-scanned only.
+
+Config can add patterns, never remove them. Put anything operator-specific — your real TAK server hostname, callsign lists, unit names — in `config.forbiddenPatterns` so the content pass can catch it.
+
+Output goes to `build/tpp/`. `build/` is gitignored, so nothing accidentally lands in a commit — but it also gets wiped by `./gradlew clean`. If a submission spans days, copy the zips somewhere outside `build/` before running anything that could clean.
+
+## `lib/Read-Config.ps1`
+
+Shared config loader. Dot-source it (`. (Join-Path $repoRoot "scripts/lib/Read-Config.ps1")`) and call `Read-ScriptConfig -RepoRoot $repoRoot` to get a hashtable. Missing keys fall back to defaults. See the file for the full default list.

--- a/scripts/config.example.json
+++ b/scripts/config.example.json
@@ -1,0 +1,49 @@
+{
+  "_comment_": "Local config for the scripts in this directory. Copy to scripts/config.json (gitignored) and edit for your plugin/operator. Every key is optional. Scripts fall back to safe generic defaults; the values here are what TAK-XVoice's operator uses.",
+
+  "pluginPackage":     "com.atakmap.android.xv.plugin",
+  "pluginShortName":   "xv",
+  "productFlavor":     "civ",
+
+  "defaultBaseline":   "5.7.0",
+  "tppBaselines":      ["5.6.0", "5.7.0"],
+
+  "sourceZipPrefix":   "xv",
+  "sourceZipBaseName": "xv-tpp-source",
+  "sanityApkBaseName": "ATAK-Plugin-xv",
+
+  "_atak_apks_comment_": "Per-baseline paths used by install-dev.ps1's -InstallAtakDev / -InstallAtakRelease switches. Keyed by baseline (e.g. '5.6.0', '5.7.0') and selected by the -Baseline value at install time. atakDevApks should point at the atak.apk INSIDE the corresponding ATAK-CIV SDK bundle (Developer edition, DEBUGGABLE-flagged, accepts dev-signed plugins). atakReleaseApks should point at production/TPP-signed ATAK-CIV APKs (Play Store or civ-release from tak.gov). Leave an entry (or the whole hash) null / missing if you don't have that baseline on disk. Paths use POSIX slashes; %USERPROFILE% is a fine substitute for a hardcoded C:/Users/<user>.",
+  "atakDevApks": {
+    "5.6.0": "%USERPROFILE%/repos/ATAK-CIV-5.6.0.21-SDK/atak.apk",
+    "5.7.0": "%USERPROFILE%/repos/ATAK-CIV-5.7.0.10-SDK/atak.apk"
+  },
+  "atakReleaseApks": {
+    "5.6.0": null,
+    "5.7.0": null
+  },
+
+  "_atakPackage_comment_": "Android package name of ATAK itself. The CIV variant is com.atakmap.app.civ; other variants use different suffixes.",
+  "atakPackage":       "com.atakmap.app.civ",
+
+  "_forbiddenPatterns_comment_": "Regex patterns that must NEVER appear in a TPP source zip beyond the built-in universal list (.audio/, /logs/, .logs/, .tmp/, diagnostics/, /build/, keystore.properties, credentials, .env). Add anything operator-specific here: real TAK server hostnames, callsign lists, unit names.",
+  "forbiddenPatterns": [
+    "tak\\.example\\.com"
+  ],
+
+  "_takServer_comment_": "TAK / OpenTAK server upload settings used by scripts/upload-tak-plugin.ps1. Leave baseUrl null (or omit the whole takServer block) if you don't intend to upload from this machine. authMode is one of 'bearer', 'basic', 'mtls', or 'none'. Secrets live in env vars, not in this file — set the env var whose NAME is listed here (e.g. setx TAK_API_TOKEN <value>) and the script reads it at upload time. extraFormFields is a hash of extra multipart body fields; use {baseline} as a template placeholder that the script substitutes per upload.",
+  "takServer": {
+    "baseUrl":              "https://tak.example.com:8443",
+    "uploadPath":           "/api/plugins/upload",
+    "fileFieldName":        "file",
+    "authMode":             "bearer",
+    "tokenEnvVar":          "TAK_API_TOKEN",
+    "basicUser":            null,
+    "basicPassEnvVar":      null,
+    "clientCertPath":       null,
+    "clientCertPassEnvVar": null,
+    "insecureSkipTlsVerify": false,
+    "extraFormFields": {
+      "atakApiVersion": "{baseline}"
+    }
+  }
+}

--- a/scripts/install-dev.ps1
+++ b/scripts/install-dev.ps1
@@ -85,6 +85,18 @@ if (-not (Get-Command adb -ErrorAction SilentlyContinue)) {
     throw "adb not found on PATH. Install Android platform-tools and add them to PATH (e.g. %USERPROFILE%\Android\Sdk\platform-tools), then reopen the shell."
 }
 
+# First capture group of the first matching line, or "" if nothing
+# matches. dumpsys output varies across Android versions and often
+# repeats a field (versionName= appears more than once), so a raw
+# `(... | Select-String ...).Matches.Groups[1]` can both mis-index into
+# the wrong match and — on a missing field — surface a confusing error
+# right after a successful install. Degrade to blank instead.
+function Get-FirstMatch([object] $Text, [string] $Pattern) {
+    $m = $Text | Select-String -Pattern $Pattern | Select-Object -First 1
+    if ($m) { return $m.Matches[0].Groups[1].Value }
+    return ""
+}
+
 # -- 1. Enumerate authorized devices -----------------------------------
 
 # `adb devices` returns one row per attached device with a status:
@@ -156,9 +168,9 @@ if ($InstallAtakDev -or $InstallAtakRelease) {
         # Report installed state. Look for DEBUGGABLE flag to confirm
         # it's actually the dev edition when that was requested.
         $after = & adb -s $t shell dumpsys package $cfg.atakPackage 2>$null
-        $ver   = ($after | Select-String -Pattern 'versionName=(\S+)').Matches.Groups[1].Value
-        $sig   = ($after | Select-String -Pattern 'signatures:\[([0-9a-f]+)\]').Matches.Groups[1].Value
-        $flags = ($after | Select-String -Pattern 'flags=\[([^\]]+)\]').Matches.Groups[1].Value
+        $ver   = Get-FirstMatch $after 'versionName=(\S+)'
+        $sig   = Get-FirstMatch $after 'signatures:\[([0-9a-f]+)\]'
+        $flags = Get-FirstMatch $after 'flags=\[([^\]]+)\]'
         $isDbg = $flags -match "DEBUGGABLE"
 
         Write-Host "  Installed: $ver  sig=$sig  DEBUGGABLE=$isDbg" -ForegroundColor Green
@@ -204,8 +216,8 @@ foreach ($t in $targets) {
 
     $existing = & adb -s $t shell dumpsys package $cfg.pluginPackage 2>$null
     if ($existing) {
-        $exVer  = ($existing | Select-String -Pattern 'versionName=(\S+)').Matches.Groups[1].Value
-        $exSig  = ($existing | Select-String -Pattern 'signatures:\[([0-9a-f]+)\]').Matches.Groups[1].Value
+        $exVer  = Get-FirstMatch $existing 'versionName=(\S+)'
+        $exSig  = Get-FirstMatch $existing 'signatures:\[([0-9a-f]+)\]'
         Write-Host "  Currently installed: $exVer sig=$exSig" -ForegroundColor DarkGray
     } else {
         Write-Host "  Plugin not yet installed on this device." -ForegroundColor DarkGray
@@ -230,9 +242,9 @@ foreach ($t in $targets) {
 
     $after = & adb -s $t shell dumpsys package $cfg.pluginPackage 2>$null
     if ($after) {
-        $ver  = ($after | Select-String -Pattern 'versionName=(\S+)').Matches.Groups[1].Value
-        $vc   = ($after | Select-String -Pattern 'versionCode=(\d+)').Matches.Groups[1].Value
-        $sigs = ($after | Select-String -Pattern 'signatures:\[([0-9a-f]+)\]').Matches.Groups[1].Value
+        $ver  = Get-FirstMatch $after 'versionName=(\S+)'
+        $vc   = Get-FirstMatch $after 'versionCode=(\d+)'
+        $sigs = Get-FirstMatch $after 'signatures:\[([0-9a-f]+)\]'
         Write-Host "  Installed: $ver (vc=$vc) sig=$sigs" -ForegroundColor Green
         $results += [PSCustomObject]@{ Serial = $t; Status = "OK"; Version = $ver; Sig = $sigs }
     } else {

--- a/scripts/install-dev.ps1
+++ b/scripts/install-dev.ps1
@@ -1,4 +1,5 @@
 #!/usr/bin/env pwsh
+#requires -Version 7.0
 # scripts/install-dev.ps1
 #
 # Build the current branch's debug APK and install it on every

--- a/scripts/install-dev.ps1
+++ b/scripts/install-dev.ps1
@@ -1,0 +1,250 @@
+#!/usr/bin/env pwsh
+# scripts/install-dev.ps1
+#
+# Build the current branch's debug APK and install it on every
+# connected + authorized Android device. Also supports installing ATAK
+# itself (Developer or Release edition) for phone-prep workflows.
+#
+# Configuration (all keys optional) lives in scripts/config.json —
+# copy scripts/config.example.json and edit. See scripts/lib/Read-Config.ps1
+# for the fallback defaults if no config is present.
+#
+# Prerequisites:
+#   - At least one adb device with USB debugging authorized. The script
+#     installs to EVERY authorized device it sees so you can flash
+#     several phones in one shot. Use -Serial to target one.
+#   - For the plugin install path: ATAK-CIV Developer edition already
+#     on the phone. The debug plugin APK only loads on the Developer
+#     edition (DEBUGGABLE flag set). If not, run -InstallAtakDev first.
+#
+# Common invocations:
+#   .\scripts\install-dev.ps1                   # build + install plugin on every attached device
+#   .\scripts\install-dev.ps1 -Baseline 5.6.0
+#   .\scripts\install-dev.ps1 -Serial <ID>      # single device
+#   .\scripts\install-dev.ps1 -Uninstall        # signing cert change (e.g. after TPP-signed install)
+#   .\scripts\install-dev.ps1 -SkipBuild        # reinstall the last-built APK
+#   .\scripts\install-dev.ps1 -InstallAtakDev                 # install Dev ATAK for defaultBaseline
+#   .\scripts\install-dev.ps1 -InstallAtakDev -Baseline 5.6.0 # install the 5.6 Dev ATAK
+#   .\scripts\install-dev.ps1 -InstallAtakRelease -Baseline 5.7.0
+#
+# Notes:
+#   - versionCode / versionName are NEVER bumped by this script — dev
+#     iteration is tracked by lastUpdateTime + commit SHA, not by
+#     incrementing version fields.
+#   - -InstallAtakDev and -InstallAtakRelease are terminal: they install
+#     ATAK and exit without touching the plugin. Chain another invocation
+#     without them to install the plugin afterward.
+#   - Per-baseline ATAK APK paths live in config.atakDevApks /
+#     config.atakReleaseApks (hash keyed by baseline). -Baseline picks
+#     which entry to use, so multi-SDK setups (5.6 + 5.7 in parallel)
+#     work with a single script invocation each.
+
+[CmdletBinding()]
+param(
+    # ATAK baseline to build against. Defaults to config.defaultBaseline.
+    [string] $Baseline,
+
+    # Uninstall the plugin first. Required when the signing cert has
+    # changed (e.g. moving from a TPP-signed release install to a
+    # locally dev-signed debug install). Loses plugin prefs / data.
+    [switch] $Uninstall,
+
+    # Skip the Gradle build and reinstall the last-built APK.
+    [switch] $SkipBuild,
+
+    # Optional single-device targeting. Without this, the script fans
+    # out to every authorized device. Pass the serial from `adb devices`.
+    [string] $Serial,
+
+    # Install the ATAK-CIV Developer edition APK (from config.atakDevApks,
+    # keyed by -Baseline) on the target devices instead of the plugin.
+    # Uninstalls any existing ATAK first because the signing cert almost
+    # always differs.
+    [switch] $InstallAtakDev,
+
+    # Install a production/release ATAK-CIV APK (from config.atakReleaseApks,
+    # keyed by -Baseline) instead of the plugin. Same uninstall-first behavior.
+    [switch] $InstallAtakRelease
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+Set-Location $repoRoot
+
+. (Join-Path $repoRoot "scripts/lib/Read-Config.ps1")
+$cfg = Read-ScriptConfig -RepoRoot $repoRoot
+
+if (-not $Baseline) { $Baseline = $cfg.defaultBaseline }
+
+if ($InstallAtakDev -and $InstallAtakRelease) {
+    throw "-InstallAtakDev and -InstallAtakRelease are mutually exclusive."
+}
+
+if (-not (Get-Command adb -ErrorAction SilentlyContinue)) {
+    throw "adb not found on PATH. Install Android platform-tools and add them to PATH (e.g. %USERPROFILE%\Android\Sdk\platform-tools), then reopen the shell."
+}
+
+# -- 1. Enumerate authorized devices -----------------------------------
+
+# `adb devices` returns one row per attached device with a status:
+# "device" = authorized, "unauthorized" = accepted USB but RSA not
+# yet approved, "offline" = flaky USB. We only want authorized.
+$authorized = @(& adb devices 2>$null |
+    Select-Object -Skip 1 |
+    Where-Object { $_ -match '^(\S+)\s+device\s*$' } |
+    ForEach-Object { ($_ -split '\s+')[0] })
+
+if ($Serial) {
+    if ($authorized -notcontains $Serial) {
+        Write-Host "Authorized devices seen by adb:" -ForegroundColor Yellow
+        $authorized | ForEach-Object { Write-Host "  $_" -ForegroundColor Yellow }
+        throw "Requested serial '$Serial' is not authorized. Check the phone screen for a USB-debug authorization prompt."
+    }
+    $targets = @($Serial)
+} else {
+    $targets = $authorized
+}
+
+if (-not $targets -or $targets.Count -eq 0) {
+    throw "No authorized adb devices. Plug in a phone, enable USB debugging, and authorize this computer's RSA key."
+}
+
+Write-Host "Targeting $($targets.Count) device(s): $($targets -join ', ')" -ForegroundColor Cyan
+
+# -- 2. ATAK-install path (terminal — no plugin work after) -------------
+
+if ($InstallAtakDev -or $InstallAtakRelease) {
+    $bucket  = if ($InstallAtakDev) { $cfg.atakDevApks } else { $cfg.atakReleaseApks }
+    $label   = if ($InstallAtakDev) { "ATAK Developer edition" } else { "ATAK Release/production" }
+    $key     = if ($InstallAtakDev) { "atakDevApks" } else { "atakReleaseApks" }
+
+    if (-not $bucket -or $bucket.Count -eq 0) {
+        throw "No paths configured under $key in scripts/config.json. Add at least one baseline entry, e.g. { `"$Baseline`": `"path/to/atak.apk`" }."
+    }
+    $apkPath = $bucket[$Baseline]
+    if (-not $apkPath) {
+        $available = ($bucket.Keys | Sort-Object) -join ", "
+        throw "No $label APK configured for baseline '$Baseline' under $key in scripts/config.json. Available: [$available]. Add an entry for '$Baseline' or pass a different -Baseline."
+    }
+    if (-not (Test-Path $apkPath)) {
+        throw "$label APK for baseline '$Baseline' not found at: $apkPath"
+    }
+    Write-Host "`nInstalling $label for baseline $Baseline from $apkPath" -ForegroundColor Cyan
+
+    $results = @()
+    foreach ($t in $targets) {
+        Write-Host "`n=== $t ===" -ForegroundColor Cyan
+
+        # Uninstall existing ATAK — variants have different signing
+        # certs so a plain `install -r` typically fails.
+        $existing = & adb -s $t shell pm list packages $cfg.atakPackage 2>$null
+        if ($existing) {
+            Write-Host "  Uninstalling existing $($cfg.atakPackage)..." -ForegroundColor DarkGray
+            & adb -s $t uninstall $cfg.atakPackage | Out-Null
+        }
+
+        Write-Host "  Installing..." -ForegroundColor Cyan
+        $installOut = & adb -s $t install -r $apkPath 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "  FAILED:" -ForegroundColor Red
+            $installOut | ForEach-Object { Write-Host "    $_" -ForegroundColor Red }
+            $results += [PSCustomObject]@{ Serial = $t; Status = "FAILED" }
+            continue
+        }
+
+        # Report installed state. Look for DEBUGGABLE flag to confirm
+        # it's actually the dev edition when that was requested.
+        $after = & adb -s $t shell dumpsys package $cfg.atakPackage 2>$null
+        $ver   = ($after | Select-String -Pattern 'versionName=(\S+)').Matches.Groups[1].Value
+        $sig   = ($after | Select-String -Pattern 'signatures:\[([0-9a-f]+)\]').Matches.Groups[1].Value
+        $flags = ($after | Select-String -Pattern 'flags=\[([^\]]+)\]').Matches.Groups[1].Value
+        $isDbg = $flags -match "DEBUGGABLE"
+
+        Write-Host "  Installed: $ver  sig=$sig  DEBUGGABLE=$isDbg" -ForegroundColor Green
+        if ($InstallAtakDev -and -not $isDbg) {
+            Write-Host "  WARNING: -InstallAtakDev requested but DEBUGGABLE flag is NOT set. This APK is not the Developer edition." -ForegroundColor Yellow
+        }
+        if ($InstallAtakRelease -and $isDbg) {
+            Write-Host "  WARNING: -InstallAtakRelease requested but DEBUGGABLE flag IS set. This APK looks like the Developer edition, not Release." -ForegroundColor Yellow
+        }
+        $results += [PSCustomObject]@{ Serial = $t; Status = "OK"; Version = $ver; Debuggable = $isDbg }
+    }
+
+    Write-Host "`n=== Summary ===" -ForegroundColor Cyan
+    $results | Format-Table -AutoSize
+    $failed = @($results | Where-Object { $_.Status -ne "OK" })
+    if ($failed.Count -gt 0) { exit 1 }
+    return
+}
+
+# -- 3. Plugin install path ---------------------------------------------
+
+$branch = (& git rev-parse --abbrev-ref HEAD).Trim()
+$sha    = (& git rev-parse --short HEAD).Trim()
+Write-Host "Building from $branch @ $sha (baseline=$Baseline)" -ForegroundColor Cyan
+
+if (-not $SkipBuild) {
+    Write-Host "`nGradle assemble$([char]::ToUpper($cfg.productFlavor[0]) + $cfg.productFlavor.Substring(1))Debug..." -ForegroundColor Cyan
+    $flavorCap = [char]::ToUpper($cfg.productFlavor[0]) + $cfg.productFlavor.Substring(1)
+    & ".\gradlew.bat" "-PatakBaselineVersion=$Baseline" "assemble${flavorCap}Debug" --console=plain
+    if ($LASTEXITCODE -ne 0) { throw "assemble${flavorCap}Debug failed" }
+}
+
+$apk = "app/build/outputs/apk/$($cfg.productFlavor)/debug/app-$($cfg.productFlavor)-debug.apk"
+if (-not (Test-Path $apk)) {
+    throw "APK not found at $apk — build must produce it before install can run."
+}
+
+# -- 4. Fan out to every target device --------------------------------
+
+$results = @()
+foreach ($t in $targets) {
+    Write-Host "`n=== $t ===" -ForegroundColor Cyan
+
+    $existing = & adb -s $t shell dumpsys package $cfg.pluginPackage 2>$null
+    if ($existing) {
+        $exVer  = ($existing | Select-String -Pattern 'versionName=(\S+)').Matches.Groups[1].Value
+        $exSig  = ($existing | Select-String -Pattern 'signatures:\[([0-9a-f]+)\]').Matches.Groups[1].Value
+        Write-Host "  Currently installed: $exVer sig=$exSig" -ForegroundColor DarkGray
+    } else {
+        Write-Host "  Plugin not yet installed on this device." -ForegroundColor DarkGray
+    }
+
+    if ($Uninstall -and $existing) {
+        Write-Host "  Uninstalling old plugin (signing cert change expected)..." -ForegroundColor DarkGray
+        & adb -s $t uninstall $cfg.pluginPackage | Out-Null
+    }
+
+    Write-Host "  Installing $apk..." -ForegroundColor Cyan
+    $installOut = & adb -s $t install -r $apk 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "  FAILED:" -ForegroundColor Red
+        $installOut | ForEach-Object { Write-Host "    $_" -ForegroundColor Red }
+        if ($installOut -match "INSTALL_FAILED_UPDATE_INCOMPATIBLE") {
+            Write-Host "  Signing cert mismatch — re-run with -Uninstall to drop the existing cert first." -ForegroundColor Yellow
+        }
+        $results += [PSCustomObject]@{ Serial = $t; Status = "FAILED"; Version = ""; Sig = "" }
+        continue
+    }
+
+    $after = & adb -s $t shell dumpsys package $cfg.pluginPackage 2>$null
+    if ($after) {
+        $ver  = ($after | Select-String -Pattern 'versionName=(\S+)').Matches.Groups[1].Value
+        $vc   = ($after | Select-String -Pattern 'versionCode=(\d+)').Matches.Groups[1].Value
+        $sigs = ($after | Select-String -Pattern 'signatures:\[([0-9a-f]+)\]').Matches.Groups[1].Value
+        Write-Host "  Installed: $ver (vc=$vc) sig=$sigs" -ForegroundColor Green
+        $results += [PSCustomObject]@{ Serial = $t; Status = "OK"; Version = $ver; Sig = $sigs }
+    } else {
+        Write-Host "  Installed but dumpsys can't find the plugin — unusual." -ForegroundColor Yellow
+        $results += [PSCustomObject]@{ Serial = $t; Status = "UNVERIFIED"; Version = ""; Sig = "" }
+    }
+}
+
+# -- 5. Summary --------------------------------------------------------
+
+Write-Host "`n=== Summary ===" -ForegroundColor Cyan
+$results | Format-Table -AutoSize
+Write-Host "Source: $branch @ $sha (baseline $Baseline)" -ForegroundColor Cyan
+
+$failed = @($results | Where-Object { $_.Status -ne "OK" })
+if ($failed.Count -gt 0) { exit 1 }

--- a/scripts/lib/Read-Config.ps1
+++ b/scripts/lib/Read-Config.ps1
@@ -1,3 +1,4 @@
+#requires -Version 7.0
 # scripts/lib/Read-Config.ps1
 #
 # Shared config loader for scripts/*.ps1. Dot-source, then call

--- a/scripts/lib/Read-Config.ps1
+++ b/scripts/lib/Read-Config.ps1
@@ -91,7 +91,12 @@ function Read-ScriptConfig {
     #                              mentioning "credentials" is not a leak.
     $userForbidden = @()
     if ($userCfg.ContainsKey("forbiddenPatterns")) {
-        $userForbidden = @($userCfg["forbiddenPatterns"])
+        # Drop null / blank entries. A "" left in the list joins into the
+        # scan regex as an empty alternative ('a||b'), and -match "" is
+        # always true — every zip entry would report as tainted, a false
+        # alarm that's maddening to trace back to one stray comma.
+        $userForbidden = @($userCfg["forbiddenPatterns"] |
+            Where-Object { $_ -is [string] -and $_.Trim() -ne "" })
     }
     $merged.forbiddenPatterns        = @($universalForbidden + $userForbidden | Select-Object -Unique)
     $merged.contentForbiddenPatterns = @($userForbidden | Select-Object -Unique)

--- a/scripts/lib/Read-Config.ps1
+++ b/scripts/lib/Read-Config.ps1
@@ -1,0 +1,125 @@
+# scripts/lib/Read-Config.ps1
+#
+# Shared config loader for scripts/*.ps1. Dot-source, then call
+# Read-ScriptConfig to get a hashtable of merged (config.json ⊕
+# defaults) values. Missing keys fall back to the default. Missing
+# config file falls back to all-defaults (so first-clone-on-fresh-repo
+# just works for the operator who owns the shipped defaults).
+#
+# Universal forbidden patterns are hardcoded here rather than in
+# config so an operator can't accidentally weaken the sensitive-content
+# guardrails by editing their local config. Config's forbiddenPatterns
+# is *added* to the universal list; there is no path to remove one.
+
+function Read-ScriptConfig {
+    param(
+        [string] $RepoRoot
+    )
+
+    $configPath = Join-Path $RepoRoot "scripts/config.json"
+    $userCfg    = @{}
+    if (Test-Path $configPath) {
+        try {
+            $raw = Get-Content -Raw $configPath | ConvertFrom-Json
+        } catch {
+            throw "scripts/config.json is not valid JSON: $($_.Exception.Message) — fix it or delete it to fall back to defaults (see scripts/config.example.json)."
+        }
+        # Convert PSCustomObject to hashtable and strip _comment_ keys.
+        foreach ($p in $raw.PSObject.Properties) {
+            if ($p.Name -notlike "_*_") {
+                $userCfg[$p.Name] = $p.Value
+            }
+        }
+    }
+
+    $defaults = @{
+        pluginPackage      = "com.atakmap.android.example.plugin"
+        pluginShortName    = "example"
+        productFlavor      = "civ"
+        defaultBaseline    = "5.7.0"
+        tppBaselines       = @("5.6.0", "5.7.0")
+        sourceZipPrefix    = "plugin"
+        sourceZipBaseName  = "plugin-tpp-source"
+        sanityApkBaseName  = "ATAK-Plugin-example"
+        atakPackage        = "com.atakmap.app.civ"
+        atakDevApks        = @{}
+        atakReleaseApks    = @{}
+        forbiddenPatterns  = @()
+        takServer          = $null
+    }
+
+    # Universal patterns — always applied on top of whatever config
+    # adds. Anything a TAK plugin operator would categorically want to
+    # keep out of a TPP submission zip.
+    $universalForbidden = @(
+        '\.audio/',
+        '/logs/',
+        '\.logs/',
+        '\.tmp/',
+        'diagnostics/',
+        '/build/',
+        'keystore\.properties',
+        'credentials',
+        '\.env$', '\.env\.'
+    )
+
+    $merged = @{}
+    foreach ($k in $defaults.Keys) {
+        if ($userCfg.ContainsKey($k)) {
+            $merged[$k] = $userCfg[$k]
+        } else {
+            $merged[$k] = $defaults[$k]
+        }
+    }
+
+    # Special-case forbiddenPatterns: union of config + universal.
+    #
+    # Two consumers, two scopes:
+    #   forbiddenPatterns        — universal ∪ operator. Matched against
+    #                              zip *entry paths* (filename leaks like
+    #                              a stray logcat). The universal list is
+    #                              path-shaped ('/logs/', '.env', ...) and
+    #                              would false-positive against source
+    #                              text, so it is path-scan only.
+    #   contentForbiddenPatterns — operator patterns only. Matched against
+    #                              text-file *content* inside the zip
+    #                              (a real hostname / callsign embedded in
+    #                              a tracked comment or fixture). Universal
+    #                              path shapes are deliberately excluded
+    #                              here — a source file legitimately
+    #                              mentioning "credentials" is not a leak.
+    $userForbidden = @()
+    if ($userCfg.ContainsKey("forbiddenPatterns")) {
+        $userForbidden = @($userCfg["forbiddenPatterns"])
+    }
+    $merged.forbiddenPatterns        = @($universalForbidden + $userForbidden | Select-Object -Unique)
+    $merged.contentForbiddenPatterns = @($userForbidden | Select-Object -Unique)
+
+    # atakDevApks / atakReleaseApks: normalize from PSCustomObject to
+    # hashtable + expand env vars like %USERPROFILE% in each value so
+    # config.json can stay generic. Missing baselines just return $null.
+    foreach ($k in @("atakDevApks", "atakReleaseApks")) {
+        $expanded = @{}
+        $raw = $merged[$k]
+        if ($raw -is [PSCustomObject]) {
+            foreach ($p in $raw.PSObject.Properties) {
+                if ($null -ne $p.Value) {
+                    $expanded[$p.Name] = [Environment]::ExpandEnvironmentVariables($p.Value)
+                } else {
+                    $expanded[$p.Name] = $null
+                }
+            }
+        } elseif ($raw -is [hashtable]) {
+            foreach ($kk in $raw.Keys) {
+                if ($null -ne $raw[$kk]) {
+                    $expanded[$kk] = [Environment]::ExpandEnvironmentVariables($raw[$kk])
+                } else {
+                    $expanded[$kk] = $null
+                }
+            }
+        }
+        $merged[$k] = $expanded
+    }
+
+    return $merged
+}

--- a/scripts/package-tpp.ps1
+++ b/scripts/package-tpp.ps1
@@ -1,0 +1,290 @@
+#!/usr/bin/env pwsh
+# scripts/package-tpp.ps1
+#
+# Build a TAK Product Portal (TPP) submission bundle from the current HEAD.
+#
+# Per-plugin/operator values (package name, filename prefix, baselines,
+# forbidden-content patterns) live in scripts/config.json — copy
+# scripts/config.example.json and edit. See scripts/lib/Read-Config.ps1
+# for the fallback defaults.
+#
+# What lands in build/tpp/ :
+#
+#   <sourceZipBaseName>-<versionName>-<baseline>.zip   (one per baseline)
+#     The actual TPP submission artifact — a source zip that TPP's
+#     third-party pipeline builds and signs on their side.
+#     Built with `git archive HEAD`, which includes ONLY tracked files.
+#     Everything gitignored (logs/, .audio/, .logs/, .tmp/, diagnostics/,
+#     build/, .gradle/, keystore.properties, credentials, .env*) is
+#     automatically excluded — the load-bearing safety net that stops
+#     operator field captures from leaking into a submission.
+#
+#   <sanityApkBaseName>-<versionName>-<baseline>-<flavor>-release.apk (sanity only)
+#     Unsigned civ-release APKs, built as a local sanity check that
+#     the source builds cleanly. DO NOT SUBMIT — TPP applies the
+#     Untrusted Plugin Release cert on their side from the source zip.
+#     Skip with -SkipApkBuild if you only need source zips.
+#
+# Post-build sanity check greps every source zip for forbidden content
+# patterns (universal built-in list + config.forbiddenPatterns). If ANY
+# match, the script errors out and refuses to treat the bundle as ready.
+# Motivating incident: 2026-07-11 TPP submission included ~175 MB of
+# raw field logcats and mumble recordings whose filenames leaked the
+# operator's real TAK server hostname and callsigns, because the zip
+# was built with a tool that ignored .gitignore. Never again.
+
+[CmdletBinding()]
+param(
+    # Baselines to produce zips + sanity APKs for. Defaults to
+    # config.tppBaselines.
+    [string[]] $Baselines,
+
+    # Skip the local sanity APK build (source zips only).
+    [switch]   $SkipApkBuild,
+
+    # Allow building from a dirty working tree. Off by default because
+    # a TPP submission that doesn't match HEAD is hard to reproduce.
+    [switch]   $AllowDirtyTree
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+Set-Location $repoRoot
+
+. (Join-Path $repoRoot "scripts/lib/Read-Config.ps1")
+$cfg = Read-ScriptConfig -RepoRoot $repoRoot
+
+if (-not $Baselines -or $Baselines.Count -eq 0) { $Baselines = $cfg.tppBaselines }
+
+$flavor    = $cfg.productFlavor
+$flavorCap = [char]::ToUpper($flavor[0]) + $flavor.Substring(1)
+
+# -- 1. Git state sanity ------------------------------------------------
+
+$dirty = & git status --porcelain
+if ($LASTEXITCODE -ne 0) {
+    throw "git status failed — is this a git checkout?"
+}
+if ($dirty -and -not $AllowDirtyTree) {
+    Write-Host "Working tree has uncommitted changes:" -ForegroundColor Red
+    $dirty | ForEach-Object { Write-Host "  $_" -ForegroundColor Red }
+    throw "Commit or stash before packaging TPP. Override with -AllowDirtyTree only if you know what you're doing."
+}
+
+$branch = (& git rev-parse --abbrev-ref HEAD).Trim()
+$sha    = (& git rev-parse HEAD).Trim()
+
+if ($branch -ne "main" -and -not $AllowDirtyTree) {
+    Write-Host "WARNING: not on main (currently on '$branch'). TPP submissions usually come off main." -ForegroundColor Yellow
+    Write-Host "         Continuing because HEAD is clean; pass -AllowDirtyTree to silence this note.`n" -ForegroundColor Yellow
+}
+
+Write-Host "Building TPP bundle from $branch @ $sha" -ForegroundColor Cyan
+
+# -- 2. Read versionName from app/build.gradle.kts ----------------------
+
+$buildGradle = Get-Content -Raw "app/build.gradle.kts"
+if ($buildGradle -notmatch 'versionName\s*=\s*"([^"]+)"') {
+    throw "Could not read versionName from app/build.gradle.kts"
+}
+$versionName = $matches[1]
+Write-Host "versionName = $versionName  (flavor=$flavor, prefix=$($cfg.sourceZipPrefix))" -ForegroundColor Cyan
+
+# -- 3. Output dir ------------------------------------------------------
+
+$out = Join-Path $repoRoot "build/tpp"
+New-Item -ItemType Directory -Force -Path $out | Out-Null
+
+function Get-BaselineShort([string]$b) {
+    ($b -split '\.')[0..1] -join '.'
+}
+
+# -- 4. Source zips (git archive + per-baseline gradle.properties patch)
+
+# TPP runs `./gradlew assemble<Flavor>Release` on a clean checkout of
+# whatever we submit — it never sees a `-P` CLI override. So each
+# baseline's zip needs its own `gradle.properties` with
+# `atakBaselineVersion=<baseline>` baked in. Otherwise TPP falls back
+# to the checked-in default and produces the wrong-baseline APK (this
+# happened 2026-07-13: both submissions returned 5.6.0-baseline APKs
+# despite the intent being 5.6 + 5.7).
+
+$baseZip = Join-Path $out "_base-source.tmp.zip"
+Write-Host "`nBuilding base source zip via git archive HEAD..." -ForegroundColor Cyan
+& git archive --format=zip --prefix="$($cfg.sourceZipPrefix)/" HEAD -o $baseZip
+if ($LASTEXITCODE -ne 0) {
+    throw "git archive failed"
+}
+
+$gradlePropsEntry = "$($cfg.sourceZipPrefix)/gradle.properties"
+foreach ($b in $Baselines) {
+    $short   = Get-BaselineShort $b
+    $zipPath = Join-Path $out "$($cfg.sourceZipBaseName)-$versionName-$short.zip"
+    Copy-Item $baseZip $zipPath -Force
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $zip = [System.IO.Compression.ZipFile]::Open($zipPath, [System.IO.Compression.ZipArchiveMode]::Update)
+    try {
+        $entry = $zip.GetEntry($gradlePropsEntry)
+        if (-not $entry) {
+            throw "Expected entry '$gradlePropsEntry' not found in the source zip. Adjust sourceZipPrefix in scripts/config.json or add a repo-root gradle.properties."
+        }
+
+        # Read existing content.
+        $stream = $entry.Open()
+        $sr = New-Object System.IO.StreamReader($stream)
+        $content = $sr.ReadToEnd()
+        $sr.Dispose()
+
+        # Replace atakBaselineVersion line, or append if not present.
+        if ($content -match '(?m)^atakBaselineVersion=.*$') {
+            $content = [regex]::Replace($content, '(?m)^atakBaselineVersion=.*$', "atakBaselineVersion=$b")
+        } else {
+            $content = $content.TrimEnd() + "`natakBaselineVersion=$b`n"
+        }
+
+        # Overwrite entry: delete + recreate. .NET's ZipArchive doesn't
+        # expose in-place content replacement so this is the sanctioned
+        # pattern.
+        $entry.Delete()
+        $newEntry = $zip.CreateEntry($gradlePropsEntry)
+        $ws = $newEntry.Open()
+        $sw = New-Object System.IO.StreamWriter($ws)
+        $sw.Write($content)
+        $sw.Dispose()
+    } finally {
+        $zip.Dispose()
+    }
+    Write-Host "  patched atakBaselineVersion=$b → $(Split-Path $zipPath -Leaf)" -ForegroundColor DarkGray
+}
+
+Remove-Item $baseZip -Force
+
+# -- 5. Sensitive-content sanity check ----------------------------------
+
+# Two passes, per Read-Config.ps1:
+#   PATH pass    — universal ∪ operator patterns vs every entry's name.
+#                  Catches leaked files by filename (the 2026-07-11
+#                  logcat/mumble-recording incident).
+#   CONTENT pass — operator patterns only vs the text of each tracked
+#                  text file. Catches a real hostname / callsign / unit
+#                  name embedded in a committed comment or fixture, which
+#                  the path pass would never see. Universal path shapes
+#                  ('/logs/', 'credentials', '.env') are excluded from
+#                  this pass on purpose — legitimate source routinely
+#                  contains those words and would false-positive.
+$pathRe    = $cfg.forbiddenPatterns -join '|'
+$contentRe = if ($cfg.contentForbiddenPatterns.Count -gt 0) { $cfg.contentForbiddenPatterns -join '|' } else { $null }
+
+# Only text-like entries are content-scanned. Binaries (images, the
+# gradle wrapper jar, fonts) are skipped — they can't carry a
+# human-readable operator string and would waste time / trip the NUL
+# guard. Anything not on this list still gets a NUL-byte sniff before
+# being treated as text.
+$textExt = @(
+    '.kt', '.kts', '.java', '.xml', '.json', '.gradle', '.properties',
+    '.txt', '.md', '.pro', '.cfg', '.yml', '.yaml', '.gitignore',
+    '.gitattributes', '.ps1', '.sh', '.bat', '.py', '.html'
+)
+$maxScanBytes = 4MB
+
+function Test-EntryIsText([System.IO.Compression.ZipArchiveEntry]$entry, [byte[]]$bytes) {
+    $ext = [IO.Path]::GetExtension($entry.Name).ToLower()
+    if ($textExt -contains $ext) { return $true }
+    if ([string]::IsNullOrEmpty($ext)) {
+        # Extensionless tracked files (LICENSE, gradlew, Dockerfile...) —
+        # sniff for a NUL byte in the first 8 KB; NUL ⇒ binary.
+        $probe = [Math]::Min($bytes.Length, 8192)
+        for ($i = 0; $i -lt $probe; $i++) { if ($bytes[$i] -eq 0) { return $false } }
+        return $true
+    }
+    return $false
+}
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+Write-Host "`nSanity-checking source zips (path + content)..." -ForegroundColor Cyan
+$anyBad = $false
+foreach ($z in Get-ChildItem "$out/$($cfg.sourceZipBaseName)-$versionName-*.zip") {
+    $badPaths   = @()
+    $badContent = @()
+    $zip = $null
+    try {
+        $zip = [System.IO.Compression.ZipFile]::OpenRead($z.FullName)
+        foreach ($e in $zip.Entries) {
+            if ($e.FullName -match $pathRe) {
+                $badPaths += $e.FullName
+            }
+            # Directory entries and oversized blobs: path-scan only.
+            if (-not $contentRe -or $e.Length -eq 0 -or $e.Length -gt $maxScanBytes) { continue }
+
+            $ms = New-Object System.IO.MemoryStream
+            $es = $e.Open()
+            try { $es.CopyTo($ms) } finally { $es.Dispose() }
+            $bytes = $ms.ToArray()
+            $ms.Dispose()
+
+            if (-not (Test-EntryIsText $e $bytes)) { continue }
+            $text = [System.Text.Encoding]::UTF8.GetString($bytes)
+            foreach ($m in [regex]::Matches($text, $contentRe)) {
+                $badContent += "$($e.FullName): matched /$($m.Value)/"
+            }
+        }
+    } finally {
+        if ($zip) { $zip.Dispose() }
+    }
+
+    if ($badPaths.Count -gt 0 -or $badContent.Count -gt 0) {
+        Write-Host "  TAINTED: $($z.Name)" -ForegroundColor Red
+        if ($badPaths.Count -gt 0) {
+            Write-Host "    forbidden PATHS:" -ForegroundColor Red
+            $badPaths | Select-Object -First 10 | ForEach-Object { Write-Host "      $_" -ForegroundColor Red }
+            if ($badPaths.Count -gt 10) { Write-Host "      ... $($badPaths.Count - 10) more" -ForegroundColor Red }
+        }
+        if ($badContent.Count -gt 0) {
+            Write-Host "    forbidden CONTENT:" -ForegroundColor Red
+            $badContent | Select-Object -First 10 | ForEach-Object { Write-Host "      $_" -ForegroundColor Red }
+            if ($badContent.Count -gt 10) { Write-Host "      ... $($badContent.Count - 10) more" -ForegroundColor Red }
+        }
+        $anyBad = $true
+    } else {
+        Write-Host "  clean:   $($z.Name)" -ForegroundColor Green
+    }
+}
+if ($anyBad) {
+    throw "Sensitive content found in source zips. Do NOT submit. Investigate .gitignore coverage and forbiddenPatterns in scripts/config.json."
+}
+
+# -- 6. Sanity APK build (optional) -------------------------------------
+
+if (-not $SkipApkBuild) {
+    foreach ($b in $Baselines) {
+        Write-Host "`nBuilding $flavor-release APK for baseline $b (sanity only, not for submission)..." -ForegroundColor Cyan
+
+        # `clean` deletes app/build/empty-atak-proguard-mapping.txt that
+        # build.gradle.kts writes at config time. R8 then can't find it.
+        # Fix: split clean and assemble into separate Gradle invocations
+        # so the config pass runs again before R8 executes.
+        & ".\gradlew.bat" clean
+        if ($LASTEXITCODE -ne 0) { throw "gradle clean failed" }
+
+        & ".\gradlew.bat" "-PatakBaselineVersion=$b" "assemble${flavorCap}Release"
+        if ($LASTEXITCODE -ne 0) { throw "assemble${flavorCap}Release failed for baseline $b" }
+
+        $apk = "app/build/outputs/apk/$flavor/release/$($cfg.sanityApkBaseName)-$versionName-$b-$flavor-release.apk"
+        if (-not (Test-Path $apk)) {
+            throw "Expected APK not found: $apk"
+        }
+        Copy-Item $apk (Join-Path $out (Split-Path -Leaf $apk)) -Force
+    }
+}
+
+# -- 7. Summary + SHA-256 -----------------------------------------------
+
+Write-Host "`n=== TPP bundle ===" -ForegroundColor Cyan
+Get-ChildItem $out | Sort-Object Name | ForEach-Object {
+    $h = (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLower()
+    ("  {0,10:N0}  {1}" -f $_.Length, $_.Name) | Write-Host
+    Write-Host ("              sha256: $h") -ForegroundColor DarkGray
+}
+Write-Host "`nSource: $branch @ $sha" -ForegroundColor Cyan
+Write-Host "Submit the .zip files to the TPP portal. The .apk files are LOCAL SANITY ONLY, not for submission." -ForegroundColor Green

--- a/scripts/package-tpp.ps1
+++ b/scripts/package-tpp.ps1
@@ -189,17 +189,37 @@ $textExt = @(
 )
 $maxScanBytes = 4MB
 
-function Test-EntryIsText([System.IO.Compression.ZipArchiveEntry]$entry, [byte[]]$bytes) {
-    $ext = [IO.Path]::GetExtension($entry.Name).ToLower()
-    if ($textExt -contains $ext) { return $true }
-    if ([string]::IsNullOrEmpty($ext)) {
-        # Extensionless tracked files (LICENSE, gradlew, Dockerfile...) —
-        # sniff for a NUL byte in the first 8 KB; NUL ⇒ binary.
-        $probe = [Math]::Min($bytes.Length, 8192)
-        for ($i = 0; $i -lt $probe; $i++) { if ($bytes[$i] -eq 0) { return $false } }
-        return $true
+function Get-ScanText([System.IO.Compression.ZipArchiveEntry]$entry, [byte[]]$bytes) {
+    # Decode an entry's bytes into the text variants worth scanning, or
+    # @() to treat it as binary (path-scan only). UTF-8 is scanned
+    # always; UTF-16 LE/BE are added whenever a BOM or interior NUL byte
+    # signals a UTF-16 text file — otherwise a hostname stored as UTF-16
+    # ("t\0e\0x\0a\0s…") slides straight past a UTF-8-only decode. Note a
+    # NUL sniff alone can't gate this: a legitimate UTF-16 .xml is full
+    # of NULs, so we must decode it as UTF-16 rather than skip it.
+    $ext   = [IO.Path]::GetExtension($entry.Name).ToLower()
+    $known = $textExt -contains $ext
+
+    $bomLE = $bytes.Length -ge 2 -and $bytes[0] -eq 0xFF -and $bytes[1] -eq 0xFE
+    $bomBE = $bytes.Length -ge 2 -and $bytes[0] -eq 0xFE -and $bytes[1] -eq 0xFF
+    $probe = [Math]::Min($bytes.Length, 8192)
+    $hasNul = $false
+    for ($i = 0; $i -lt $probe; $i++) { if ($bytes[$i] -eq 0) { $hasNul = $true; break } }
+
+    if (-not $known) {
+        # Non-text extension (.png, .jar, ...) → binary, path-scan only.
+        if (-not [string]::IsNullOrEmpty($ext)) { return @() }
+        # Extensionless (LICENSE, gradlew, Dockerfile...): NUL without a
+        # UTF-16 BOM ⇒ a genuine binary; skip it.
+        if ($hasNul -and -not ($bomLE -or $bomBE)) { return @() }
     }
-    return $false
+
+    $texts = @([System.Text.Encoding]::UTF8.GetString($bytes))
+    if ($bomLE -or $bomBE -or $hasNul) {
+        $texts += [System.Text.Encoding]::Unicode.GetString($bytes)          # UTF-16 LE
+        $texts += [System.Text.Encoding]::BigEndianUnicode.GetString($bytes) # UTF-16 BE
+    }
+    return $texts
 }
 
 Add-Type -AssemblyName System.IO.Compression.FileSystem
@@ -224,10 +244,12 @@ foreach ($z in Get-ChildItem "$out/$($cfg.sourceZipBaseName)-$versionName-*.zip"
             $bytes = $ms.ToArray()
             $ms.Dispose()
 
-            if (-not (Test-EntryIsText $e $bytes)) { continue }
-            $text = [System.Text.Encoding]::UTF8.GetString($bytes)
-            foreach ($m in [regex]::Matches($text, $contentRe)) {
-                $badContent += "$($e.FullName): matched /$($m.Value)/"
+            $hits = foreach ($text in (Get-ScanText $e $bytes)) {
+                foreach ($m in [regex]::Matches($text, $contentRe)) { $m.Value }
+            }
+            # Dedupe: the same secret can surface in more than one decode.
+            foreach ($v in ($hits | Select-Object -Unique)) {
+                $badContent += "$($e.FullName): matched /$v/"
             }
         }
     } finally {

--- a/scripts/package-tpp.ps1
+++ b/scripts/package-tpp.ps1
@@ -1,4 +1,5 @@
 #!/usr/bin/env pwsh
+#requires -Version 7.0
 # scripts/package-tpp.ps1
 #
 # Build a TAK Product Portal (TPP) submission bundle from the current HEAD.

--- a/scripts/review-tpp-result.ps1
+++ b/scripts/review-tpp-result.ps1
@@ -1,4 +1,5 @@
 #!/usr/bin/env pwsh
+#requires -Version 7.0
 # scripts/review-tpp-result.ps1
 #
 # Review a TAK Product Portal (TPP) build+scan result bundle. Reads the
@@ -73,11 +74,10 @@ if (-not $sdkBuildTools) {
 }
 
 # Windows build-tools ship aapt.exe / apksigner.bat; macOS/Linux ship
-# bare 'aapt' / 'apksigner'. $IsWindows is $true on Windows pwsh, $false
-# on *nix pwsh, and $null on Windows PowerShell 5.1 (treat null as Win).
-$onWindows = $IsWindows -ne $false
-$aapt      = Join-Path $sdkBuildTools.FullName ("aapt"      + $(if ($onWindows) { ".exe" } else { "" }))
-$apksigner = Join-Path $sdkBuildTools.FullName ("apksigner" + $(if ($onWindows) { ".bat" } else { "" }))
+# bare 'aapt' / 'apksigner'. $IsWindows is a reliable automatic variable
+# under pwsh 7+ (the #requires floor), so no 5.1 null-case handling.
+$aapt      = Join-Path $sdkBuildTools.FullName ("aapt"      + $(if ($IsWindows) { ".exe" } else { "" }))
+$apksigner = Join-Path $sdkBuildTools.FullName ("apksigner" + $(if ($IsWindows) { ".bat" } else { "" }))
 foreach ($tool in @($aapt, $apksigner)) {
     if (-not (Test-Path $tool)) {
         throw "Expected build-tools binary not found: $tool (build-tools dir: $($sdkBuildTools.FullName)). Reinstall/repair the build-tools package via Android Studio SDK Manager."

--- a/scripts/review-tpp-result.ps1
+++ b/scripts/review-tpp-result.ps1
@@ -47,13 +47,37 @@ Set-Location $repoRoot
 . (Join-Path $repoRoot "scripts/lib/Read-Config.ps1")
 $cfg = Read-ScriptConfig -RepoRoot $repoRoot
 
-$sdkBuildTools = Get-ChildItem "$env:USERPROFILE/Android/Sdk/build-tools" -Directory -ErrorAction SilentlyContinue |
-    Sort-Object Name -Descending | Select-Object -First 1
-if (-not $sdkBuildTools) {
-    throw "Could not find Android SDK build-tools. Install one via Android Studio SDK Manager."
+# Locate the Android SDK build-tools. Honor the standard env vars first
+# (ANDROID_SDK_ROOT / ANDROID_HOME), then fall back to the usual install
+# locations. Pick the highest build-tools version present.
+$sdkRoots = @(
+    $env:ANDROID_SDK_ROOT,
+    $env:ANDROID_HOME,
+    (Join-Path $env:LOCALAPPDATA "Android/Sdk"),
+    (Join-Path $env:USERPROFILE  "Android/Sdk"),
+    (Join-Path $env:HOME         "Android/Sdk"),
+    (Join-Path $env:HOME         "Library/Android/sdk")
+) | Where-Object { $_ } | Select-Object -Unique
+
+$sdkBuildTools = $null
+foreach ($root in $sdkRoots) {
+    $bt = Join-Path $root "build-tools"
+    if (Test-Path $bt) {
+        $sdkBuildTools = Get-ChildItem $bt -Directory -ErrorAction SilentlyContinue |
+            Sort-Object Name -Descending | Select-Object -First 1
+        if ($sdkBuildTools) { break }
+    }
 }
-$aapt      = Join-Path $sdkBuildTools.FullName "aapt.exe"
-$apksigner = Join-Path $sdkBuildTools.FullName "apksigner.bat"
+if (-not $sdkBuildTools) {
+    throw "Could not find Android SDK build-tools. Set ANDROID_SDK_ROOT (or ANDROID_HOME), or install build-tools via Android Studio SDK Manager. Searched: $($sdkRoots -join ', ')."
+}
+
+# Windows build-tools ship aapt.exe / apksigner.bat; macOS/Linux ship
+# bare 'aapt' / 'apksigner'. $IsWindows is $true on Windows pwsh, $false
+# on *nix pwsh, and $null on Windows PowerShell 5.1 (treat null as Win).
+$onWindows = $IsWindows -ne $false
+$aapt      = Join-Path $sdkBuildTools.FullName ("aapt"      + $(if ($onWindows) { ".exe" } else { "" }))
+$apksigner = Join-Path $sdkBuildTools.FullName ("apksigner" + $(if ($onWindows) { ".bat" } else { "" }))
 foreach ($tool in @($aapt, $apksigner)) {
     if (-not (Test-Path $tool)) {
         throw "Expected build-tools binary not found: $tool (build-tools dir: $($sdkBuildTools.FullName)). Reinstall/repair the build-tools package via Android Studio SDK Manager."
@@ -93,9 +117,9 @@ Add-Type -AssemblyName System.IO.Compression.FileSystem
 function Get-ApkBaseline([string]$apkPath) {
     $out = & $aapt dump xmltree $apkPath AndroidManifest.xml 2>$null
     if ($LASTEXITCODE -ne 0) { return "?" }
-    $m = $out | Select-String -Pattern '"plugin-api".*\r?\n.*"([^"]+@[^"]+)"'
-    if ($m) { return $m.Matches.Groups[1].Value }
-    # Fallback: two-line parse the raw output.
+    # The plugin-api value sits on the line after the "plugin-api" name
+    # attribute in aapt's xmltree dump. Select-String is line-oriented so
+    # a single cross-line regex can't catch it — walk adjacent lines.
     $lines = $out -split "`n"
     for ($i = 0; $i -lt $lines.Length - 1; $i++) {
         if ($lines[$i] -match '"plugin-api"' -and $lines[$i+1] -match '"([^"]+@[^"]+)"') {
@@ -110,8 +134,13 @@ function Get-ApkSigningCert([string]$apkPath) {
     if ($LASTEXITCODE -ne 0) {
         return [PSCustomObject]@{ Verifies = $false; DN = ""; Sha256 = "" }
     }
-    $dn     = ($out | Select-String -Pattern 'Signer #1 certificate DN: (.+)').Matches.Groups[1].Value
-    $sha256 = ($out | Select-String -Pattern 'Signer #1 certificate SHA-256 digest: ([0-9a-f]+)').Matches.Groups[1].Value
+    # Guard each extraction: if apksigner's output format differs (or is
+    # localized) Select-String returns nothing, and blindly chaining
+    # .Matches.Groups would surface a confusing error. Degrade to "".
+    $dnMatch  = $out | Select-String -Pattern 'Signer #1 certificate DN: (.+)' | Select-Object -First 1
+    $shaMatch = $out | Select-String -Pattern 'Signer #1 certificate SHA-256 digest: ([0-9a-f]+)' | Select-Object -First 1
+    $dn     = if ($dnMatch)  { $dnMatch.Matches[0].Groups[1].Value }  else { "" }
+    $sha256 = if ($shaMatch) { $shaMatch.Matches[0].Groups[1].Value } else { "" }
     return [PSCustomObject]@{ Verifies = $true; DN = $dn; Sha256 = $sha256 }
 }
 

--- a/scripts/review-tpp-result.ps1
+++ b/scripts/review-tpp-result.ps1
@@ -1,0 +1,267 @@
+#!/usr/bin/env pwsh
+# scripts/review-tpp-result.ps1
+#
+# Review a TAK Product Portal (TPP) build+scan result bundle. Reads the
+# ZIP that comes back from tak.gov after a submission, extracts the
+# signed APK / AAB, and summarizes Fortify + OWASP Dependency-Check
+# findings so an operator can decide whether to promote the APKs to
+# their TAK server without wading through hundreds of MB of scan output.
+#
+# Usage:
+#   .\scripts\review-tpp-result.ps1 <bundle.zip> [<bundle2.zip> ...]
+#   .\scripts\review-tpp-result.ps1 -Dir path\to\already-extracted
+#
+# What the script does per bundle:
+#   1. Extract into diagnostics/tpp-review-<ts>/<bundleName>/
+#   2. Verify each APK's signing cert + baseline (plugin-api meta-data)
+#   3. Parse scan_results.fpr (a ZIP containing audit.fvdl XML) and
+#      report findings grouped by Kingdom, Category, and severity
+#   4. Skim dependency-check-report.html for any CVE identifiers
+#   5. Print a single-page summary; extraction stays on disk under
+#      diagnostics/ (gitignored) for follow-up drilldown.
+#
+# Rename to include baseline:
+#   Pass -RenameApks. This copies each APK to
+#   <sourceDir>/<sanityApkBaseName>-<versionName>-<manifestBaseline>-<flavor>-release.apk
+#   so downstream TAK-server uploads can distinguish 5.6 vs 5.7 builds
+#   even when TPP names both the same. The original files stay in place.
+
+[CmdletBinding()]
+param(
+    # One or more TPP result bundle ZIPs (as downloaded from tak.gov).
+    [Parameter(Position=0, ValueFromRemainingArguments)]
+    [string[]] $Bundles,
+
+    # Alternatively point at an already-extracted directory. Skips extraction.
+    [string]   $Dir,
+
+    # Rename each APK to include its actual manifest baseline in the
+    # filename. Original filename stays; a renamed copy sits alongside.
+    [switch]   $RenameApks
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+Set-Location $repoRoot
+
+. (Join-Path $repoRoot "scripts/lib/Read-Config.ps1")
+$cfg = Read-ScriptConfig -RepoRoot $repoRoot
+
+$sdkBuildTools = Get-ChildItem "$env:USERPROFILE/Android/Sdk/build-tools" -Directory -ErrorAction SilentlyContinue |
+    Sort-Object Name -Descending | Select-Object -First 1
+if (-not $sdkBuildTools) {
+    throw "Could not find Android SDK build-tools. Install one via Android Studio SDK Manager."
+}
+$aapt      = Join-Path $sdkBuildTools.FullName "aapt.exe"
+$apksigner = Join-Path $sdkBuildTools.FullName "apksigner.bat"
+foreach ($tool in @($aapt, $apksigner)) {
+    if (-not (Test-Path $tool)) {
+        throw "Expected build-tools binary not found: $tool (build-tools dir: $($sdkBuildTools.FullName)). Reinstall/repair the build-tools package via Android Studio SDK Manager."
+    }
+}
+
+# -- Determine which directories to process -----------------------------
+
+$reviewDirs = @()
+
+if ($Dir) {
+    if (-not (Test-Path $Dir)) { throw "Directory not found: $Dir" }
+    $reviewDirs = @([PSCustomObject]@{ Label = Split-Path $Dir -Leaf; Path = $Dir })
+} else {
+    if (-not $Bundles -or $Bundles.Count -eq 0) {
+        throw "No bundles specified. Pass one or more .zip paths, or use -Dir <path>."
+    }
+    $ts       = (Get-Date).ToUniversalTime().ToString("yyyyMMddTHHmmssZ")
+    $outRoot  = Join-Path $repoRoot "diagnostics/tpp-review-$ts"
+    New-Item -ItemType Directory -Force -Path $outRoot | Out-Null
+
+    foreach ($b in $Bundles) {
+        if (-not (Test-Path $b)) { throw "Bundle not found: $b" }
+        $label = [IO.Path]::GetFileNameWithoutExtension($b)
+        $dest  = Join-Path $outRoot $label
+        New-Item -ItemType Directory -Force -Path $dest | Out-Null
+        Write-Host "Extracting $label ..." -ForegroundColor DarkGray
+        Expand-Archive -Path $b -DestinationPath $dest -Force
+        $reviewDirs += [PSCustomObject]@{ Label = $label; Path = $dest }
+    }
+}
+
+# -- Helpers ------------------------------------------------------------
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+function Get-ApkBaseline([string]$apkPath) {
+    $out = & $aapt dump xmltree $apkPath AndroidManifest.xml 2>$null
+    if ($LASTEXITCODE -ne 0) { return "?" }
+    $m = $out | Select-String -Pattern '"plugin-api".*\r?\n.*"([^"]+@[^"]+)"'
+    if ($m) { return $m.Matches.Groups[1].Value }
+    # Fallback: two-line parse the raw output.
+    $lines = $out -split "`n"
+    for ($i = 0; $i -lt $lines.Length - 1; $i++) {
+        if ($lines[$i] -match '"plugin-api"' -and $lines[$i+1] -match '"([^"]+@[^"]+)"') {
+            return $matches[1]
+        }
+    }
+    return "?"
+}
+
+function Get-ApkSigningCert([string]$apkPath) {
+    $out = & $apksigner verify --print-certs $apkPath 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        return [PSCustomObject]@{ Verifies = $false; DN = ""; Sha256 = "" }
+    }
+    $dn     = ($out | Select-String -Pattern 'Signer #1 certificate DN: (.+)').Matches.Groups[1].Value
+    $sha256 = ($out | Select-String -Pattern 'Signer #1 certificate SHA-256 digest: ([0-9a-f]+)').Matches.Groups[1].Value
+    return [PSCustomObject]@{ Verifies = $true; DN = $dn; Sha256 = $sha256 }
+}
+
+function Get-FortifyFindings([string]$fprPath) {
+    # audit.fvdl is XML. Read the whole thing as text — the file is
+    # usually 1-5 MB so no need for a streaming parser.
+    $zip = $null
+    try {
+        $zip   = [System.IO.Compression.ZipFile]::OpenRead($fprPath)
+        $entry = $zip.Entries | Where-Object { $_.FullName -eq "audit.fvdl" } | Select-Object -First 1
+        if (-not $entry) { return @() }
+        $sr = New-Object System.IO.StreamReader($entry.Open())
+        $xml = $sr.ReadToEnd()
+        $sr.Dispose()
+    } finally {
+        if ($zip) { $zip.Dispose() }
+    }
+
+    # Findings live inside <Vulnerability>...<AnalysisInfo>...</AnalysisInfo>
+    # <ClassInfo><ClassID>..</ClassID><Kingdom>..</Kingdom><Type>..</Type>
+    # <Subtype>..</Subtype><AnalyzerName>..</AnalyzerName>
+    # <DefaultSeverity>..</DefaultSeverity></ClassInfo>
+    # ...<InstanceInfo><InstanceID>..</InstanceID><InstanceSeverity>..
+    # </InstanceSeverity>...
+    $findings = @()
+    $rx = [regex] '(?s)<Vulnerability>.*?<ClassInfo>.*?<ClassID>([^<]+)</ClassID>.*?<Kingdom>([^<]*)</Kingdom>.*?<Type>([^<]*)</Type>(?:.*?<Subtype>([^<]*)</Subtype>)?.*?<DefaultSeverity>([^<]*)</DefaultSeverity>.*?</ClassInfo>(?:.*?<InstanceInfo>.*?<InstanceSeverity>([^<]*)</InstanceSeverity>)?.*?</Vulnerability>'
+    foreach ($m in $rx.Matches($xml)) {
+        $findings += [PSCustomObject]@{
+            ClassID          = $m.Groups[1].Value
+            Kingdom          = $m.Groups[2].Value
+            Type             = $m.Groups[3].Value
+            Subtype          = $m.Groups[4].Value
+            DefaultSeverity  = $m.Groups[5].Value
+            InstanceSeverity = $m.Groups[6].Value
+        }
+    }
+    return $findings
+}
+
+function Get-CvesFromDepCheck([string]$htmlPath) {
+    $html = Get-Content -Raw $htmlPath
+    return @($html | Select-String -Pattern 'CVE-\d{4}-\d+' -AllMatches).Matches |
+        ForEach-Object { $_.Value } | Sort-Object -Unique
+}
+
+# -- Report per bundle --------------------------------------------------
+
+$rowsForRename = @()
+
+foreach ($r in $reviewDirs) {
+    Write-Host "`n============================================================" -ForegroundColor Cyan
+    Write-Host "  Bundle: $($r.Label)" -ForegroundColor Cyan
+    Write-Host "  Path:   $($r.Path)" -ForegroundColor DarkGray
+    Write-Host "============================================================" -ForegroundColor Cyan
+
+    $apks = @(Get-ChildItem $r.Path -Filter "*.apk" -File)
+    foreach ($apk in $apks) {
+        Write-Host "`n-- APK: $($apk.Name)" -ForegroundColor Yellow
+        $baseline = Get-ApkBaseline -apkPath $apk.FullName
+        $signing  = Get-ApkSigningCert -apkPath $apk.FullName
+        Write-Host "  baseline (manifest plugin-api): $baseline"
+        if ($signing.Verifies) {
+            Write-Host "  signed OK: cert SHA-256 $($signing.Sha256)"
+            Write-Host "  cert DN: $($signing.DN)" -ForegroundColor DarkGray
+        } else {
+            Write-Host "  NOT SIGNED / signature verification failed" -ForegroundColor Red
+        }
+        Write-Host "  file sha256: $((Get-FileHash $apk.FullName -Algorithm SHA256).Hash.ToLower())"
+        Write-Host "  file size:   $($apk.Length) bytes"
+
+        $rowsForRename += [PSCustomObject]@{
+            Bundle   = $r.Label
+            SrcPath  = $apk.FullName
+            Baseline = $baseline
+        }
+    }
+
+    $fpr = Get-ChildItem $r.Path -Filter "*.fpr" -File | Select-Object -First 1
+    if ($fpr) {
+        Write-Host "`n-- Fortify SAST ($($fpr.Name))" -ForegroundColor Yellow
+        $findings = Get-FortifyFindings -fprPath $fpr.FullName
+        Write-Host "  total findings: $($findings.Count)"
+        if ($findings.Count -gt 0) {
+            $findings |
+                Group-Object -Property Kingdom, Type |
+                Sort-Object Count -Descending |
+                ForEach-Object {
+                    $sample = $_.Group[0]
+                    "    {0,3}x  {1} / {2}  (severity {3})" -f `
+                        $_.Count, $sample.Kingdom, $sample.Type, $sample.DefaultSeverity |
+                        Write-Host
+                }
+        }
+    } else {
+        Write-Host "`n-- Fortify SAST: no .fpr found in bundle" -ForegroundColor DarkGray
+    }
+
+    $depCheck = Join-Path $r.Path "dependency-check-report.html"
+    if (Test-Path $depCheck) {
+        Write-Host "`n-- OWASP Dependency-Check (dependency-check-report.html)" -ForegroundColor Yellow
+        $cves = Get-CvesFromDepCheck -htmlPath $depCheck
+        if ($cves.Count -eq 0) {
+            Write-Host "  no CVE identifiers found in report"
+        } else {
+            Write-Host "  CVE(s) reported ($($cves.Count)):"
+            $cves | ForEach-Object { Write-Host "    $_" }
+            Write-Host "  Open $depCheck in a browser for the full evidence table (CPE match confidence, affected file paths, etc.)."
+        }
+    } else {
+        Write-Host "`n-- OWASP Dependency-Check: no report found" -ForegroundColor DarkGray
+    }
+
+    $buildLog = Join-Path $r.Path "build.log"
+    if (Test-Path $buildLog) {
+        $errCount = @(Select-String -Path $buildLog -Pattern '^\s*\[?(ERROR|FATAL)\]?').Count
+        $warnCount = @(Select-String -Path $buildLog -Pattern '^\s*\[?(WARNING|WARN)\]?').Count
+        Write-Host "`n-- build.log: $errCount error line(s), $warnCount warning line(s)" -ForegroundColor Yellow
+        if ($errCount -gt 0) {
+            Write-Host "    First few errors:" -ForegroundColor Red
+            Select-String -Path $buildLog -Pattern '^\s*\[?(ERROR|FATAL)\]?' |
+                Select-Object -First 5 |
+                ForEach-Object { Write-Host "      $($_.Line)" -ForegroundColor Red }
+        }
+    }
+}
+
+# -- Optional rename step ----------------------------------------------
+
+if ($RenameApks) {
+    Write-Host "`n============================================================" -ForegroundColor Cyan
+    Write-Host "  Renamed copies (original filenames left in place)" -ForegroundColor Cyan
+    Write-Host "============================================================" -ForegroundColor Cyan
+
+    # Read versionName from HEAD's build.gradle.kts.
+    $bg   = Get-Content -Raw "app/build.gradle.kts"
+    $vRaw = if ($bg -match 'versionName\s*=\s*"([^"]+)"') { $matches[1] } else { "unknown" }
+    $flavor = $cfg.productFlavor
+
+    foreach ($row in $rowsForRename) {
+        # Extract just the "5.6.0" or "5.7.0" part from "com.atakmap.app@5.7.0.CIV"
+        $short = if ($row.Baseline -match '@([0-9]+\.[0-9]+\.[0-9]+)') { $matches[1] } else { "unknown" }
+        $newName = "$($cfg.sanityApkBaseName)-$vRaw-$short-$flavor-release.apk"
+        $newPath = Join-Path (Split-Path $row.SrcPath -Parent) $newName
+        if ($row.SrcPath -eq $newPath) {
+            Write-Host "  $($row.Bundle): already correctly named ($newName)"
+        } else {
+            Copy-Item $row.SrcPath $newPath -Force
+            Write-Host "  $($row.Bundle): $newName" -ForegroundColor Green
+        }
+    }
+}
+
+Write-Host "`nReview complete. Full extraction is under diagnostics/ (gitignored) for drilldown." -ForegroundColor Cyan

--- a/scripts/upload-tak-plugin.ps1
+++ b/scripts/upload-tak-plugin.ps1
@@ -11,9 +11,9 @@
 #   .\scripts\upload-tak-plugin.ps1 -Apk a.apk,b.apk -Baseline 5.6.0,5.7.0 [-Send]
 #
 # Without -Send, the script performs a dry-run: prints exactly what
-# request it would POST (URL, headers with secrets redacted, form
-# fields, file size + hash) and exits without touching the network.
-# Re-run with -Send once the dry-run looks right.
+# request it would POST (URL, the auth line with the secret redacted to
+# env-var-name + length, form fields, per-file size + SHA-256) and exits
+# without touching the network. Re-run with -Send once it looks right.
 #
 # The Baseline value is templated into extraFormFields (any string of
 # form "{baseline}" in a config value is replaced at request time).
@@ -46,6 +46,12 @@ if (-not $tak) {
 }
 if (-not $tak.baseUrl) {
     throw "takServer.baseUrl is not set in scripts/config.json. Set it to your TAK / OpenTAK server URL (e.g. https://tak.example.com:8443)."
+}
+if (-not $tak.uploadPath) {
+    throw "takServer.uploadPath is not set in scripts/config.json (the server's upload endpoint path, e.g. /api/plugins/upload)."
+}
+if (-not $tak.fileFieldName) {
+    throw "takServer.fileFieldName is not set in scripts/config.json (the multipart form field the server expects the APK under, e.g. 'file')."
 }
 if ($Apk.Count -ne $Baseline.Count) {
     throw "-Apk count ($($Apk.Count)) must equal -Baseline count ($($Baseline.Count))."
@@ -93,7 +99,11 @@ switch -Regex ($tak.authMode) {
     }
 }
 
-$fullUrl = "$($tak.baseUrl.TrimEnd('/'))$($tak.uploadPath)"
+# Normalize the join so a config uploadPath with or without a leading
+# slash both produce a valid URL (baseUrl + "/api/..." not "host:8443api/...").
+$uploadPath = $tak.uploadPath
+if ($uploadPath -notmatch '^/') { $uploadPath = "/$uploadPath" }
+$fullUrl = "$($tak.baseUrl.TrimEnd('/'))$uploadPath"
 
 Write-Host "TAK server upload target" -ForegroundColor Cyan
 Write-Host "  URL:      $fullUrl"
@@ -154,7 +164,16 @@ for ($i = 0; $i -lt $Apk.Count; $i++) {
         Headers = $auth.Header
     }
     if ($auth.ClientCertPath) {
-        $iwArgs["Certificate"] = Get-PfxCertificate -FilePath $auth.ClientCertPath
+        # Load the client cert directly so a password-protected PFX works
+        # (Get-PfxCertificate can't take a password non-interactively).
+        # clientCertPassEnvVar, if set, was read into $auth.ClientCertPass.
+        if ($auth.ClientCertPass) {
+            $iwArgs["Certificate"] = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
+                $auth.ClientCertPath, $auth.ClientCertPass)
+        } else {
+            $iwArgs["Certificate"] = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
+                $auth.ClientCertPath)
+        }
     }
     if ($tak.insecureSkipTlsVerify) {
         $iwArgs["SkipCertificateCheck"] = $true

--- a/scripts/upload-tak-plugin.ps1
+++ b/scripts/upload-tak-plugin.ps1
@@ -1,0 +1,180 @@
+#!/usr/bin/env pwsh
+# scripts/upload-tak-plugin.ps1
+#
+# Upload one or more signed plugin APKs to a TAK / OpenTAK server for
+# distribution to team devices. Reads server URL + auth + upload params
+# from scripts/config.json's `takServer` block; secrets live in env
+# vars named by that block, never in config.json itself.
+#
+# Usage:
+#   .\scripts\upload-tak-plugin.ps1 -Apk <path> -Baseline <5.6.0|5.7.0> [-Send]
+#   .\scripts\upload-tak-plugin.ps1 -Apk a.apk,b.apk -Baseline 5.6.0,5.7.0 [-Send]
+#
+# Without -Send, the script performs a dry-run: prints exactly what
+# request it would POST (URL, headers with secrets redacted, form
+# fields, file size + hash) and exits without touching the network.
+# Re-run with -Send once the dry-run looks right.
+#
+# The Baseline value is templated into extraFormFields (any string of
+# form "{baseline}" in a config value is replaced at request time).
+# Order of -Apk and -Baseline matters and their counts must match.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string[]] $Apk,
+
+    [Parameter(Mandatory)]
+    [string[]] $Baseline,
+
+    # Only when this switch is passed does the script actually POST.
+    # Defaults to false so an accidental invocation just prints the
+    # intended request.
+    [switch]   $Send
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+Set-Location $repoRoot
+
+. (Join-Path $repoRoot "scripts/lib/Read-Config.ps1")
+$cfg = Read-ScriptConfig -RepoRoot $repoRoot
+$tak = $cfg.takServer
+
+if (-not $tak) {
+    throw "No 'takServer' block in scripts/config.json. Copy from scripts/config.example.json and fill in baseUrl + auth settings."
+}
+if (-not $tak.baseUrl) {
+    throw "takServer.baseUrl is not set in scripts/config.json. Set it to your TAK / OpenTAK server URL (e.g. https://tak.example.com:8443)."
+}
+if ($Apk.Count -ne $Baseline.Count) {
+    throw "-Apk count ($($Apk.Count)) must equal -Baseline count ($($Baseline.Count))."
+}
+
+# -- Resolve auth header / TLS options ----------------------------------
+
+$auth = @{ Header = @{}; ClientCertPath = $null; ClientCertPass = $null; TokenPreview = "(none)" }
+switch -Regex ($tak.authMode) {
+    "bearer" {
+        $var = $tak.tokenEnvVar
+        if (-not $var) { throw "authMode=bearer but takServer.tokenEnvVar is not set." }
+        $tok = [Environment]::GetEnvironmentVariable($var)
+        if (-not $tok) {
+            throw "Env var '$var' is empty. Set it in this shell (or system-wide via setx) before running with -Send."
+        }
+        $auth.Header["Authorization"] = "Bearer $tok"
+        $auth.TokenPreview = "Bearer <$var; $($tok.Length) chars>"
+    }
+    "basic" {
+        if (-not $tak.basicUser) { throw "authMode=basic but takServer.basicUser is not set." }
+        $passVar = $tak.basicPassEnvVar
+        if (-not $passVar) { throw "authMode=basic but takServer.basicPassEnvVar is not set." }
+        $pass = [Environment]::GetEnvironmentVariable($passVar)
+        if (-not $pass) { throw "Env var '$passVar' is empty." }
+        $pair = "$($tak.basicUser):$pass"
+        $b64  = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes($pair))
+        $auth.Header["Authorization"] = "Basic $b64"
+        $auth.TokenPreview = "Basic <$($tak.basicUser):(pw from $passVar)>"
+    }
+    "mtls" {
+        if (-not $tak.clientCertPath) { throw "authMode=mtls but takServer.clientCertPath is not set." }
+        if (-not (Test-Path $tak.clientCertPath)) { throw "Client cert not found at $($tak.clientCertPath)" }
+        $auth.ClientCertPath = $tak.clientCertPath
+        if ($tak.clientCertPassEnvVar) {
+            $auth.ClientCertPass = [Environment]::GetEnvironmentVariable($tak.clientCertPassEnvVar)
+        }
+        $auth.TokenPreview = "mTLS cert=$(Split-Path $tak.clientCertPath -Leaf)"
+    }
+    "none" {
+        $auth.TokenPreview = "(none)"
+    }
+    default {
+        throw "Unknown takServer.authMode '$($tak.authMode)'. Use one of: bearer, basic, mtls, none."
+    }
+}
+
+$fullUrl = "$($tak.baseUrl.TrimEnd('/'))$($tak.uploadPath)"
+
+Write-Host "TAK server upload target" -ForegroundColor Cyan
+Write-Host "  URL:      $fullUrl"
+Write-Host "  auth:     $($auth.TokenPreview)"
+Write-Host "  fileField: $($tak.fileFieldName)"
+if ($tak.insecureSkipTlsVerify) {
+    Write-Host "  WARNING: insecureSkipTlsVerify=true. TLS certificate validation is DISABLED." -ForegroundColor Yellow
+}
+
+# -- Per-file upload loop ----------------------------------------------
+
+$anyFailed = $false
+for ($i = 0; $i -lt $Apk.Count; $i++) {
+    $apkPath = $Apk[$i]
+    $bl      = $Baseline[$i]
+
+    if (-not (Test-Path $apkPath)) {
+        Write-Host "`nAPK not found: $apkPath" -ForegroundColor Red
+        $anyFailed = $true
+        continue
+    }
+    $apkInfo = Get-Item $apkPath
+    $sha     = (Get-FileHash $apkPath -Algorithm SHA256).Hash.ToLower()
+
+    Write-Host "`n=== $($apkInfo.Name)  (baseline $bl)" -ForegroundColor Cyan
+    Write-Host "  size:   $($apkInfo.Length) bytes"
+    Write-Host "  sha256: $sha"
+
+    # Template extra fields with the baseline value.
+    $formFields = @{}
+    if ($tak.extraFormFields) {
+        foreach ($p in $tak.extraFormFields.PSObject.Properties) {
+            $v = $p.Value
+            if ($v -is [string]) { $v = $v.Replace("{baseline}", $bl) }
+            $formFields[$p.Name] = $v
+        }
+    }
+    Write-Host "  extra form fields:"
+    if ($formFields.Count -eq 0) { Write-Host "    (none)" -ForegroundColor DarkGray }
+    foreach ($k in $formFields.Keys) { Write-Host "    $k = $($formFields[$k])" }
+
+    if (-not $Send) {
+        Write-Host "  DRY RUN — not sending. Re-run with -Send to actually upload." -ForegroundColor Yellow
+        continue
+    }
+
+    # Build the multipart request and POST.
+    # PowerShell's Invoke-WebRequest -Form supports Path values, which
+    # streams the file rather than buffering it in memory. Good for a
+    # ~3 MB APK; also correct MIME type inference.
+    $form = @{ $tak.fileFieldName = Get-Item $apkPath }
+    foreach ($k in $formFields.Keys) { $form[$k] = $formFields[$k] }
+
+    $iwArgs = @{
+        Uri     = $fullUrl
+        Method  = "POST"
+        Form    = $form
+        Headers = $auth.Header
+    }
+    if ($auth.ClientCertPath) {
+        $iwArgs["Certificate"] = Get-PfxCertificate -FilePath $auth.ClientCertPath
+    }
+    if ($tak.insecureSkipTlsVerify) {
+        $iwArgs["SkipCertificateCheck"] = $true
+    }
+
+    try {
+        $resp = Invoke-WebRequest @iwArgs
+        Write-Host "  HTTP $($resp.StatusCode)" -ForegroundColor Green
+        if ($resp.Content) {
+            $body = $resp.Content
+            if ($body.Length -gt 500) { $body = $body.Substring(0, 500) + "…" }
+            Write-Host "  Response: $body" -ForegroundColor DarkGray
+        }
+    } catch {
+        Write-Host "  FAILED: $($_.Exception.Message)" -ForegroundColor Red
+        if ($_.Exception.Response) {
+            Write-Host "  HTTP $($_.Exception.Response.StatusCode.value__) $($_.Exception.Response.ReasonPhrase)" -ForegroundColor Red
+        }
+        $anyFailed = $true
+    }
+}
+
+if ($anyFailed) { exit 1 }

--- a/scripts/upload-tak-plugin.ps1
+++ b/scripts/upload-tak-plugin.ps1
@@ -1,4 +1,5 @@
 #!/usr/bin/env pwsh
+#requires -Version 7.0
 # scripts/upload-tak-plugin.ps1
 #
 # Upload one or more signed plugin APKs to a TAK / OpenTAK server for


### PR DESCRIPTION
## What

Adds `scripts/` — reusable PowerShell tooling for the dev + submission workflow, generic across TAK plugins with all per-operator values isolated to a gitignored `scripts/config.json`. Also hardens the sensitive-content guardrails.

| Script | Purpose |
|---|---|
| `install-dev.ps1` | Build debug APK + fan out to every authorized adb device; also installs Dev/Release ATAK editions for phone prep |
| `package-tpp.ps1` | `git archive HEAD` source zips + optional sanity APK build, gated by a sensitive-content scan |
| `upload-tak-plugin.ps1` | Dry-run-by-default multipart upload to a TAK/OpenTAK server; secrets read from env vars, never config |
| `review-tpp-result.ps1` | Summarize TPP build+scan result bundles (signing cert, baseline, Fortify/OWASP findings) |
| `lib/Read-Config.ps1` | Shared config loader (`config.json` ⊕ defaults) |

## Hardening in this PR

- **`package-tpp.ps1` now scans in two passes.** The existing **path pass** (universal ∪ operator patterns) catches leaked files by name. A new **content pass** greps the *text* of each tracked text file for operator-only patterns — real hostnames, callsigns, unit names — that a filename-only scan can't see. Universal path shapes (`credentials`, `/logs/`, `.env`) are deliberately excluded from the content pass so ordinary source that merely mentions those words doesn't false-positive. Binaries (NUL-sniffed) and files >4 MB are path-scanned only. Verified end-to-end against a synthetic zip: a secret embedded in file body is caught; a NUL-containing blob is skipped; a clean file passes.
- **`Read-Config.ps1`** throws a readable error on malformed `config.json` and exposes an operator-only pattern set for the content pass.
- **`install-dev.ps1`** guards on missing `adb`; **`review-tpp-result.ps1`** verifies the `aapt`/`apksigner` build-tools binaries exist before invoking them.

## Sanitization

- `.gitignore` excludes `scripts/config.json`, so per-operator values (TAK hostnames, SDK paths, redaction lists) never reach public history. Only `config.example.json` (using `tak.example.com` placeholders) travels with the repo.
- Confirmed the commit set contains no real hostnames, MACs, callsigns, IPs, or emails, and that `config.json` is excluded from staging.

## Reviewer notes

- The content pass only catches what's in `config.forbiddenPatterns`. Operators should add their real TAK FQDN, callsigns, and unit names there so the scan can enforce them.
- All five scripts parse clean under the PowerShell AST parser. PowerShell (`*.ps1`) is the primary shell per the operator's desktop.
- `CLAUDE.md` gains a "Scripting recurring workflows" section documenting the policy these scripts implement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)