### PR TITLE
fix(telecom): move PlaceDecision out of companion so tests compile

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,27 @@
 # Pre-commit framework configuration for TAK-XVoice.
 #
-# Install once per clone:
+# Install once per clone — note BOTH hook types:
 #   pipx install pre-commit
-#   pre-commit install
+#   pre-commit install --hook-type pre-commit --hook-type pre-push
 #
-# After install, `git commit` runs the hooks below and refuses commits
-# that trip them. See CLAUDE.md for the project-wide sensitive-content
-# rules these hooks back up.
+# `git commit` then runs the commit-stage hooks below and refuses
+# commits that trip them; `git push` runs the build gate. See CLAUDE.md
+# for the project-wide sensitive-content rules these hooks back up.
+#
+# Verify the install actually took — an uninstalled hook fails open and
+# is worth exactly nothing:
+#   ls .git/hooks/pre-commit .git/hooks/pre-push
 #
 # Tag pins are deliberate: floating refs (HEAD / main) make builds
 # non-reproducible and let upstream silently change behavior between
 # clones.
 ---
+# Stage names below ('pre-commit' / 'pre-push') are the modern spelling
+# introduced in pre-commit 3.2; older releases called them 'commit' /
+# 'push' and would misparse this file. Fail fast with a clear message
+# rather than silently skipping hooks.
+minimum_pre_commit_version: '3.2.0'
+
 repos:
   # Secret scanner. Backed by .gitleaks.toml at the repo root, which
   # extends the gitleaks default ruleset with project-specific
@@ -20,6 +30,7 @@ repos:
     rev: v8.21.2
     hooks:
       - id: gitleaks
+        stages: [pre-commit]
 
   # Whitespace / EOL hygiene. Catches files committed without a
   # trailing newline, which trips diff tools and editor configs.
@@ -27,3 +38,41 @@ repos:
     rev: v5.0.0
     hooks:
       - id: end-of-file-fixer
+        # Commit stage only: this hook *rewrites* files. At push time a
+        # rewrite lands in the working tree without amending anything
+        # that's actually being pushed, which is confusing and useless.
+        stages: [pre-commit]
+
+  # Local build gate. THIS is the defense that public CI cannot provide.
+  #
+  # GitHub can't compile XV (no redistributable ATAK SDK on runners), so
+  # ci.yml runs ktlint only — and ktlint parses without resolving
+  # symbols. An unresolved reference is invisible to it. That gap let
+  # PR #72 land a non-compiling test source set and kept main red
+  # through #80 and #81 with CI green the whole way.
+  #
+  # Running at pre-push rather than pre-commit is deliberate: a full
+  # gradle run costs ~40-60s, which is intolerable per-commit but fine
+  # per-push, and push is the boundary that actually matters — it's the
+  # point where a break stops being local.
+  - repo: local
+    hooks:
+      - id: gradle-gates
+        name: Gradle gates (ktlint + assemble + unit tests)
+        entry: pwsh -NoProfile -File scripts/verify-gates.ps1
+        language: system
+        stages: [pre-push]
+        # The gate builds the whole project, so per-file arguments are
+        # meaningless — it takes none.
+        pass_filenames: false
+        # Only fire when something that can actually break the build is
+        # in the push. A docs- or workflow-only push shouldn't pay 60s.
+        # Covers Kotlin/KTS, the AIDL + proto sources that generate
+        # code, Android resources and manifests, and the gradle
+        # toolchain/version-catalog files.
+        files: >-
+          (\.kts?$|\.aidl$|\.proto$|^gradle/|^gradle\.properties$|^app/src/.*\.xml$)
+        # Surface the gradle output on success too — a silent gate is
+        # one nobody trusts, and the timing line is how you notice the
+        # daemon went cold.
+        verbose: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,11 +133,33 @@ ready for review:
 ./gradlew testCivDebugUnitTest
 ```
 
+Or just `./scripts/verify-gates.ps1`, which runs all three and is
+wired to a pre-push hook.
+
 `ktlintCheck` enforces the formatting baseline. `assembleCivDebug`
 exercises the takdev SDK wiring + manifest, which is the most common
 way a refactor breaks plugin loading. `testCivDebugUnitTest` is the
 JUnit/MockK/Robolectric unit suite for the state machines listed in
 the initial commit.
+
+**These gates are local-only, and that is load-bearing.** GitHub CI
+cannot compile this project — no redistributable ATAK SDK on public
+runners — so `.github/workflows/ci.yml` runs ktlint and nothing more.
+ktlint parses Kotlin without resolving symbols, so it cannot see an
+unresolved reference. Never infer build health from a green PR check
+or a merged PR; the only evidence that `main` builds is someone
+running these locally and reading the output.
+
+Two traps this has already sprung:
+
+- **`assembleCivDebug` does not compile the test source set.** A
+  broken test symbol is invisible to it. Run `testCivDebugUnitTest`
+  explicitly — it is the gate that catches this class of break.
+- **A red `main` is a real state, not a hypothetical.** PR #72
+  (e12dc3b) landed a non-compiling test source set; CI was green and
+  `main` stayed red through #80 and #81. When asked to "fix the
+  build," reproduce all three gates first — the reported symptom may
+  live in a different gate than the one named.
 
 ## Scripting recurring workflows
 
@@ -203,11 +225,23 @@ commits. Install once per clone:
 
 ```sh
 pipx install pre-commit
-pre-commit install
+pre-commit install --hook-type pre-commit --hook-type pre-push
+ls .git/hooks/pre-commit .git/hooks/pre-push   # verify — see below
 ```
 
-After that, `git commit` will run `gitleaks` + `end-of-file-fixer`
-locally and refuse commits that trip either hook. If a hook trips,
-**investigate the underlying content** — do not bypass with
-`--no-verify` unless the operator explicitly approves it for a
-specific commit, and even then prefer fixing the content.
+After that, `git commit` runs `gitleaks` + `end-of-file-fixer` and
+refuses commits that trip either hook, and `git push` runs the
+build gate (`scripts/verify-gates.ps1`) so a red tree can't reach the
+remote. If a hook trips, **investigate the underlying content** — do
+not bypass with `--no-verify` unless the operator explicitly approves
+it for a specific commit, and even then prefer fixing the content.
+
+**Verify the install actually took.** `pre-commit install` refuses to
+do anything while `core.hooksPath` is set, and the failure is one line
+that is trivial to miss. This clone sat in exactly that state until
+2026-07-14: `.pre-commit-config.yaml` and `.gitleaks.toml` were
+committed and looked authoritative, `core.hooksPath` was pointing at
+`.git/hooks` (git's own default — a no-op that still tripped the
+check), and no hook had ever run. An uninstalled hook fails open and
+protects nothing. If `git config --get core.hooksPath` returns
+anything, find out what owns it before clearing it.

--- a/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
+++ b/app/src/main/java/com/atakmap/android/xv/service/XvVoiceService.kt
@@ -2281,6 +2281,27 @@ class XvVoiceService : Service() {
             }
         }
 
+    /**
+     * Outcome of the placement decision in [placeTelecomCallInternal].
+     *  - [PLACE]           — no live call and none in flight: issue a
+     *                        fresh [android.telecom.TelecomManager.placeCall].
+     *  - [REUSE_ACTIVE]    — a live [com.atakmap.android.xv.telecom.XvConnection]
+     *                        is registered: keep it ACTIVE, do not
+     *                        place again.
+     *  - [REUSE_IN_FLIGHT] — our `telecomState` says a call is
+     *                        active/warming but the connection has
+     *                        not registered yet (the first placeCall
+     *                        is still inside its async
+     *                        onCreateOutgoingConnection gap): suppress
+     *                        the duplicate placeCall.
+     *
+     * Declared at class level rather than inside [Companion]: Kotlin does
+     * not surface a companion's nested classifiers as `XvVoiceService.X`,
+     * so nesting this in the companion makes it unreferenceable from the
+     * unit tests that pin [decidePlacement]'s truth table.
+     */
+    internal enum class PlaceDecision { PLACE, REUSE_ACTIVE, REUSE_IN_FLIGHT }
+
     companion object {
         private const val TAG = "XvVoiceSvc"
 
@@ -2550,22 +2571,6 @@ class XvVoiceService : Service() {
             if (hasActiveConnection) return false
             return hasHadOwnCallInProcess
         }
-
-        /**
-         * Outcome of the placement decision in [placeTelecomCallInternal].
-         *  - [PLACE]           — no live call and none in flight: issue a
-         *                        fresh [android.telecom.TelecomManager.placeCall].
-         *  - [REUSE_ACTIVE]    — a live [com.atakmap.android.xv.telecom.XvConnection]
-         *                        is registered: keep it ACTIVE, do not
-         *                        place again.
-         *  - [REUSE_IN_FLIGHT] — our `telecomState` says a call is
-         *                        active/warming but the connection has
-         *                        not registered yet (the first placeCall
-         *                        is still inside its async
-         *                        onCreateOutgoingConnection gap): suppress
-         *                        the duplicate placeCall.
-         */
-        internal enum class PlaceDecision { PLACE, REUSE_ACTIVE, REUSE_IN_FLIGHT }
 
         /**
          * Pure decision for [placeTelecomCallInternal]. Extracted so the

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,36 @@ notepad scripts/config.json
 
 Then edit the values to match your plugin. Every key is optional; falls back to the safe generic defaults in `scripts/lib/Read-Config.ps1` if omitted. Keys you'll almost certainly want to override: `pluginPackage`, `pluginShortName`, `productFlavor`, `sanityApkBaseName`, `sourceZipBaseName`, `sourceZipPrefix`, `defaultBaseline`, `tppBaselines`. Add any operator-specific redaction patterns to `forbiddenPatterns` (e.g. your real TAK server hostname, callsign lists).
 
+Then install the git hooks (see `verify-gates.ps1` below — this is what keeps a broken build off `main`):
+
+```powershell
+pipx install pre-commit                                          # or: python -m pip install --user pre-commit
+pre-commit install --hook-type pre-commit --hook-type pre-push
+Get-ChildItem .git/hooks -File | Where-Object Name -notlike '*.sample'   # expect: pre-commit, pre-push
+```
+
+That last line is not ceremony — verify it. If `core.hooksPath` is set in your clone, `pre-commit install` **refuses and exits non-zero**, and it is easy to miss in scrollback. The result is a clone where `.pre-commit-config.yaml` looks authoritative but no hook has ever run. Clear it with `git config --unset-all core.hooksPath` (check `git config --get core.hooksPath` first — if it points somewhere other than `.git/hooks`, something else owns your hooks and you should find out what before unsetting).
+
+## `verify-gates.ps1` — run the pre-merge build gates
+
+```powershell
+.\scripts\verify-gates.ps1                       # ktlintCheck + assembleCivDebug + testCivDebugUnitTest
+.\scripts\verify-gates.ps1 -Task testCivDebugUnitTest   # one gate
+```
+
+Runs as a **pre-push hook**, so a red tree can't reach the remote. This is the project's only real build gate, and it exists because public CI structurally cannot provide one:
+
+- GitHub runners have no ATAK CIV SDK. The SDK isn't redistributable and the tak.gov maven coordinates need USG-sponsored credentials, so CI cannot compile the main source set — let alone run tests. (`.github/workflows/ci.yml` documents this at length.)
+- What CI *can* run is ktlint, which **parses without resolving symbols**. An unresolved reference is invisible to it.
+- So an entire class of break reaches `main` with CI fully green. PR #72 (e12dc3b) did exactly that: it landed a test source set that didn't compile, and `main` stayed red through #80 and #81 until someone ran the tests by hand.
+
+Two things worth internalizing:
+
+- **`assembleCivDebug` is not a substitute for the test gate.** Assembling the APK does not compile the unit-test source set, so it cannot catch a broken test symbol. #72 built clean APKs the whole time it was red. Don't trim the test task to speed up pushes.
+- **The gate builds the working tree, not the commits being pushed.** Normally identical (you push what you built), but with a dirty tree it verifies what's on disk rather than what's going out. Push from a clean tree.
+
+The task list is derived from `config.productFlavor` (`civ` → `assembleCivDebug`), so the script stays generic across TAK plugins. Override with `config.verifyGateTasks` only if your gates don't follow that shape. `git push --no-verify` bypasses it — an explicit operator decision, per CLAUDE.md.
+
 ## `install-dev.ps1` — build the debug APK and install on connected phones
 
 Fans out to every authorized adb device so multi-device flashing takes one command.

--- a/scripts/config.example.json
+++ b/scripts/config.example.json
@@ -25,6 +25,9 @@
   "_atakPackage_comment_": "Android package name of ATAK itself. The CIV variant is com.atakmap.app.civ; other variants use different suffixes.",
   "atakPackage":       "com.atakmap.app.civ",
 
+  "_verifyGateTasks_comment_": "Gradle tasks that scripts/verify-gates.ps1 runs as the pre-push build gate. Omit or leave null to derive them from productFlavor above (ktlintCheck + assemble<Flavor>Debug + test<Flavor>DebugUnitTest), which is what TAK-XVoice uses. Set an explicit list only for a plugin whose gates don't follow that shape. Do not drop the unit-test task to speed up pushes: assemble does NOT compile the test source set, so it cannot catch a broken test symbol — that is exactly how main went red from PR #72 through #81.",
+  "verifyGateTasks":   null,
+
   "_forbiddenPatterns_comment_": "Regex patterns that must NEVER appear in a TPP source zip beyond the built-in universal list (.audio/, /logs/, .logs/, .tmp/, diagnostics/, /build/, keystore.properties, credentials, .env). Add anything operator-specific here: real TAK server hostnames, callsign lists, unit names.",
   "forbiddenPatterns": [
     "tak\\.example\\.com"

--- a/scripts/lib/Read-Config.ps1
+++ b/scripts/lib/Read-Config.ps1
@@ -47,6 +47,11 @@ function Read-ScriptConfig {
         atakReleaseApks    = @{}
         forbiddenPatterns  = @()
         takServer          = $null
+        # null => verify-gates.ps1 derives the task list from
+        # productFlavor (ktlintCheck + assemble<F>Debug +
+        # test<F>DebugUnitTest). Set only to override for a plugin whose
+        # gates don't follow that shape.
+        verifyGateTasks    = $null
     }
 
     # Universal patterns — always applied on top of whatever config

--- a/scripts/verify-gates.ps1
+++ b/scripts/verify-gates.ps1
@@ -1,0 +1,171 @@
+#requires -Version 7.0
+<#
+.SYNOPSIS
+    Runs the pre-merge Gradle gates and fails if any is red.
+
+.DESCRIPTION
+    This is the local stand-in for a CI build. Public GitHub CI cannot
+    compile this project: the Android build needs the ATAK CIV SDK
+    (app/libs/main.jar) on the compile classpath, the SDK is not
+    redistributable, and the tak.gov maven coordinates the takdev
+    plugin would fetch from require USG-sponsored credentials. See the
+    header of .github/workflows/ci.yml for the full rationale.
+
+    The consequence: ktlint is the ONLY gate GitHub can enforce, and
+    ktlint merely parses Kotlin — it never resolves symbols. A broken
+    symbol reference is therefore invisible to CI by construction.
+    That is not hypothetical. PR #72 (e12dc3b) landed a test source set
+    that did not compile ('Unresolved reference: PlaceDecision'), CI was
+    green, and main stayed red through #80 and #81 until it was caught
+    by hand.
+
+    Note that `assemble<Flavor>Debug` alone would NOT have caught it
+    either — assembling the APK does not compile the unit-test source
+    set. `test<Flavor>DebugUnitTest` is the gate that actually resolves
+    test symbols, which is why it is not optional here.
+
+    Wired to a pre-push hook via .pre-commit-config.yaml, so a red tree
+    cannot reach the remote in the first place.
+
+.PARAMETER Task
+    Override the gradle task list. Default is derived from the
+    productFlavor in scripts/config.json (see below), or taken verbatim
+    from the config's verifyGateTasks if that key is set.
+
+.PARAMETER SkipSdkHint
+    Suppress the ATAK-SDK troubleshooting hint on failure.
+
+.EXAMPLE
+    pwsh -File scripts/verify-gates.ps1
+    Runs ktlintCheck + assembleCivDebug + testCivDebugUnitTest.
+
+.EXAMPLE
+    pwsh -File scripts/verify-gates.ps1 -Task testCivDebugUnitTest
+    Runs just the unit-test gate.
+#>
+[CmdletBinding()]
+param(
+    [string[]] $Task,
+    [switch]   $SkipSdkHint
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+. (Join-Path $PSScriptRoot 'lib/Read-Config.ps1')
+$cfg = Read-ScriptConfig -RepoRoot $repoRoot
+
+# Task list resolution, most-specific first:
+#   -Task param  >  config verifyGateTasks  >  derived from productFlavor
+#
+# Deriving from productFlavor keeps this script generic across TAK
+# plugins (CLAUDE.md: nothing plugin-specific hardcoded in scripts/*.ps1).
+# 'civ' -> 'Civ' gives assembleCivDebug / testCivDebugUnitTest; a plugin
+# built with productFlavor 'mil' gets assembleMilDebug for free.
+if ($Task -and $Task.Count -gt 0) {
+    $tasks = $Task
+} elseif ($cfg.ContainsKey('verifyGateTasks') -and $cfg.verifyGateTasks) {
+    $tasks = @($cfg.verifyGateTasks)
+} else {
+    $flavor = $cfg.productFlavor
+    if ([string]::IsNullOrWhiteSpace($flavor)) { $flavor = 'civ' }
+    $F = $flavor.Substring(0, 1).ToUpperInvariant() + $flavor.Substring(1)
+    $tasks = @(
+        'ktlintCheck'
+        "assemble${F}Debug"
+        "test${F}DebugUnitTest"
+    )
+}
+
+# Windows needs the .bat wrapper; the extensionless script is POSIX-only.
+$gradlew = if ($IsWindows) {
+    Join-Path $repoRoot 'gradlew.bat'
+} else {
+    Join-Path $repoRoot 'gradlew'
+}
+if (-not (Test-Path $gradlew)) {
+    throw "No Gradle wrapper at $gradlew — run from a full clone."
+}
+
+Write-Host ''
+Write-Host "  Gradle gates: $($tasks -join ' ')" -ForegroundColor Cyan
+Write-Host "  (local build gate — GitHub cannot compile this project; see script header)" -ForegroundColor DarkGray
+Write-Host ''
+
+$sw = [System.Diagnostics.Stopwatch]::StartNew()
+
+# One invocation for all tasks: a single daemon + one configuration
+# pass is markedly faster than N invocations, and this sits in the push
+# path where latency is felt directly. Gradle names the failing task in
+# its own output, so per-task granularity buys nothing here.
+Push-Location $repoRoot
+try {
+    # Do NOT assign this pipeline to a variable. `$x = ... | Tee-Object`
+    # captures the stream into $x instead of passing it to the host, so
+    # gradle's output — including the actual compile error — is
+    # swallowed and the operator sees a bare "FAIL" with no cause.
+    # Tee-Object -Variable both prints and captures; keep it that way.
+    & $gradlew @tasks 2>&1 | Tee-Object -Variable teed
+    $exit = $LASTEXITCODE
+} finally {
+    Pop-Location
+}
+
+$sw.Stop()
+$elapsed = '{0:mm}m{0:ss}s' -f ([timespan]::FromSeconds($sw.Elapsed.TotalSeconds))
+
+Write-Host ''
+if ($exit -eq 0) {
+    Write-Host "  PASS  all gates green ($elapsed)" -ForegroundColor Green
+    Write-Host ''
+    exit 0
+}
+
+Write-Host "  FAIL  gradle exited $exit after $elapsed" -ForegroundColor Red
+Write-Host "        Gates: $($tasks -join ' ')" -ForegroundColor Red
+
+# The single most common failure on a fresh clone is a missing SDK jar.
+# CLAUDE.md is explicit that the fix is to install the SDK, never to
+# vendor a copy of main.jar into app/libs/ — so say so here, at the
+# moment someone is staring at the error and looking for a shortcut.
+if (-not $SkipSdkHint) {
+    $text = ($teed | Out-String)
+
+    # Match only genuine *resolution* failures. An earlier version of
+    # this heuristic matched bare 'main.jar|takdev' against the whole
+    # log — but those strings appear in ordinary gradle output on every
+    # run, so the hint fired on every failure, including plain
+    # compile errors. Telling someone "this is not a code defect" when
+    # it is one is worse than saying nothing: it sends them off
+    # reinstalling an SDK that was never broken.
+    $missingSdk = (
+        $text -match 'main\.jar.{0,80}(does not exist|no such file|not found|cannot be found)' -or
+        $text -match 'Could not find .{0,40}atak' -or
+        $text -match 'atak-gradle-takdev.{0,80}(does not exist|not found)' -or
+        $text -match 'SDK location not found'
+    )
+
+    # A Kotlin/Java diagnostic means the toolchain resolved fine and the
+    # source is at fault — never blame the SDK in that case.
+    $compileError = (
+        $text -match '(?m)^e: file:' -or
+        $text -match 'Compilation error' -or
+        $text -match 'Unresolved reference'
+    )
+
+    if ($missingSdk -and -not $compileError) {
+        Write-Host ''
+        Write-Host '        This looks like a missing ATAK CIV SDK, not a code defect.' -ForegroundColor Yellow
+        Write-Host '        Install the SDK distribution and point the build at it per' -ForegroundColor Yellow
+        Write-Host '        build.gradle.kts (default: ../ATAK-CIV-<ver>-SDK/ next to this repo).' -ForegroundColor Yellow
+        Write-Host '        Do NOT commit a copy of main.jar into app/libs/ — it is gitignored' -ForegroundColor Yellow
+        Write-Host '        and non-redistributable. See CLAUDE.md "ATAK SDK jar".' -ForegroundColor Yellow
+    }
+}
+
+Write-Host ''
+Write-Host '        To push anyway (needs an explicit operator decision):' -ForegroundColor DarkGray
+Write-Host '            git push --no-verify' -ForegroundColor DarkGray
+Write-Host ''
+exit 1


### PR DESCRIPTION
## Why

`main` does not build. `./gradlew testCivDebugUnitTest` has failed since **e12dc3b (#72)** and stayed red through #80 and #81:

```
XvPlacementDecisionTest.kt:33:28 Unresolved reference 'PlaceDecision'.  (x8)
```

Every branch cut from `main` inherits this.

## Root cause

`#72` added `PlaceDecision` and `XvPlacementDecisionTest` in the same commit, with the enum declared **inside `XvVoiceService`'s `companion object`**. Kotlin does not surface a companion's nested classifiers under the outer class name — `XvVoiceService.PlaceDecision` does not resolve; that spelling requires `XvVoiceService.Companion.PlaceDecision`.

The tell is in the error output: companion *functions* **are** surfaced, so the `XvVoiceService.decidePlacement(...)` calls on the very same lines resolved fine, and only the enum references failed.

This moves the enum to the class body, which makes the spelling the test and the enum's own KDoc already use the correct one. The in-companion call sites still resolve unqualified, since the companion is nested in the class scope. No call-site changes needed.

## Why CI was green the whole time

Public CI structurally cannot catch this:

- GitHub runners have no ATAK CIV SDK (not redistributable; tak.gov maven needs USG-sponsored credentials), so `ci.yml` runs **ktlint alone** — as its own header documents.
- **ktlint parses without resolving symbols.** An unresolved reference is invisible to it by construction.
- `assembleCivDebug` would not have caught it either: **assembling the APK does not compile the unit-test source set.** #72 built clean APKs the entire time `main` was red.

## The defense

Since a remote gate isn't possible, this adds a local one that runs where the SDK actually is:

- **`scripts/verify-gates.ps1`** — runs `ktlintCheck` + `assemble<F>Debug` + `test<F>DebugUnitTest`. The task list derives from `config.productFlavor`, so the script stays generic across TAK plugins (`civ` -> `assembleCivDebug`); override via `config.verifyGateTasks` only if a plugin's gates differ.
- Wired as a **pre-push hook** via the existing pre-commit framework, so a red tree can't reach the remote. Pre-push rather than pre-commit: ~30s is intolerable per-commit, fine per-push, and push is the boundary where a break stops being local.
- Existing `gitleaks` / `end-of-file-fixer` hooks pinned to the commit stage (the latter rewrites files, which is meaningless at push time).

### Hooks were never actually installed in this clone

Worth flagging for anyone else with an old clone: `core.hooksPath` was set to `.git/hooks` — git's *own default*, so a no-op for git, but `pre-commit install` **refuses outright while it's set** and the failure is one easily-missed line. Net effect: `.pre-commit-config.yaml` and `.gitleaks.toml` were committed and looked authoritative, but **no hook had ever run** and the gitleaks secret scanning was inert. CLAUDE.md and `scripts/README.md` now document the trap and tell you to verify the install took.

## Verification

Gates green on this branch:

```
PASS  all gates green
77 test suites; XvPlacementDecisionTest 4 tests, 0 failures, 0 skipped
```

The gate was tested in **both** directions against a throwaway local remote — a gate only proven to pass proves nothing:

- **Red tree** (reintroduced #72 verbatim by reverting `XvVoiceService.kt` to main's version): push **refused**, exit 1, remote empty, and the actual `Unresolved reference` error surfaced with file and line.
- **Green tree**: push allowed through.

That exercise caught two real bugs in the gate script itself, both fixed here:

1. The missing-SDK hint matched bare `main.jar|takdev` against the whole build log — strings present in *every* normal gradle run — so it fired on every failure and told the operator "this is not a code defect" when it was one. Now requires an actual resolution-failure pattern and suppresses itself when a Kotlin diagnostic is present.
2. `$output = ... | Tee-Object` captured gradle's stream instead of printing it, so the gate reported a bare `FAIL` with no cause. Now prints and captures.

## Docs

CLAUDE.md and `scripts/README.md` record that these gates are local-only, that a green PR check is **not** evidence `main` builds, and that `assemble` is not a substitute for the test gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
